### PR TITLE
feat: add Verbose Logging Utility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/espressif/esp-idf.git
 [submodule "deps/Arduino-CMake-Toolchain"]
 	path = deps/Arduino-CMake-Toolchain
-	url = https://github.com/a9183756-gh/Arduino-CMake-Toolchain
+	url = https://github.com/a9183756-gh/Arduino-CMake-Toolchain.git

--- a/include/at_client/at_logger.h
+++ b/include/at_client/at_logger.h
@@ -1,0 +1,9 @@
+#ifndef ATLOGGER_H
+#define ATLOGGER_H
+
+#include <stddef.h>
+
+int atlogger_log(const char *title, const char *message);
+int atlogger_logx(const char *title, const unsigned char *bytes, size_t byteslen);
+
+#endif  // ATLOGGER_H

--- a/src/at_client/at_logger.c
+++ b/src/at_client/at_logger.c
@@ -1,0 +1,20 @@
+#include "at_client/at_logger.h"
+#include <stdio.h>
+
+void printx(const unsigned char *bytes, size_t byteslen) {
+    for (size_t i = 0; i < byteslen; i++) {
+        printf("%02x ", bytes[i]);
+    }
+    printf("\n");
+}
+
+int atlogger_log(const char *title, const char *message) {
+    printf("%s | %s:\n", title, message);
+    return 0;
+}
+
+int atlogger_logx(const char *title, const unsigned char *bytes, size_t byteslen) {
+    printf("%s | ", title);
+    printx(bytes, byteslen);
+    return 0;
+}


### PR DESCRIPTION
Closes #11 

**- What I did**

Add Verbose Logger utility for at_c

**- How I did it**

- [x] Created header file `at_logger.h` under `include/at_client/`
- [x] Created `at_logger.c` under `src/at_client/` and added `atlogger_log` and `atlogger_logx` methods

**- Description for the changelog**

Add Verbose Logger utility for at_c