### PR TITLE
fix: set CMP0135 policy to be NEW

### DIFF
--- a/packages/atchops/CMakeLists.txt
+++ b/packages/atchops/CMakeLists.txt
@@ -19,6 +19,8 @@ set(atchops_include_dir
     ${CMAKE_CURRENT_LIST_DIR}/include # not `include/atchops` because we want clients to include it like #include "atchops/atchops.h"
 )
 
+cmake_policy(SET CMP0135 NEW)
+
 option(ATCHOPS_FETCH_MBEDTLS "Fetch MbedTLS from GitHub" ON) # If OFF, we assume MbedTLS is installed on the system and was already built from source
 option(ATCHOPS_BUILD_TESTS "Build tests" OFF)
 

--- a/packages/atclient/CMakeLists.txt
+++ b/packages/atclient/CMakeLists.txt
@@ -72,6 +72,9 @@ if(NOT ESP_PLATFORM) # build for Desktop
 	# ${CMAKE_INSTALL_*} variables are defined in GNUInstallDirs and changes according to OS. E.g. on Linux & MacOS, ${CMAKE_INSTALL_LIBDIR} is /usr/local/lib, but on Windows it may be C:\Program Files\atchops\lib
 	include(GNUInstallDirs)
 
+	# https://cmake.org/cmake/help/latest/policy/CMP0135.html
+	cmake_policy(SET CMP0135 NEW)
+
 	# #########################################################
 	# 2A. Get MbedTLS::mbedtls
 	# #########################################################
@@ -97,6 +100,7 @@ if(NOT ESP_PLATFORM) # build for Desktop
 		FetchContent_Declare(
 			atchops
 			SOURCE_DIR ${atchops_src_dir}
+			
 		)
 		FetchContent_MakeAvailable(atchops) # ensures named dependencies have been populated
 		message(STATUS "Successfully fetched `atchops` package")
@@ -204,4 +208,6 @@ if(NOT ESP_PLATFORM) # build for Desktop
 		include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 		add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/src)
 	endif()
+
+
 endif()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Set the CMP0135 policy to NEW

**- How I did it**

In CMake v3.24, they reached a caveat regarding the ExternalProject_Add command (in this repo, we use FetchContent, but it seems to still give the same warning).

This OLD behaviour is deprecated by CMake's definition, so we should go with the NEW implementation regardless.

"Note The OLD behavior of a policy is [deprecated by definition](https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html#manual:cmake-policies(7)) and may be removed in a future version of CMake."

Source: https://cmake.org/cmake/help/latest/policy/CMP0135.html

**- How to verify it**

- Check GHA logs and warning is no longer there

closes #52
