### PR TITLE
feat: atbytes, atstr improvements, atsign, repl

### DIFF
--- a/examples/pkam_authenticate/src/main.c
+++ b/examples/pkam_authenticate/src/main.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
 {
     int ret = 1;
 
-    atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
+    atclient_atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
 
     // 1. init atkeys
 
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
     {
         goto exit;
     }
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_file_read: %d\n", ret);
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_file_read: %d\n", ret);
 
     // 1b. populate `atkeys` struct
     atclient_atkeys atkeys;
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
     {
         goto exit;
     }
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_populate_from_atkeysfile: %d\n", ret);
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_populate_from_atkeysfile: %d\n", ret);
 
     // 2. pkam auth
     atclient atclient;

--- a/examples/pkam_authenticate/src/main.c
+++ b/examples/pkam_authenticate/src/main.c
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_populate_from_atkeysfile: %d\n", ret);
 
     // 2. pkam auth
-    atclient_ctx atclient;
+    atclient atclient;
     atclient_init(&atclient);
     ret = atclient_init_root_connection(&atclient, ROOT_HOST, ROOT_PORT);
     // printf("atclient_init_root_connection_code: %d\n", ret);
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
         goto exit;
     }
 
-    ret = atclient_pkam_authenticate(&atclient, atkeys, ATSIGN);
+    ret = atclient_pkam_authenticate(&atclient, atkeys, ATSIGN, strlen(ATSIGN));
     // printf("atclient_pkam_authenticate_code: %d\n", ret);
     if (ret != 0)
     {

--- a/examples/repl/CMakeLists.txt
+++ b/examples/repl/CMakeLists.txt
@@ -10,12 +10,9 @@ project(
 include(GNUInstallDirs)
 include(FetchContent)
 
-# FetchContent_Declare(
-#     atclient
-#     SOURCE_DIR ${CMAKE_SOURCE_DIR}/../../atclient
-# )
-# FetchContent_MakeAvailable(atclient)
 find_package(atclient REQUIRED CONFIG)
+find_package (atchops CONFIG QUIET)
+find_package (MbedTLS CONFIG QUIET)
 
 message(STATUS "atclient was found")
 

--- a/examples/repl/run.sh
+++ b/examples/repl/run.sh
@@ -5,6 +5,12 @@ set -eu
 rm -f build/CMakeCache.txt
 sudo rm -f bin/repl
 
+# install dependencies
+FULL_PATH_TO_SCRIPT="$(realpath "${BASH_SOURCE[0]}")"
+SCRIPT_DIRECTORY="$(dirname "$FULL_PATH_TO_SCRIPT")"
+"$SCRIPT_DIRECTORY/../../packages/atclient/tools/install.sh"
+cd "$SCRIPT_DIRECTORY"
+
 # configure
 cmake -S . -B build
 
@@ -12,4 +18,4 @@ cmake -S . -B build
 sudo cmake --build build --target install
 
 # run
-./bin/repl
+./bin/repl $@

--- a/examples/repl/src/main.c
+++ b/examples/repl/src/main.c
@@ -20,11 +20,11 @@ static char *get_home_dir()
 int main(int argc, char *argv[])
 {
     int ret = 1;
-    atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);
+    atclient_atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);
 
     if(argc < 2 || argc > 3)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Usage: ./repl <atsign> [rootUrl]");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Usage: ./repl <atsign> [rootUrl]");
         ret = 1;
         goto exit;
     }
@@ -45,14 +45,14 @@ int main(int argc, char *argv[])
         strcat(temp, atsign);
         atsign = temp;
     }
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Using atSign \"%s\" and rootUrl \"%s:%d\"\n", atsign, roothost, rootport);
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Using atSign \"%s\" and rootUrl \"%s:%d\"\n", atsign, roothost, rootport);
 
     atclient_atkeys atkeys;
     atclient_atkeys_init(&atkeys);
     char *homedir = get_home_dir();
     if(homedir == NULL || strlen(homedir) == 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to get home directory\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to get home directory\n");
         ret = 1;
         goto exit;
     }
@@ -60,28 +60,28 @@ int main(int argc, char *argv[])
     sprintf(atkeysfilepath, "%s/.atsign/keys/%s_key.atKeys", homedir, atsign);
     if(atclient_atkeys_populate_from_path(&atkeys, atkeysfilepath) != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read atKeys file at path %s\n", atkeysfilepath);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read atKeys file at path %s\n", atkeysfilepath);
         ret = 1;
         goto exit;
     }
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Read atKeys file at path %s\n" , atkeysfilepath);
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Read atKeys file at path %s\n" , atkeysfilepath);
 
     atclient atclient;
     atclient_init(&atclient);
     ret = atclient_start_root_connection(&atclient, roothost, rootport);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_start_root_connection: %d | failed to connect to root\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_start_root_connection: %d | failed to connect to root\n", ret);
         goto exit;
     }
 
     ret = atclient_pkam_authenticate(&atclient, atkeys, atsign, strlen(atsign));
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_pkam_authenticate: %d | failed to authenticate\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_pkam_authenticate: %d | failed to authenticate\n", ret);
         goto exit;
     }
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Successfully PKAM Authenticated with atSign \"%s\"\n", atsign);
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Successfully PKAM Authenticated with atSign \"%s\"\n", atsign);
 
 
 

--- a/examples/repl/src/main.c
+++ b/examples/repl/src/main.c
@@ -1,209 +1,89 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <atchops/aesctr.h>
-#include <atchops/rsa.h>
+#include <pwd.h>
+#include <unistd.h>
 #include <atclient/connection.h>
-#include <atclient/atkeys_filereader.h>
+#include <atclient/atkeysfile.h>
+#include <atclient/atlogger.h>
+#include <atclient/atclient.h>
+#include <atclient/atkeys.h>
 
-#define ATSIGN "@jeremy_0"
-#define ATKEYS_FILE_PATH "/Users/jeremytubongbanua/.atsign/keys/@jeremy_0_key.atKeys"
-// #define ATKEYS_FILE_PATH "./@jeremy_0_key.atKeys"
+#define TAG "REPL"
 
-static void *without_at_symbol(char *atsign, char *buf)
+static char *get_home_dir()
 {
-    int i = 0;
-    while (atsign[i] != '\0')
-    {
-        buf[i] = atsign[i + 1];
-        i++;
-    }
-    buf[i] = '\0';
-    return buf;
+    struct passwd *pw = getpwuid(getuid());
+    return pw->pw_dir;
 }
 
-int main()
+int main(int argc, char *argv[])
 {
     int ret = 1;
+    atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);
 
-    // 1. initialize buffer to use throughout program
-
-    size_t recvlen = 32768;
-    unsigned char *recv = malloc(sizeof(unsigned char) * recvlen);
-    size_t olen = 0;
-
-    // 2. initialize atkeys, `atkeysfile` is now a struct that holds read atkeys
-
-
-    const char *keyspath = ATKEYS_FILE_PATH;
-    printf("Reading keys from \"%s\"...\n", keyspath);
-
-    atclient_atkeysfile atkeysfile;
-    atclient_atkeysfile_init(&atkeysfile);
-    ret = atclient_atkeysfile_read(keyspath, &atkeysfile);
-    if(ret != 0)
+    if(argc < 2 || argc > 3)
     {
-        printf("Error reading keys from \"%s\"\n", keyspath);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Usage: ./repl <atsign> [rootUrl]");
+        ret = 1;
         goto exit;
     }
-    printf("Done reading...\n");
 
-    // 3. connect to root and find secondary address
+    const char *atsign = argv[1];
+    const char *rooturl = argc == 3 ? argv[2] : "root.atsign.org:64";
+    char *rooturlcopy = strdup(rooturl); // Create a copy of rootUrl because strtok modifies the original string
+    char *roothost = strtok(rooturlcopy, ":");
+    char *portstr = strtok(NULL, ":");
+    int rootport = portstr ? atoi(portstr) : 64; // Convert the port part to an integer. If portStr is NULL, port will be 0.
 
-    // 3a. establish connection to root
-    atclient_connection_ctx root_connection;
-    atclient_connection_init(&root_connection);
-    atclient_connection_connect(&root_connection, "root.atsign.org", 64);
-    printf("Connected to root\n");
 
-    // 3b. send atsign without @ symbol to root
-
-    unsigned char *atsign_without_at = malloc(sizeof(unsigned char) * 100);
-    memset(atsign_without_at, 0, 100);
-    without_at_symbol(ATSIGN, atsign_without_at);
-    strcat(atsign_without_at, "\r\n");
-    size_t atsign_without_atlen = strlen(atsign_without_at);
-
-    printf("Sending to root: \"%s\"\n", atsign_without_at);
-    ret = atclient_connection_send(&root_connection, recv, recvlen, &olen, atsign_without_at, atsign_without_atlen);
-    printf("Received from root: \"%.*s\"\n", (int) olen, recv);
-
-    // 3c. parse secondary address
-
-    const size_t secondary_len = 100;
-    char *secondary_host = malloc(sizeof(char) * secondary_len);
-    char *secondary_port = malloc(sizeof(char) * secondary_len);
-
-    int i = 0, c;
-    while ((c = recv[i]) != ':' && i < olen)
+    // if atSign doesn't start with `@`, then add it
+    if(atsign[0] != '@')
     {
-        secondary_host[i] = c;
-        i++;
+        char *temp = malloc(strlen(atsign) + 2);
+        strcpy(temp, "@");
+        strcat(temp, atsign);
+        atsign = temp;
     }
-    secondary_host[i] = '\0';
-    i++;
-    int j = 0;
-    while ((c = recv[i]) != '\0' && i < olen)
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Using atSign \"%s\" and rootUrl \"%s:%d\"\n", atsign, roothost, rootport);
+
+    atclient_atkeys atkeys;
+    atclient_atkeys_init(&atkeys);
+    char *homedir = get_home_dir();
+    if(homedir == NULL || strlen(homedir) == 0)
     {
-        secondary_port[j] = c;
-        i++;
-        j++;
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to get home directory\n");
+        ret = 1;
+        goto exit;
     }
-
-    printf("secondary_host: %s\n", secondary_host);
-    printf("secondary_port: %s\n", secondary_port);
-
-    // 4. connect to secondary
-
-    // 4a. establish secondary connection
-    atclient_connection_ctx secondary_connection;
-    atclient_connection_init(&secondary_connection);
-    atclient_connection_connect(&secondary_connection, secondary_host, atoi(secondary_port));
-
-    // 4b. send from request
-
-    memset(recv, 0, recvlen);
-    const unsigned char *from_command = malloc(sizeof(unsigned char) * 1024);
-    memset(from_command, 0, 1024);
-    strcat(from_command, "from:");
-    strcat(from_command, ATSIGN);
-    strcat(from_command, "\r\n");
-    const size_t from_commandlen = strlen(from_command);
-    atclient_connection_send(&secondary_connection, recv, recvlen, &olen, from_command, from_commandlen);
-    printf("Sent: \"%.*s\" | Received: \"%.*s\"\n", (int) from_commandlen, from_command, (int) olen, recv);
-
-    // 4c. parse from response, store data after the `data:` prefix
-    const size_t from_responselen = 1024;
-    unsigned char *from_response = malloc(sizeof(unsigned char) * from_responselen);
-    memset(from_response, 0, from_responselen);
-
-    int in = 0;
-    j = 0;
-    for (int i = 0; i < olen; i++)
+    char atkeysfilepath[1024];
+    sprintf(atkeysfilepath, "%s/.atsign/keys/%s_key.atKeys", homedir, atsign);
+    if(atclient_atkeys_populate_from_path(&atkeys, atkeysfilepath) != 0)
     {
-        char c = recv[i];
-        if (in == 1)
-        {
-            from_response[j++] = c;
-        }
-        if (c == ':')
-        {
-            in = 1;
-        }
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read atKeys file at path %s\n", atkeysfilepath);
+        ret = 1;
+        goto exit;
+    }
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Read atKeys file at path %s\n" , atkeysfilepath);
+
+    atclient atclient;
+    atclient_init(&atclient);
+    ret = atclient_start_root_connection(&atclient, roothost, rootport);
+    if(ret != 0)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_start_root_connection: %d | failed to connect to root\n", ret);
+        goto exit;
     }
 
-    printf("from_response: %.*s\n", (int) olen, (const char *) from_response);
-
-    // get pkam private key
-
-    atchops_rsa_privatekey pkamprivatekeystruct;
-
-    const size_t pkamprivatekeylen = 10000;
-    unsigned char *pkamprivatekey = malloc(sizeof(unsigned char) * pkamprivatekeylen);
-    memset(pkamprivatekey, 0, pkamprivatekeylen);
-    size_t pkamprivatekeyolen = 0;
-
-    printf("self encryption key: \"%s\"\n", atkeysfile.self_encryption_key->key);
-    printf("pkam private key (encrypted): \"%s\"\n", atkeysfile.aes_pkam_private_key->key);
-    printf("pkam private key (encrypted) len: %lu\n", atkeysfile.aes_pkam_private_key->len);
-
-    unsigned char *iv = malloc(sizeof(unsigned char) * 16);
-    memset(iv, 0, 16);
-
-    ret = atchops_aesctr_decrypt(atkeysfile.self_encryption_key->key, atkeysfile.self_encryption_key->len, 256, iv, 16, atkeysfile.aes_pkam_private_key->key, atkeysfile.aes_pkam_private_key->len, pkamprivatekey, pkamprivatekeylen, &pkamprivatekeyolen);
-    printf("atchops_aesctr_decrypt: %d\n", ret);
-
-    printf("pkam private key (decrypted): \"%s\"\n", pkamprivatekey);
-    printf("pkam private key (decrypted) len: %lu\n", pkamprivatekeyolen);
-
-    ret = atchops_rsakey_populate_privatekey(pkamprivatekey, pkamprivatekeyolen, &pkamprivatekeystruct);
-
-    printf("n: %lu\n", pkamprivatekeystruct.n.len);
-    printf("e: %lu\n", pkamprivatekeystruct.e.len);
-
-    // sign from response
-
-    const size_t signaturelen = 32768;
-    unsigned char *signature = malloc(sizeof(unsigned char) * signaturelen);
-    unsigned long signatureolen = 0;
-    memset(signature, 0, signaturelen);
-    atchops_rsa_sign(pkamprivatekeystruct, ATCHOPS_MD_SHA256, from_response, strlen(from_response), signature, signaturelen, &signatureolen);
-
-    printf("signature: \"%.*s\"\n", (int) signatureolen, signature);
-
-    // send pkam command
-
-    size_t pkamcommandlen = 32768;
-    unsigned char *pkamcommand = malloc(sizeof(unsigned char) * pkamcommandlen);
-    memset(pkamcommand, 0, pkamcommandlen);
-
-    strcat(pkamcommand, "pkam:");
-    strcat(pkamcommand, signature);
-    strcat(pkamcommand, "\r\n");
-
-    printf("pkam command: \"%s\"\n", pkamcommand);
-
-    ret = atclient_connection_send(&secondary_connection, recv, recvlen, &olen, pkamcommand, strlen(pkamcommand));
-
-    printf("signature olen: %lu\n", signatureolen);
-    printf("\"%.*s\"\n", (int) olen, recv);
-
-    size_t commandlen = 32768;
-    unsigned char *command = malloc(sizeof(unsigned char) * commandlen);
-    memset(command, 0, commandlen);
-    while (1)
+    ret = atclient_pkam_authenticate(&atclient, atkeys, atsign, strlen(atsign));
+    if(ret != 0)
     {
-        fgets(command, commandlen, stdin);
-        if (strcmp(command, "exit") == 0)
-        {
-            break;
-        }
-        atclient_connection_send(&secondary_connection, recv, recvlen, &olen, command, strlen(command));
-        memset(command, 0, commandlen);
-        printf("\nrecv: \"%.*s\"\n\n", olen, recv);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_pkam_authenticate: %d | failed to authenticate\n", ret);
+        goto exit;
     }
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Successfully PKAM Authenticated with atSign \"%s\"\n", atsign);
 
-    goto exit;
+
 
 exit:
 {

--- a/packages/atclient/CMakeLists.txt
+++ b/packages/atclient/CMakeLists.txt
@@ -7,11 +7,13 @@ cmake_minimum_required(VERSION 3.19)
 # 1a. Manually add your src files here
 # globs are known as bad practice, so we do not use them here
 set(atclient_srcs
+	${CMAKE_CURRENT_LIST_DIR}/src/atbytes.c
 	${CMAKE_CURRENT_LIST_DIR}/src/atclient.c
 	${CMAKE_CURRENT_LIST_DIR}/src/atkey.c
 	${CMAKE_CURRENT_LIST_DIR}/src/atkeys.c
 	${CMAKE_CURRENT_LIST_DIR}/src/atkeysfile.c
 	${CMAKE_CURRENT_LIST_DIR}/src/atlogger.c
+	${CMAKE_CURRENT_LIST_DIR}/src/atsign.c
 	${CMAKE_CURRENT_LIST_DIR}/src/atstr.c
 	${CMAKE_CURRENT_LIST_DIR}/src/connection.c
 	${CMAKE_CURRENT_LIST_DIR}/src/metadata.c

--- a/packages/atclient/include/atclient/atbytes.h
+++ b/packages/atclient/include/atclient/atbytes.h
@@ -1,0 +1,68 @@
+
+
+#ifndef ATCLIENT_ATBYTES_H
+#define ATCLIENT_ATBYTES_H
+
+#include "atclient/atstr.h"
+
+/**
+ * @brief Represents a buffer of bytes. Similar to atclient_atstr
+ */
+typedef struct atclient_atbytes {
+    unsigned long len; // the allocated length of the buffer
+    unsigned char *bytes; // the buffer of bytes (pointer to the first byte in the buffer on the heap)
+    unsigned long olen; // the output length of the buffer
+} atclient_atbytes;
+
+/**
+ * @brief Initializes atbytes on the heap
+ *
+ * @param atbytes the atbytes to initialize
+ * @param atbyteslen the buffer length to allocate on the heap
+ */
+void atclient_atbytes_init(atclient_atbytes *atbytes, const unsigned long atbyteslen);
+
+/**
+ * @brief Reset atbytes to all zeroes
+ *
+ * @param atbytes the atbytes to reset
+ */
+void atclient_atbytes_reset(atclient_atbytes *atbytes);
+
+/**
+ * @brief Set atbytes to the given bytes
+ *
+ * @param atbytes the atbytes to set
+ * @param bytes the bytes to set
+ * @param byteslen the length of the bytes
+ * @return int 0 on success, non-zero on failure
+ */
+int atclient_atbytes_set(atclient_atbytes *atbytes, const unsigned char *bytes, const unsigned long byteslen);
+
+/**
+ * @brief Convert a string to atbytes
+ * 
+ * @param atbytes the atbytes to convert to
+ * @param str the string to convert from
+ * @param strlen the length of the string
+ * @return int 0 on success
+ */
+int atclient_atbytes_convert(atclient_atbytes *atbytes, const char *str, const unsigned long strlen);
+
+/**
+ * @brief Converts an atstr to atbytes
+ * 
+ * @param atbytes atbytes to write to
+ * @param atstr the atstr to copy from
+ * @return int 0 on success
+ */
+int atclient_atbytes_convert_atstr(atclient_atbytes *atbytes, const atclient_atstr atstr);
+
+/**
+ * @brief Free atbytes on the heap. Should be called once atbytes is no longer needed
+ *
+ * @param atbytes the atbytes to free
+ */
+void atclient_atbytes_free(atclient_atbytes *atbytes);
+
+#endif

--- a/packages/atclient/include/atclient/atclient.h
+++ b/packages/atclient/include/atclient/atclient.h
@@ -8,18 +8,18 @@
  * @brief represents atclient
  *
  */
-typedef struct atclient_ctx
+typedef struct atclient
 {
-    atclient_connection_ctx root_connection;
-    atclient_connection_ctx secondary_connection;
-} atclient_ctx;
+    atclient_connection root_connection;
+    atclient_connection secondary_connection;
+} atclient;
 
 /**
  * @brief initialize the atclient context for further use
  *
  * @param ctx pointer to the atclient context to initialize
  */
-void atclient_init(atclient_ctx *ctx);
+void atclient_init(atclient *ctx);
 
 /**
  * @brief initalize the atclient's root connection to the specified host and port
@@ -29,7 +29,7 @@ void atclient_init(atclient_ctx *ctx);
  * @param rootport  port of the root (e.g. 64)
  * @return int 0 on success, error otherwise
  */
-int atclient_init_root_connection(atclient_ctx *ctx, const char *roothost, const int rootport);
+int atclient_start_root_connection(atclient *ctx, const char *roothost, const int rootport);
 
 /**
  * @brief initialize the atclient's secondary connection to the specified host and port
@@ -39,7 +39,7 @@ int atclient_init_root_connection(atclient_ctx *ctx, const char *roothost, const
  * @param secondaryport port of secondary. this is usually fetched from the root connection
  * @return int 0 on success, error otherwise
  */
-int atclient_init_secondary_connection(atclient_ctx *ctx, const char *secondaryhost, const int secondaryport);
+int atclient_start_secondary_connection(atclient *ctx, const char *secondaryhost, const int secondaryport);
 
 /**
  * @brief authenticate with secondary server with RSA pkam private key. it is expected atkeys has been populated with the pkam private key and atclient context is connected to the root server
@@ -49,10 +49,10 @@ int atclient_init_secondary_connection(atclient_ctx *ctx, const char *secondaryh
  * @param atsign the atsign the atkeys belong to
  * @return int 0 on success
  */
-int atclient_pkam_authenticate(atclient_ctx *ctx, atclient_atkeys atkeys, const char *atsign);
-int atclient_put(atclient_ctx *ctx, const char *key, const char *value);
-int atclient_get(atclient_ctx *ctx, const char *key, char *value, const unsigned long valuelen);
-int atclient_delete(atclient_ctx *ctx, const char *key);
-void atclient_free(atclient_ctx *ctx);
+int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, const char *atsign, const unsigned long atsignlen);
+int atclient_put(atclient *ctx, const char *key, const char *value);
+int atclient_get(atclient *ctx, const char *key, char *value, const unsigned long valuelen);
+int atclient_delete(atclient *ctx, const char *key);
+void atclient_free(atclient *ctx);
 
 #endif

--- a/packages/atclient/include/atclient/atlogger.h
+++ b/packages/atclient/include/atclient/atlogger.h
@@ -2,17 +2,17 @@
 #ifndef ATCLIENT_ATLOGGER_H
 #define ATCLIENT_ATLOGGER_H
 
-typedef enum atlogger_logging_level
+typedef enum atclient_atlogger_logging_level
 {
     ATLOGGER_LOGGING_LEVEL_NONE = 0,   // literally nothing, not verbose at all
     ATLOGGER_LOGGING_LEVEL_ERROR,      // only errors, not that verbose
     ATLOGGER_LOGGING_LEVEL_WARN,    // errors and warnings , verbose only when something's up
     ATLOGGER_LOGGING_LEVEL_INFO,       // errors, warnings and info, pretty verbose
     ATLOGGER_LOGGING_LEVEL_DEBUG       // everything, very verbose
-} atlogger_logging_level;
+} atclient_atlogger_logging_level;
 
-atlogger_logging_level atlogger_get_logging_level();
-void atlogger_set_logging_level(atlogger_logging_level level);
-void atlogger_log(const char *tag, atlogger_logging_level level, const char *format, ...);
+atclient_atlogger_logging_level atlogger_get_logging_level();
+void atclient_atlogger_set_logging_level(atclient_atlogger_logging_level level);
+void atclient_atlogger_log(const char *tag, atclient_atlogger_logging_level level, const char *format, ...);
 
 #endif

--- a/packages/atclient/include/atclient/atsign.h
+++ b/packages/atclient/include/atclient/atsign.h
@@ -1,0 +1,16 @@
+#ifndef ATCLIENT_ATSIGN_H
+#define ATCLIENT_ATSIGN_H
+
+/**
+ * @brief populates *atsign and *atsignolen with the atsign without the prefixed `@` symbol . Calling this function will guarantee that *atsign is always withot a prefixed `@` symbol, whether if it started with one or not.
+ *
+ * @param atsign the atsign to populate (there wil be no prefixd `@` symbol. example: @bob -> bob)
+ * @param atsignlen the buffer size
+ * @param atsignolen the actually written size
+ * @param originalatsign the atsign that supposedly has the prefixed `@` symbol you would liek to remove
+ * @param originalatsignlen the string length of the atsign being read
+ * @return int 0 on success, 1 on if atsignlen is not large enough, 2 on if the originalatsignlen length passed is <= 0.
+ */
+int atclient_atsign_without_at_symbol(char *atsign, const unsigned long atsignlen, unsigned long *atsignolen, const char *originalatsign, const unsigned long *originalatsignlen);
+
+#endif

--- a/packages/atclient/include/atclient/atsign.h
+++ b/packages/atclient/include/atclient/atsign.h
@@ -11,6 +11,6 @@
  * @param originalatsignlen the string length of the atsign being read
  * @return int 0 on success, 1 on if atsignlen is not large enough, 2 on if the originalatsignlen length passed is <= 0.
  */
-int atclient_atsign_without_at_symbol(char *atsign, const unsigned long atsignlen, unsigned long *atsignolen, const char *originalatsign, const unsigned long *originalatsignlen);
+int atclient_atsign_without_at_symbol(char *atsign, const unsigned long atsignlen, unsigned long *atsignolen, const char *originalatsign, const unsigned long originalatsignlen);
 
 #endif

--- a/packages/atclient/include/atclient/atstr.h
+++ b/packages/atclient/include/atclient/atstr.h
@@ -17,7 +17,7 @@ typedef struct atclient_atstr
  * @param atstr pointer to atstr to initialize
  * @param bufferlen length of buffer to allocate in bytes (recommended to use a number that is a power of 2). the bufferlen is the length of the buffer generated. we do not add 1 for null terminator.
  */
-void atclient_atstr_init(atclient_atstr *atstr, unsigned long bufferlen);
+void atclient_atstr_init(atclient_atstr *atstr, const unsigned long bufferlen);
 
 /**
  * @brief initialize an atstr with a literal string
@@ -25,7 +25,14 @@ void atclient_atstr_init(atclient_atstr *atstr, unsigned long bufferlen);
  * @param atstr the atstr struct to populate
  * @param str the string to set atstr to. best to use string literals here. (or a null-terminated string)
  */
-void atclient_atstr_init_literal(atclient_atstr *atstr, const char *str);
+int atclient_atstr_init_literal(atclient_atstr *atstr, const unsigned long bufferlen, const char *format, ...);
+
+/**
+ * @brief set an atstr to an empty string
+ *
+ * @param atstr the atstr struct to reset
+ */
+void atclient_atstr_reset(atclient_atstr *atstr);
 
 /**
  * @brief set an atstr to a string
@@ -42,7 +49,7 @@ int atclient_atstr_set(atclient_atstr *atstr, const char *str, const unsigned lo
  * @param atstr atstr struct to populate
  * @param str null-terminated string to set atstr to. Best to use string literals here
  */
-int atclient_atstr_set_literal(atclient_atstr *atstr, const char *str);
+int atclient_atstr_set_literal(atclient_atstr *atstr, const char *format, ...);
 
 /**
  * @brief Copy what is in an atstr to another atstr
@@ -58,5 +65,27 @@ int atclient_atstr_copy(atclient_atstr *atstr, atclient_atstr *data);
  * @param atstr pointer to atstr to free from the heap
  */
 void atclient_atstr_free(atclient_atstr *atstr);
+
+/**
+ * @brief Copy what is in original to substring and then set substring to a substring of original
+ * 
+ * @param substring the atstr to set to the substring. Assumed that this is already initialized (via atclient_atstr_init)
+ * @param original the atstr to get the substring from. Assumed that this is already initialized (via atclient_atstr_init)
+ * @param start the start index of the substring
+ * @param end the end index of the substring
+ * @return int 0 on success, non-zero on failure
+ */
+int atclient_atstr_substring(atclient_atstr *substring, const atclient_atstr original, const unsigned long start, const unsigned long end);
+
+/**
+ * @brief Append a string to an atstr
+ * 
+ * @param atstr the atstr to append to
+ * @param format the format of the string to append
+ * @param ...   the arguments to format
+ * @return int 0 on success
+ */
+int atclient_atstr_append(atclient_atstr *atstr, const char *format, ...);
+
 
 #endif

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -5,9 +5,12 @@
 #include <mbedtls/net_sockets.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/ctr_drbg.h>
+#include "atclient/constants.h"
+#include "atclient/atstr.h"
 
-typedef struct atclient_connection_ctx {
-    char *host; // assume null terminated, example: "root.atsign.org"
+typedef struct atclient_connection {
+    // char *host; // assume null terminated, example: "root.atsign.org"
+    char host[ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE];
     int port; // example: 64
     mbedtls_net_context net;
     mbedtls_ssl_context ssl;
@@ -15,28 +18,28 @@ typedef struct atclient_connection_ctx {
     mbedtls_x509_crt cacert;
     mbedtls_entropy_context entropy;
     mbedtls_ctr_drbg_context ctr_drbg;
-} atclient_connection_ctx;
+} atclient_connection;
 
 /**
  * @brief initialize the context for a connection. this function should be called before use of any other function
- * 
+ *
  * @param ctx the context to initialize
  */
-void atclient_connection_init(atclient_connection_ctx *ctx);
+void atclient_connection_init(atclient_connection *ctx);
 
 /**
  * @brief after initializing a connection context, connect to a host and port
- * 
+ *
  * @param ctx the initialized context
  * @param host the host to connect to
  * @param port the port to connect to
  * @return int 0 on success, otherwise error
  */
-int atclient_connection_connect(atclient_connection_ctx *ctx, const char *host, const int port);
+int atclient_connection_connect(atclient_connection *ctx, const char *host, const int port);
 
 /**
  * @brief send data to the connection
- * 
+ *
  * @param ctx the connection which was initialized (via the init function) and connected (via the connect function)
  * @param src the data to send
  * @param srclen the length of the data to send
@@ -45,29 +48,39 @@ int atclient_connection_connect(atclient_connection_ctx *ctx, const char *host, 
  * @param olen the length of the data received
  * @return int 0 on success, otherwise error
  */
-int atclient_connection_send(atclient_connection_ctx *ctx, const unsigned char *src, const unsigned long srclen, unsigned char *recv, const unsigned long recvlen, unsigned long *olen);
+int atclient_connection_send(atclient_connection *ctx, const unsigned char *src, const unsigned long srclen, unsigned char *recv, const unsigned long recvlen, unsigned long *olen);
 
 /**
  * @brief disconnect a connection
- * 
+ *
  * @param ctx the connection to disconnect
  * @return int 0 on success, otherwise error
  */
-int atclient_connection_disconnect(atclient_connection_ctx *ctx);
+int atclient_connection_disconnect(atclient_connection *ctx);
 
 /**
  * @brief checks if the connection is connected
- * 
+ *
  * @param ctx the connection to check
  * @return int 1 if connected, 0 if not connected, negative on error
  */
-int atclient_connection_is_connected(atclient_connection_ctx *ctx);
+int atclient_connection_is_connected(atclient_connection *ctx);
 
 /**
  * @brief free memory allocated by the init function
- * 
+ *
  * @param ctx the struct which was previously initialized
  */
-void atclient_connection_free(atclient_connection_ctx *ctx);
+void atclient_connection_free(atclient_connection *ctx);
+
+/**
+ * @brief get the host and port from a url
+ *
+ * @param host a pointer to an atclient_atstr to store the host, will hold "root.atsign.org" after the function call, for example. Assumed that this is already initialized via atclient_atstr_init(&host)
+ * @param port a pointer to an int to store the port, will hold 64 after the function call, for example
+ * @param url the url to parse (example "root.atsign.org:64")
+ * @return int 0 on success, otherwise error
+ */
+int atclient_connection_get_host_and_port(atclient_atstr *host, int *port, const atclient_atstr url);
 
 #endif

--- a/packages/atclient/include/atclient/constants.h
+++ b/packages/atclient/include/atclient/constants.h
@@ -4,4 +4,7 @@
 
 #define ATSIGN_BUFFER_LENGTH 4096 // sufficient memory for atSigns
 
+#define ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE 128 // the size of the buffer for the host name
+#define ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE 4096 // represents the buffer size of a decrypted RSA key in base64 format
+
 #endif

--- a/packages/atclient/src/atbytes.c
+++ b/packages/atclient/src/atbytes.c
@@ -1,0 +1,78 @@
+#include <stdlib.h>
+#include <string.h>
+#include "atclient/atbytes.h"
+#include "atclient/atstr.h"
+#include "atclient/atlogger.h"
+
+#define TAG "atbytes"
+
+void atclient_atbytes_init(atclient_atbytes *atbytes, const unsigned long atbyteslen)
+{
+    memset(atbytes, 0, sizeof(atclient_atbytes));
+    atbytes->len = atbyteslen;
+    atbytes->bytes = malloc(sizeof(unsigned char) * atbytes->len);
+    atbytes->olen =0;
+}
+
+void atclient_atbytes_reset(atclient_atbytes *atbytes)
+{
+    memset(atbytes->bytes, 0, sizeof(unsigned char) * atbytes->len);
+    atbytes->olen = 0;
+}
+
+int atclient_atbytes_set(atclient_atbytes *atbytes, const unsigned char *bytes, const unsigned long byteslen)
+{
+    int ret = 1;
+    if(byteslen > atbytes->len)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "byteslen is greater than atbyteslen. byteslen: %lu, atbyteslen: %lu\n", byteslen, atbytes->len);
+        ret = 1;
+        goto exit;
+    }
+    memcpy(atbytes->bytes, bytes, byteslen);
+    atbytes->olen = byteslen;
+    ret = 0;
+    goto exit;
+exit:
+{
+    return ret;
+}
+}
+
+int atclient_atbytes_convert(atclient_atbytes *atbytes, const char *str, const unsigned long strlen)
+{
+    int ret = 1;
+    if(strlen > atbytes->len)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "strlen is greater than atbyteslen. strlen: %lu, atbyteslen: %lu\n", strlen, atbytes->len);
+        ret = 1;
+        goto exit;
+    }
+    memcpy(atbytes->bytes, (unsigned char *) str, strlen);
+    atbytes->olen = strlen;
+    ret = 0;
+    goto exit;
+exit:
+{
+    return ret;
+}
+}
+
+int atclient_atbytes_convert_atstr(atclient_atbytes *atbytes, const atclient_atstr atstr)
+{
+    int ret = atclient_atbytes_convert(atbytes, atstr.str, atstr.olen);
+    if(ret != 0)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert failed");
+        goto exit;
+    }
+exit:
+{
+    return ret;
+}
+}
+
+void atclient_atbytes_free(atclient_atbytes *atbytes)
+{
+    free(atbytes->bytes);
+}

--- a/packages/atclient/src/atbytes.c
+++ b/packages/atclient/src/atbytes.c
@@ -25,7 +25,7 @@ int atclient_atbytes_set(atclient_atbytes *atbytes, const unsigned char *bytes, 
     int ret = 1;
     if(byteslen > atbytes->len)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "byteslen is greater than atbyteslen. byteslen: %lu, atbyteslen: %lu\n", byteslen, atbytes->len);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "byteslen is greater than atbyteslen. byteslen: %lu, atbyteslen: %lu\n", byteslen, atbytes->len);
         ret = 1;
         goto exit;
     }
@@ -44,7 +44,7 @@ int atclient_atbytes_convert(atclient_atbytes *atbytes, const char *str, const u
     int ret = 1;
     if(strlen > atbytes->len)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "strlen is greater than atbyteslen. strlen: %lu, atbyteslen: %lu\n", strlen, atbytes->len);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "strlen is greater than atbyteslen. strlen: %lu, atbyteslen: %lu\n", strlen, atbytes->len);
         ret = 1;
         goto exit;
     }
@@ -63,7 +63,7 @@ int atclient_atbytes_convert_atstr(atclient_atbytes *atbytes, const atclient_ats
     int ret = atclient_atbytes_convert(atbytes, atstr.str, atstr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert failed");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert failed");
         goto exit;
     }
 exit:

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -30,10 +30,10 @@ int atclient_start_root_connection(atclient *ctx, const char *roothost, const in
     ret = atclient_connection_connect(&(ctx->root_connection), roothost, rootport);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_connect: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_connect: %d\n", ret);
         goto exit;
     }
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_connection_connect: %d. Successfully connected to root\n", ret);
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_connection_connect: %d. Successfully connected to root\n", ret);
 
     goto exit;
 
@@ -51,10 +51,10 @@ int atclient_start_secondary_connection(atclient *ctx, const char *secondaryhost
     ret = atclient_connection_connect(&(ctx->secondary_connection), secondaryhost, secondaryport);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_connect: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_connect: %d\n", ret);
         goto exit;
     }
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_connection_connect: %d. Successfully connected to secondary\n", ret);
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_connection_connect: %d. Successfully connected to secondary\n", ret);
 
     goto exit;
 
@@ -115,28 +115,28 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atsign_without_at_symbol(withoutat.str, withoutat.len, &(withoutat.olen), atsign, atsignlen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atsign_without_at_symbol: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atsign_without_at_symbol: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set_literal(&atsigncmd, "%.*s\r\n", (int) withoutat.olen, withoutat.str);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_atbytes_convert_atstr(&src, atsigncmd);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert_atstr: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert_atstr: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_connection_send(&(ctx->root_connection), src.bytes, src.olen, recv.bytes, recv.len, &(recv.olen));
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n | failed to send: %.*s\n", ret, withoutat.olen, withoutat);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n | failed to send: %.*s\n", ret, withoutat.olen, withoutat);
         goto exit;
     }
 
@@ -146,21 +146,21 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atstr_set_literal(&url, "%.*s", (int) recv.olen, recv.bytes);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_connection_get_host_and_port(&host, &port, url);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_get_host_and_port: %d | failed to parse url %.*s\n", ret, recv.olen, recv.bytes);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_get_host_and_port: %d | failed to parse url %.*s\n", ret, recv.olen, recv.bytes);
         goto exit;
     }
 
     ret = atclient_start_secondary_connection(ctx, host.str, port);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_start_secondary_connection: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_start_secondary_connection: %d\n", ret);
         goto exit;
     }
 
@@ -168,28 +168,28 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atstr_set_literal(&fromcmd, "from:%.*s\r\n", (int) withoutat.olen, withoutat.str);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_atbytes_convert(&src, fromcmd.str, fromcmd.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_connection_send(&(ctx->secondary_connection), src.bytes, src.olen, recv.bytes, recv.len, &(recv.olen));
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set_literal(&challenge, "%.*s", (int) recv.olen, recv.bytes);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
         goto exit;
     }
 
@@ -197,7 +197,7 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atstr_substring(&challengewithoutdata, challenge, 5, challenge.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_substring: %d\n | failed to remove \'data:\' prefix", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_substring: %d\n | failed to remove \'data:\' prefix", ret);
         goto exit;
     }
 
@@ -206,20 +206,20 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atbytes_convert_atstr(&challengebytes, challengewithoutdata);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert_atstr: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert_atstr: %d\n", ret);
         goto exit;
     }
     ret = atchops_rsa_sign(atkeys.pkamprivatekey, MBEDTLS_MD_SHA256, challengebytes.bytes, challengebytes.olen, recv.bytes, recv.len, &recv.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsa_sign: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsa_sign: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set_literal(&pkamcmd, "pkam:%.*s\r\n", (int) recv.olen, recv.bytes);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
         goto exit;
     }
     
@@ -227,14 +227,14 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atbytes_convert_atstr(&src, pkamcmd);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert_atstr: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert_atstr: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_connection_send(&(ctx->secondary_connection), src.bytes, src.olen, recv.bytes, recv.len, &recv.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n", ret);
         goto exit;
     }
 

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -202,7 +202,7 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     }
 
     // sign
-    atclient_atstr_reset(&recv);
+    atclient_atbytes_reset(&recv);
     ret = atclient_atbytes_convert_atstr(&challengebytes, challengewithoutdata);
     if(ret != 0)
     {
@@ -223,7 +223,7 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
         goto exit;
     }
     
-    atclient_atstr_reset(&recv);
+    atclient_atbytes_reset(&recv);
     ret = atclient_atbytes_convert_atstr(&src, pkamcmd);
     if(ret != 0)
     {

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -115,28 +115,28 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atsign_without_at_symbol(withoutat.str, withoutat.len, &(withoutat.olen), atsign, atsignlen);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atsign_without_at_symbol: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atsign_without_at_symbol: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set_literal(&atsigncmd, "%.*s\r\n", (int) withoutat.olen, withoutat.str);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atstr_set_literal: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_atbytes_convert_atstr(&src, atsigncmd);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atbytes_convert_atstr: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert_atstr: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_connection_send(&(ctx->root_connection), src.bytes, src.olen, recv.bytes, recv.len, &(recv.olen));
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_connection_send: %d\n | failed to send: %.*s\n", ret, withoutat.olen, withoutat);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n | failed to send: %.*s\n", ret, withoutat.olen, withoutat);
         goto exit;
     }
 
@@ -146,21 +146,21 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atstr_set_literal(&url, "%.*s", (int) recv.olen, recv.bytes);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atstr_set_literal: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_connection_get_host_and_port(&host, &port, url);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_connection_get_host_and_port: %d | failed to parse url %.*s\n", ret, recv.olen, recv.bytes);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_get_host_and_port: %d | failed to parse url %.*s\n", ret, recv.olen, recv.bytes);
         goto exit;
     }
 
     ret = atclient_start_secondary_connection(ctx, host.str, port);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_start_secondary_connection: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_start_secondary_connection: %d\n", ret);
         goto exit;
     }
 
@@ -168,28 +168,28 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atstr_set_literal(&fromcmd, "from:%.*s\r\n", (int) withoutat.olen, withoutat.str);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atstr_set_literal: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_atbytes_convert(&src, fromcmd.str, fromcmd.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atbytes_convert: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_connection_send(&(ctx->secondary_connection), src.bytes, src.olen, recv.bytes, recv.len, &(recv.olen));
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_connection_send: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set_literal(&challenge, "%.*s", (int) recv.olen, recv.bytes);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atstr_set_literal: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
         goto exit;
     }
 
@@ -197,7 +197,7 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atstr_substring(&challengewithoutdata, challenge, 5, challenge.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atstr_substring: %d\n | failed to remove \'data:\' prefix", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_substring: %d\n | failed to remove \'data:\' prefix", ret);
         goto exit;
     }
 
@@ -206,20 +206,20 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atbytes_convert_atstr(&challengebytes, challengewithoutdata);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atbytes_convert_atstr: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert_atstr: %d\n", ret);
         goto exit;
     }
     ret = atchops_rsa_sign(atkeys.pkamprivatekey, MBEDTLS_MD_SHA256, challengebytes.bytes, challengebytes.olen, recv.bytes, recv.len, &recv.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atchops_rsa_sign: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsa_sign: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set_literal(&pkamcmd, "pkam:%.*s\r\n", (int) recv.olen, recv.bytes);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atstr_set_literal: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal: %d\n", ret);
         goto exit;
     }
     
@@ -227,14 +227,14 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     ret = atclient_atbytes_convert_atstr(&src, pkamcmd);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_atbytes_convert_atstr: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert_atstr: %d\n", ret);
         goto exit;
     }
 
     ret = atclient_connection_send(&(ctx->secondary_connection), src.bytes, src.olen, recv.bytes, recv.len, &recv.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, "atclient_connection_send: %d\n", ret);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n", ret);
         goto exit;
     }
 

--- a/packages/atclient/src/atkeys.c
+++ b/packages/atclient/src/atkeys.c
@@ -58,7 +58,7 @@ int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys,
     ret = atclient_atstr_set(&(atkeys->selfencryptionkeystr), selfencryptionkeystr, selfencryptionkeylen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n", ret);
         goto exit;
     }
 
@@ -69,7 +69,7 @@ int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys,
         (unsigned char *) atkeys->pkampublickeystr.str, atkeys->pkampublickeystr.len, &(atkeys->pkampublickeystr.olen));
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_aesctr_decrypt: %d | failed to decrypt pkam public key\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_aesctr_decrypt: %d | failed to decrypt pkam public key\n", ret);
         goto exit;
     }
     memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_SIZE);
@@ -81,7 +81,7 @@ int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys,
         (unsigned char *) atkeys->pkamprivatekeystr.str, atkeys->pkamprivatekeystr.len, &(atkeys->pkamprivatekeystr.olen));
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_aesctr_decrypt: %d | failed to decrypt pkam private key\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_aesctr_decrypt: %d | failed to decrypt pkam private key\n", ret);
         goto exit;
     }
     memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_SIZE);
@@ -93,7 +93,7 @@ int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys,
         (unsigned char *) atkeys->encryptpublickeystr.str, atkeys->encryptpublickeystr.len, &(atkeys->encryptpublickeystr.olen));
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_aesctr_decrypt: %d | failed to decrypt encrypt public key\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_aesctr_decrypt: %d | failed to decrypt encrypt public key\n", ret);
         goto exit;
     }
     memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_SIZE);
@@ -105,7 +105,7 @@ int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys,
         (unsigned char *) atkeys->encryptprivatekeystr.str, atkeys->encryptprivatekeystr.len, &(atkeys->encryptprivatekeystr.olen));
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_aesctr_decrypt: %d | failed to decrypt encrypt private key\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_aesctr_decrypt: %d | failed to decrypt encrypt private key\n", ret);
         goto exit;
     }
 
@@ -115,28 +115,28 @@ int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys,
     ret = atchops_rsakey_populate_publickey(&(atkeys->pkampublickey), atkeys->pkampublickeystr.str, atkeys->pkampublickeystr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsakey_populate_publickey: %d | failed to populate pkam public key\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsakey_populate_publickey: %d | failed to populate pkam public key\n", ret);
         goto exit;
     }
 
     ret = atchops_rsakey_populate_privatekey(&(atkeys->pkamprivatekey), atkeys->pkamprivatekeystr.str, atkeys->pkamprivatekeystr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsakey_populate_privatekey: %d | failed to populate pkam private key\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsakey_populate_privatekey: %d | failed to populate pkam private key\n", ret);
         goto exit;
     }
 
     ret = atchops_rsakey_populate_privatekey(&(atkeys->encryptprivatekey), atkeys->encryptprivatekeystr.str, atkeys->encryptprivatekeystr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsakey_populate_privatekey: %d | failed to populate encrypt private key\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsakey_populate_privatekey: %d | failed to populate encrypt private key\n", ret);
         goto exit;
     }
 
     ret = atchops_rsakey_populate_publickey(&(atkeys->encryptpublickey), atkeys->encryptpublickeystr.str, atkeys->encryptpublickeystr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsakey_populate_publickey: %d | failed to populate encrypt public key\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsakey_populate_publickey: %d | failed to populate encrypt public key\n", ret);
         goto exit;
     }
 
@@ -162,7 +162,7 @@ int atclient_atkeys_populate_from_atkeysfile(atclient_atkeys *atkeys, atclient_a
         atkeysfile.selfencryptionkeystr.str, atkeysfile.selfencryptionkeystr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeys_populate_from_strings: %d | failed to populate from strings\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeys_populate_from_strings: %d | failed to populate from strings\n", ret);
         goto exit;
     }
 
@@ -184,14 +184,14 @@ int atclient_atkeys_populate_from_path(atclient_atkeys *atkeys, const char *path
     ret = atclient_atkeysfile_read(&atkeysfile, path);
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeysfile_read: %d | failed to read file at path: %s\n", ret, path);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeysfile_read: %d | failed to read file at path: %s\n", ret, path);
         goto exit;
     }
 
     ret = atclient_atkeys_populate_from_atkeysfile(atkeys, atkeysfile);
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeys_populate_from_atkeysfile: %d | failed to decrypt & populate struct \n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeys_populate_from_atkeysfile: %d | failed to decrypt & populate struct \n", ret);
         goto exit;
     }
 

--- a/packages/atclient/src/atkeys.c
+++ b/packages/atclient/src/atkeys.c
@@ -7,28 +7,28 @@
 #include "atclient/atlogger.h"
 #include "atclient/atkeys.h"
 #include "atclient/atstr.h"
+#include "atclient/constants.h"
 
 #define TAG "atkeys"
 
-#define BUFFER_SIZE 4096 // the max size of an RSA key base 64 encoded (unencrypted)
 
 void atclient_atkeys_init(atclient_atkeys *atkeys)
 {
     memset(atkeys, 0, sizeof(atclient_atkeys));
 
-    atclient_atstr_init(&(atkeys->pkampublickeystr), BUFFER_SIZE);
+    atclient_atstr_init(&(atkeys->pkampublickeystr), ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE);
     atchops_rsakey_init_publickey(&(atkeys->pkampublickey));
 
-    atclient_atstr_init(&(atkeys->pkamprivatekeystr), BUFFER_SIZE);
+    atclient_atstr_init(&(atkeys->pkamprivatekeystr), ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE);
     atchops_rsakey_init_privatekey(&(atkeys->pkamprivatekey));
 
-    atclient_atstr_init(&(atkeys->encryptpublickeystr), BUFFER_SIZE);
+    atclient_atstr_init(&(atkeys->encryptpublickeystr), ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE);
     atchops_rsakey_init_publickey(&(atkeys->encryptpublickey));
 
-    atclient_atstr_init(&(atkeys->encryptprivatekeystr), BUFFER_SIZE);
+    atclient_atstr_init(&(atkeys->encryptprivatekeystr), ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE);
     atchops_rsakey_init_privatekey(&(atkeys->encryptprivatekey));
 
-    atclient_atstr_init(&(atkeys->selfencryptionkeystr), BUFFER_SIZE);
+    atclient_atstr_init(&(atkeys->selfencryptionkeystr), ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE);
 }
 
 int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys,

--- a/packages/atclient/src/atkeysfile.c
+++ b/packages/atclient/src/atkeysfile.c
@@ -36,7 +36,7 @@ int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path)
 
     if (file == NULL)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "fopen failed\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "fopen failed\n");
         ret = 1;
         goto exit;
     }
@@ -44,7 +44,7 @@ int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path)
     unsigned long bytesread = fread(readbuf.str, sizeof(char), readbuf.len, file);
     if (bytesread == 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "fread failed\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "fread failed\n");
         ret = 1;
         goto exit;
     }
@@ -54,7 +54,7 @@ int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path)
     cJSON *aespkamprivatekey = cJSON_GetObjectItem(root, "aesPkamPrivateKey");
     if (aespkamprivatekey == NULL)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Error reading aesPkamPrivateKey!\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Error reading aesPkamPrivateKey!\n");
         ret = 1;
         goto exit;
     }
@@ -62,7 +62,7 @@ int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path)
     cJSON *aespkampublickey = cJSON_GetObjectItem(root, "aesPkamPublicKey");
     if (aespkampublickey == NULL)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Error reading aesPkamPublicKey!\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Error reading aesPkamPublicKey!\n");
         ret = 1;
         goto exit;
     }
@@ -70,7 +70,7 @@ int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path)
     cJSON *aesencryptprivatekey = cJSON_GetObjectItem(root, "aesEncryptPrivateKey");
     if (aesencryptprivatekey == NULL)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Error reading aesEncryptPrivateKey!\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Error reading aesEncryptPrivateKey!\n");
         ret = 1;
         goto exit;
     }
@@ -78,7 +78,7 @@ int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path)
     cJSON *aesencryptpublickey = cJSON_GetObjectItem(root, "aesEncryptPublicKey");
     if (aesencryptpublickey == NULL)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Error reading aesEncryptPublicKey!\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Error reading aesEncryptPublicKey!\n");
         ret = 1;
         goto exit;
     }
@@ -86,7 +86,7 @@ int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path)
     cJSON *selfencryptionkey = cJSON_GetObjectItem(root, "selfEncryptionKey");
     if (selfencryptionkey == NULL)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Error reading selfEncryptionKey!\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Error reading selfEncryptionKey!\n");
         ret = 1;
         goto exit;
     }
@@ -94,35 +94,35 @@ int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path)
     ret = atclient_atstr_set(&(atkeysfile->aespkampublickeystr), aespkampublickey->valuestring, strlen(aespkampublickey->valuestring));
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkampublickeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkampublickeystr\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set(&(atkeysfile->aespkamprivatekeystr), aespkamprivatekey->valuestring, strlen(aespkamprivatekey->valuestring));
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkamprivatekeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkamprivatekeystr\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set(&(atkeysfile->aesencryptprivatekeystr), aesencryptprivatekey->valuestring, strlen(aesencryptprivatekey->valuestring));
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptprivatekeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptprivatekeystr\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set(&(atkeysfile->aesencryptpublickeystr), aesencryptpublickey->valuestring, strlen(aesencryptpublickey->valuestring));
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptpublickeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptpublickeystr\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set(&(atkeysfile->selfencryptionkeystr), selfencryptionkey->valuestring, strlen(selfencryptionkey->valuestring));
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n", ret);
         goto exit;
     }
     goto exit;
@@ -158,42 +158,42 @@ int atclient_atkeysfile_write(atclient_atkeysfile *atkeysfile, const char *path,
     ret = atclient_atstr_set(&aespkampublickey, atkeysfile->aespkampublickeystr.str, atkeysfile->aespkampublickeystr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkampublickeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkampublickeystr\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set(&aespkamprivatekey, atkeysfile->aespkamprivatekeystr.str, atkeysfile->aespkamprivatekeystr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkamprivatekeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkamprivatekeystr\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set(&aesencryptprivatekey, atkeysfile->aesencryptprivatekeystr.str, atkeysfile->aesencryptprivatekeystr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptprivatekeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptprivatekeystr\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set(&aesencryptpublickey, atkeysfile->aesencryptpublickeystr.str, atkeysfile->aesencryptpublickeystr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptpublickeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptpublickeystr\n", ret);
         goto exit;
     }
 
     ret = atclient_atstr_set(&selfencryptionkey, atkeysfile->selfencryptionkeystr.str, atkeysfile->selfencryptionkeystr.olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n", ret);
         goto exit;
     }
 
     // check that atkeysfile has populated values
     if (atkeysfile->aespkamprivatekeystr.olen == 0 || atkeysfile->aespkampublickeystr.olen == 0 || atkeysfile->aesencryptprivatekeystr.olen == 0 || atkeysfile->aesencryptpublickeystr.olen == 0 || atkeysfile->selfencryptionkeystr.olen == 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkeysfile has not been populated with values\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkeysfile has not been populated with values\n");
         ret = 1;
         goto exit;
     }

--- a/packages/atclient/src/atlogger.c
+++ b/packages/atclient/src/atlogger.c
@@ -17,10 +17,10 @@ static char *prefix;
 
 typedef struct atlogger_ctx
 {
-    atlogger_logging_level level;
+    atclient_atlogger_logging_level level;
 } atlogger_ctx;
 
-static void atlogger_get_prefix(atlogger_logging_level logging_level, char *prefix, unsigned long prefixlen)
+static void atlogger_get_prefix(atclient_atlogger_logging_level logging_level, char *prefix, unsigned long prefixlen)
 {
     memset(prefix, 0, prefixlen);
     switch(logging_level)
@@ -66,19 +66,19 @@ static atlogger_ctx *atlogger_get_instance()
     return ctx;
 }
 
-atlogger_logging_level atlogger_get_logging_level()
+atclient_atlogger_logging_level atlogger_get_logging_level()
 {
     atlogger_ctx *ctx = atlogger_get_instance();
     return ctx->level;
 }
 
-void atlogger_set_logging_level(atlogger_logging_level level)
+void atclient_atlogger_set_logging_level(atclient_atlogger_logging_level level)
 {
     atlogger_ctx *ctx = atlogger_get_instance();
     ctx->level = level;
 }
 
-void atlogger_log(const char *tag, atlogger_logging_level level, const char *format, ...)
+void atclient_atlogger_log(const char *tag, atclient_atlogger_logging_level level, const char *format, ...)
 {
     atlogger_ctx *ctx = atlogger_get_instance();
 

--- a/packages/atclient/src/atsign.c
+++ b/packages/atclient/src/atsign.c
@@ -1,0 +1,45 @@
+#ifndef ATCLIENT_ATSIGN_H
+#define ATCLIENT_ATSIGN_H
+
+#include <string.h>
+#include <stdio.h>
+#include "atclient/atlogger.h"
+#include "atclient/atsign.h"
+
+#define TAG "atsign"
+
+int atclient_atsign_without_at_symbol(char *atsign, const unsigned long atsignlen, unsigned long *atsignolen, const char *originalatsign, const unsigned long originalatsignlen)
+{
+    int ret = 1;
+    if(atsignlen + 1 < originalatsignlen)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atsignlen might be too low. consider allocating more buffer space. atsignlen: %d\n", atsignlen);
+        ret = 1;
+        goto exit;
+    }
+
+    if(originalatsignlen <= 0)
+    {
+        ret = 2;
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "originalatsignlen is <= 0: %lu\n", originalatsignlen);
+        goto exit;
+    }
+
+    if (originalatsign[0] != '@') {
+        // it did not begin with an `@` to begin with
+        ret = 0;
+        goto exit;
+    }
+
+    strncpy(atsign, originalatsign + 1, originalatsignlen - 1);
+    *atsignolen = originalatsignlen - 1;
+    ret = 0;
+    goto exit;
+exit:
+{
+    return ret;
+}
+}
+
+
+#endif

--- a/packages/atclient/src/atsign.c
+++ b/packages/atclient/src/atsign.c
@@ -13,7 +13,7 @@ int atclient_atsign_without_at_symbol(char *atsign, const unsigned long atsignle
     int ret = 1;
     if(atsignlen + 1 < originalatsignlen)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atsignlen might be too low. consider allocating more buffer space. atsignlen: %d\n", atsignlen);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atsignlen might be too low. consider allocating more buffer space. atsignlen: %d\n", atsignlen);
         ret = 1;
         goto exit;
     }
@@ -21,7 +21,7 @@ int atclient_atsign_without_at_symbol(char *atsign, const unsigned long atsignle
     if(originalatsignlen <= 0)
     {
         ret = 2;
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "originalatsignlen is <= 0: %lu\n", originalatsignlen);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "originalatsignlen is <= 0: %lu\n", originalatsignlen);
         goto exit;
     }
 

--- a/packages/atclient/src/atstr.c
+++ b/packages/atclient/src/atstr.c
@@ -1,33 +1,65 @@
 #include <string.h>
 #include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
 #include "atclient/atstr.h"
 #include "atclient/atlogger.h"
 
 #define TAG "atstr"
 
-void atclient_atstr_init(atclient_atstr *atstr, unsigned long bufferlen)
+void atclient_atstr_init(atclient_atstr *atstr, const unsigned long bufferlen)
 {
     memset(atstr, 0, sizeof(atclient_atstr));
     atstr->len = bufferlen;
+    if(atstr->str != NULL)
+    {
+        free(atstr->str);
+    }
     atstr->str = (char *) malloc(sizeof(char) * atstr->len);
     atstr->olen = 0;
 }
 
-void atclient_atstr_init_literal(atclient_atstr *atstr, const char *str)
-{
-    atclient_atstr_init(atstr, strlen(str));
-    atclient_atstr_set(atstr, str, strlen(str));
-}
-
-int atclient_atstr_set_literal(atclient_atstr *atstr, const char *str)
+int atclient_atstr_init_literal(atclient_atstr *atstr, const unsigned long bufferlen, const char *format, ...)
 {
     int ret = 1;
-    ret = atclient_atstr_set(atstr, str, strlen(str));
+    atclient_atstr_init(atstr, bufferlen);
+    ret = atclient_atstr_set_literal(atstr, format);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set failed");
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal failed");
         goto exit;
     }
+    goto exit;
+exit:
+{
+    return ret;
+}
+}
+
+void atclient_atstr_reset(atclient_atstr *atstr)
+{
+    memset(atstr->str, 0, atstr->len);
+    atstr->olen = 0;
+}
+
+int atclient_atstr_set_literal(atclient_atstr *atstr, const char *format, ...){
+    int ret = 1;
+    if(atstr->str == NULL)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atstr->str is NULL\n");
+        goto exit;
+    }
+    va_list args;
+    va_start(args, format);
+    ret = vsnprintf(atstr->str, atstr->len, format, args);
+    va_end(args); // Add va_end() to properly handle variadic arguments
+    if(ret < 0)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "vsnprintf failed");
+        goto exit;
+    }
+    atstr->olen = ret;
+    ret = 0;
     goto exit;
 exit:
 {
@@ -42,7 +74,7 @@ int atclient_atstr_set(atclient_atstr *atstr, const char *str, const unsigned lo
     if(len > atstr->len)
     {
         ret = 1;
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "len > atstr->len (%d > %d)", len, atstr->len);
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "len > atstr->len (%d > %d)\n", len, atstr->len);
         goto exit;
     }
 
@@ -67,6 +99,55 @@ int atclient_atstr_copy(atclient_atstr *atstr, atclient_atstr *data)
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set failed");
         goto exit;
     }
+    goto exit;
+exit:
+{
+    return ret;
+}
+}
+
+int atclient_atstr_substring(atclient_atstr *substring, const atclient_atstr original, const unsigned long start, const unsigned long end)
+{
+    int ret = 1;
+    if(start > original.olen || end > original.olen)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "start or end is greater than original.olen\n");
+        goto exit;
+    }
+    if(start > end)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "start is greater than end\n");
+        goto exit;
+    }
+    if(end - start > substring->len)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "end - start > substring->len\n");
+        goto exit;
+    }
+    memcpy(substring->str, original.str + start, end - start);
+    substring->olen = end - start;
+    ret = 0;
+    goto exit;
+
+exit:
+{
+    return ret;
+}
+}
+
+int atclient_atstr_append(atclient_atstr *atstr, const char *format, ...)
+{
+    int ret = 1;
+    va_list args;
+    va_start(args, format);
+    ret = vsnprintf(atstr->str + atstr->olen, atstr->len - atstr->olen, format, args);
+    if(ret < 0)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "vsnprintf failed");
+        goto exit;
+    }
+    atstr->olen += ret;
+    ret = 0;
     goto exit;
 exit:
 {

--- a/packages/atclient/src/atstr.c
+++ b/packages/atclient/src/atstr.c
@@ -26,7 +26,7 @@ int atclient_atstr_init_literal(atclient_atstr *atstr, const unsigned long buffe
     ret = atclient_atstr_set_literal(atstr, format);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal failed");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal failed");
         goto exit;
     }
     goto exit;
@@ -46,7 +46,7 @@ int atclient_atstr_set_literal(atclient_atstr *atstr, const char *format, ...){
     int ret = 1;
     if(atstr->str == NULL)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atstr->str is NULL\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atstr->str is NULL\n");
         goto exit;
     }
     va_list args;
@@ -55,7 +55,7 @@ int atclient_atstr_set_literal(atclient_atstr *atstr, const char *format, ...){
     va_end(args); // Add va_end() to properly handle variadic arguments
     if(ret < 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "vsnprintf failed");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "vsnprintf failed");
         goto exit;
     }
     atstr->olen = ret;
@@ -74,7 +74,7 @@ int atclient_atstr_set(atclient_atstr *atstr, const char *str, const unsigned lo
     if(len > atstr->len)
     {
         ret = 1;
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "len > atstr->len (%d > %d)\n", len, atstr->len);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "len > atstr->len (%d > %d)\n", len, atstr->len);
         goto exit;
     }
 
@@ -96,7 +96,7 @@ int atclient_atstr_copy(atclient_atstr *atstr, atclient_atstr *data)
     ret = atclient_atstr_set(atstr, data->str, data->olen);
     if(ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set failed");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set failed");
         goto exit;
     }
     goto exit;
@@ -111,17 +111,17 @@ int atclient_atstr_substring(atclient_atstr *substring, const atclient_atstr ori
     int ret = 1;
     if(start > original.olen || end > original.olen)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "start or end is greater than original.olen\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "start or end is greater than original.olen\n");
         goto exit;
     }
     if(start > end)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "start is greater than end\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "start is greater than end\n");
         goto exit;
     }
     if(end - start > substring->len)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "end - start > substring->len\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "end - start > substring->len\n");
         goto exit;
     }
     memcpy(substring->str, original.str + start, end - start);
@@ -143,7 +143,7 @@ int atclient_atstr_append(atclient_atstr *atstr, const char *format, ...)
     ret = vsnprintf(atstr->str + atstr->olen, atstr->len - atstr->olen, format, args);
     if(ret < 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "vsnprintf failed");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "vsnprintf failed");
         goto exit;
     }
     atstr->olen += ret;

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -298,7 +298,7 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     }
     fix_stdout_buffer(stdoutbuffer.str, stdoutbuffer.olen);
 
-    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\e[0m\"\n", "\e[1;35m", "\e[0;95m", (int)stdoutbuffer.olen, stdoutbuffer.str);
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\"\e[0m\n", "\e[1;35m", "\e[0;95m", (int)stdoutbuffer.olen, stdoutbuffer.str);
     memset(recv, 0, sizeof(unsigned char) * recvlen); // clear the buffer
     memcpy(recv, stdoutbuffer.str, stdoutbuffer.olen);
     goto exit;

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -10,10 +10,9 @@
 #include "atclient/cacerts.h"
 #include "atclient/connection.h"
 #include "atclient/constants.h"
+#include "atclient/atstr.h"
 
 #define TAG "connection"
-
-#define HOST_BUFFER_SIZE 1024 // the size of the buffer for the host name
 
 /* Concatenation of all available CA certificates in PEM format */
 const char cas_pem[] =
@@ -34,10 +33,10 @@ static void my_debug(void *ctx, int level, const char *file, int line, const cha
     fflush((FILE *)ctx);
 }
 
-void atclient_connection_init(atclient_connection_ctx *ctx)
+void atclient_connection_init(atclient_connection *ctx)
 {
-    memset(ctx, 0, sizeof(atclient_connection_ctx));
-    ctx->host = (char *)malloc(sizeof(char) * HOST_BUFFER_SIZE);
+    memset(ctx, 0, sizeof(atclient_connection));
+    memset(ctx->host, 0, ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE);
     ctx->port = -1;
 
     mbedtls_net_init(&(ctx->net));
@@ -48,40 +47,44 @@ void atclient_connection_init(atclient_connection_ctx *ctx)
     mbedtls_ctr_drbg_init(&(ctx->ctr_drbg));
 }
 
-int atclient_connection_connect(atclient_connection_ctx *ctx, const char *host, const int port)
+int atclient_connection_connect(atclient_connection *ctx, const char *host, const int port)
 {
     int ret = 1;
+
+    atclient_atstr readbuf;
+    atclient_atstr_init(&readbuf, 1024);
 
     strcpy(ctx->host, host); // assume null terminated, example: "root.atsign.org"
     ctx->port = port;        // example: 64
 
-    char *portstr = (char *) malloc(sizeof(char) * 6);
+    char portstr[6];
     sprintf(portstr, "%d", ctx->port);
 
     ret = mbedtls_ctr_drbg_seed(&(ctx->ctr_drbg), mbedtls_entropy_func, &(ctx->entropy), NULL, NULL);
-    // printf("mbedtls_ctr_drbg_seed: %d\n", ret);
     if (ret != 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ctr_drbg_seed failed with exit code: %d\n", ret);
         goto exit;
     }
 
     ret = mbedtls_x509_crt_parse(&(ctx->cacert), cas_pem, cas_pem_len);
-    if (ret != 0) 
+    if (ret != 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_x509_crt_parse failed with exit code: %d\n", ret);
         goto exit;
     }
 
     ret = mbedtls_net_connect(&(ctx->net), host, portstr, MBEDTLS_NET_PROTO_TCP);
-    // printf("mbedtls_net_connect: %d\n", ret);
     if (ret != 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_net_connect failed with exit code: %d\n", ret);
         goto exit;
     }
 
     ret = mbedtls_ssl_config_defaults(&(ctx->ssl_config), MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT);
-    // printf("mbedtls_ssl_config_defaults: %d\n", ret);
     if (ret != 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_config_defaults failed with exit code: %d\n", ret);
         goto exit;
     }
 
@@ -91,32 +94,32 @@ int atclient_connection_connect(atclient_connection_ctx *ctx, const char *host, 
     mbedtls_ssl_conf_dbg(&(ctx->ssl_config), my_debug, stdout);
 
     ret = mbedtls_ssl_setup(&(ctx->ssl), &(ctx->ssl_config));
-    // printf("mbedtls_ssl_setup: %d\n", ret);
     if (ret != 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_setup failed with exit code: %d\n", ret);
         goto exit;
     }
 
     ret = mbedtls_ssl_set_hostname(&(ctx->ssl), host);
-    // printf("mbedtls_ssl_set_hostname: %d\n", ret);
     if (ret != 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_set_hostname failed with exit code: %d\n", ret);
         goto exit;
     }
 
     mbedtls_ssl_set_bio(&(ctx->ssl), &(ctx->net), mbedtls_net_send, mbedtls_net_recv, mbedtls_net_recv_timeout);
 
     ret = mbedtls_ssl_handshake(&(ctx->ssl));
-    // printf("mbedtls_ssl_handshake: %d\n", ret);
     if (ret != 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_handshake failed with exit code: %d\n", ret);
         goto exit;
     }
 
     ret = mbedtls_ssl_get_verify_result(&(ctx->ssl));
-    // printf("mbedtls_ssl_get_verify_result: %d\n", ret);
     if (ret != 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_get_verify_result failed with exit code: %d\n", ret);
         goto exit;
     }
 
@@ -124,33 +127,31 @@ int atclient_connection_connect(atclient_connection_ctx *ctx, const char *host, 
     // after connect
     // ===============
 
-    const unsigned long readbuflen = 128;
-    unsigned char *readbuf = malloc(sizeof(unsigned char) * readbuflen);
-    memset(readbuf, 0, readbuflen);
-
     // read anything that was already sent
-    ret = mbedtls_ssl_read(&(ctx->ssl), readbuf, readbuflen);
+    ret = mbedtls_ssl_read(&(ctx->ssl), readbuf.str, readbuf.len);
     if (ret < 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_read failed with exit code: %d\n", ret);
         goto exit;
     }
 
     // press enter
-    ret = mbedtls_ssl_write(&(ctx->ssl), (const unsigned char *)"\r\n", 2);
+    ret = mbedtls_ssl_write(&(ctx->ssl), (const unsigned char *) "\r\n", 2);
     if (ret < 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_write failed with exit code: %d\n", ret);
         goto exit;
     }
 
     // read anything that was sent
-    ret = mbedtls_ssl_read(&(ctx->ssl), readbuf, readbuflen);
+    ret = mbedtls_ssl_read(&(ctx->ssl), readbuf.str, readbuf.len);
     if (ret < 0)
     {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_read failed with exit code: %d\n", ret);
         goto exit;
     }
 
     // now we are guaranteed a blank canvas
-    
     if (ret > 0)
     {
         ret = 0; // a positive exit code is not an error
@@ -160,13 +161,12 @@ int atclient_connection_connect(atclient_connection_ctx *ctx, const char *host, 
 
 exit:
 {
-    free(readbuf);
-    free(portstr);
+    atclient_atstr_free(&readbuf);
     return ret;
 }
 }
 
-int atclient_connection_send(atclient_connection_ctx *ctx, const unsigned char *src, const unsigned long srclen, unsigned char *recv, const unsigned long recvlen, unsigned long *olen)
+int atclient_connection_send(atclient_connection *ctx, const unsigned char *src, const unsigned long srclen, unsigned char *recv, const unsigned long recvlen, unsigned long *olen)
 {
     int ret = 1;
     ret = mbedtls_ssl_write(&(ctx->ssl), src, srclen);
@@ -188,11 +188,6 @@ int atclient_connection_send(atclient_connection_ctx *ctx, const unsigned char *
         }
         l = l + ret;
 
-        // printf("*(recv+%lu) == %.2x == %c\n", l-1, (unsigned char) *(recv + l-1), (unsigned char) *(recv + l-1));
-        // printf("*(recv+%lu) == %.2x == %c\n", l, (unsigned char) *(recv + l), (unsigned char) *(recv + l));
-
-        // printf("\\n: %.2x\n", '\n');
-
         for (int i = l; i >= l - ret && i >= 0; i--)
         {
             // printf("i: %d c: %.2x\n", i, (unsigned char) *(recv + i));
@@ -208,15 +203,12 @@ int atclient_connection_send(atclient_connection_ctx *ctx, const unsigned char *
             break;
         }
 
-        // size_t bytesavail = mbedtls_ssl_get_bytes_avail(ctx->ssl);
-        // printf("bytes_avail: %lu\n", bytesavail);
     } while (ret == MBEDTLS_ERR_SSL_WANT_READ || found == 0);
 
     if (ret < 0)
     {
         goto exit;
     }
-    // printf("mbedtls_ssl_read: %d\n", ret);
 
     *olen = 0;
     while (recv[(*olen)] != '\r' && recv[(*olen)] != '\n')
@@ -238,12 +230,12 @@ exit:
 }
 }
 
-int atclient_connection_disconnect(atclient_connection_ctx *ctx)
+int atclient_connection_disconnect(atclient_connection *ctx)
 {
-    return 1; // not implemented
+    return 1; // TODO: implement this
 }
 
-int atclient_connection_is_connected(atclient_connection_ctx *ctx)
+int atclient_connection_is_connected(atclient_connection *ctx)
 {
     int ret = 0; // false by default
     const char *cmd = "\r\n";
@@ -275,7 +267,7 @@ exit: {
 }
 }
 
-void atclient_connection_free(atclient_connection_ctx *ctx)
+void atclient_connection_free(atclient_connection *ctx)
 {
     mbedtls_net_free(&(ctx->net));
     mbedtls_ssl_free(&(ctx->ssl));
@@ -284,4 +276,45 @@ void atclient_connection_free(atclient_connection_ctx *ctx)
     mbedtls_entropy_free(&(ctx->entropy));
     mbedtls_ctr_drbg_free(&(ctx->ctr_drbg));
     free(ctx->host);
+}
+
+int atclient_connection_get_host_and_port(atclient_atstr *host, int *port, const atclient_atstr url)
+{
+    int ret = 1;
+
+    char *colon = strchr(url.str, ':');
+    if (colon == NULL)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "no colon in url\n");
+        ret = 1;
+        goto exit;
+    }
+
+    int hostlen = colon - url.str;
+    if (hostlen > ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "hostlen > ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE\n");
+        ret = 1;
+        goto exit;
+    }
+
+    strncpy(host->str, url.str, hostlen);
+    host->len = hostlen;
+    host->str[hostlen] = '\0';
+    *port = atoi(colon + 1);
+    if(*port == 0)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "port is 0\n");
+        ret = 1;
+        goto exit;
+    }
+
+    ret = 0;
+
+    goto exit;
+
+exit:
+{
+    return ret;
+}
 }

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -63,28 +63,28 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
     ret = mbedtls_ctr_drbg_seed(&(ctx->ctr_drbg), mbedtls_entropy_func, &(ctx->entropy), NULL, NULL);
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ctr_drbg_seed failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ctr_drbg_seed failed with exit code: %d\n", ret);
         goto exit;
     }
 
     ret = mbedtls_x509_crt_parse(&(ctx->cacert), cas_pem, cas_pem_len);
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_x509_crt_parse failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_x509_crt_parse failed with exit code: %d\n", ret);
         goto exit;
     }
 
     ret = mbedtls_net_connect(&(ctx->net), host, portstr, MBEDTLS_NET_PROTO_TCP);
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_net_connect failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_net_connect failed with exit code: %d\n", ret);
         goto exit;
     }
 
     ret = mbedtls_ssl_config_defaults(&(ctx->ssl_config), MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT);
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_config_defaults failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_config_defaults failed with exit code: %d\n", ret);
         goto exit;
     }
 
@@ -96,14 +96,14 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
     ret = mbedtls_ssl_setup(&(ctx->ssl), &(ctx->ssl_config));
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_setup failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_setup failed with exit code: %d\n", ret);
         goto exit;
     }
 
     ret = mbedtls_ssl_set_hostname(&(ctx->ssl), host);
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_set_hostname failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_set_hostname failed with exit code: %d\n", ret);
         goto exit;
     }
 
@@ -112,14 +112,14 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
     ret = mbedtls_ssl_handshake(&(ctx->ssl));
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_handshake failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_handshake failed with exit code: %d\n", ret);
         goto exit;
     }
 
     ret = mbedtls_ssl_get_verify_result(&(ctx->ssl));
     if (ret != 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_get_verify_result failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_get_verify_result failed with exit code: %d\n", ret);
         goto exit;
     }
 
@@ -131,7 +131,7 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
     ret = mbedtls_ssl_read(&(ctx->ssl), readbuf.str, readbuf.len);
     if (ret < 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_read failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_read failed with exit code: %d\n", ret);
         goto exit;
     }
 
@@ -139,7 +139,7 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
     ret = mbedtls_ssl_write(&(ctx->ssl), (const unsigned char *) "\r\n", 2);
     if (ret < 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_write failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_write failed with exit code: %d\n", ret);
         goto exit;
     }
 
@@ -147,7 +147,7 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
     ret = mbedtls_ssl_read(&(ctx->ssl), readbuf.str, readbuf.len);
     if (ret < 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_read failed with exit code: %d\n", ret);
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_read failed with exit code: %d\n", ret);
         goto exit;
     }
 
@@ -174,7 +174,7 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     {
         goto exit;
     }
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\tSENT: \"%.*s\"\n", (int) srclen, src);
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\tSENT: \"%.*s\"\n", (int) srclen, src);
 
     memset(recv, 0, recvlen);
     int found = 0;
@@ -220,7 +220,7 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     {
         ret = 0;
     }
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\tRECV: \"%.*s\"\n", (int) *olen, recv);
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\tRECV: \"%.*s\"\n", (int) *olen, recv);
 
     goto exit;
 
@@ -284,7 +284,7 @@ int atclient_connection_get_host_and_port(atclient_atstr *host, int *port, const
     char *colon = strchr(url.str, ':');
     if (colon == NULL)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "no colon in url\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "no colon in url\n");
         ret = 1;
         goto exit;
     }
@@ -292,7 +292,7 @@ int atclient_connection_get_host_and_port(atclient_atstr *host, int *port, const
     int hostlen = colon - url.str;
     if (hostlen > ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "hostlen > ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "hostlen > ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE\n");
         ret = 1;
         goto exit;
     }
@@ -303,7 +303,7 @@ int atclient_connection_get_host_and_port(atclient_atstr *host, int *port, const
     *port = atoi(colon + 1);
     if(*port == 0)
     {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "port is 0\n");
+        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "port is 0\n");
         ret = 1;
         goto exit;
     }

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -275,7 +275,6 @@ void atclient_connection_free(atclient_connection *ctx)
     mbedtls_x509_crt_free(&(ctx->cacert));
     mbedtls_entropy_free(&(ctx->entropy));
     mbedtls_ctr_drbg_free(&(ctx->ctr_drbg));
-    free(ctx->host);
 }
 
 int atclient_connection_get_host_and_port(atclient_atstr *host, int *port, const atclient_atstr url)

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -299,7 +299,8 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     fix_stdout_buffer(stdoutbuffer.str, stdoutbuffer.olen);
 
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\e[0m\"\n", "\e[1;35m", "\e[0;95m", (int)stdoutbuffer.olen, stdoutbuffer.str);
-
+    memset(recv, 0, sizeof(unsigned char) * recvlen); // clear the buffer
+    memcpy(recv, stdoutbuffer.str, stdoutbuffer.olen);
     goto exit;
 
 exit:

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -253,7 +253,7 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
 
     fix_stdout_buffer(stdoutbuffer.str, stdoutbuffer.olen);
 
-    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\tSENT: \"%s%.*s%s\"\n", "\033[0;33m", (int)stdoutbuffer.olen, stdoutbuffer.str, "\033[0m");
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sSENT: %s\"%.*s\"\e[0m\n", "\e[1;34m", "\e[0;96m", (int)stdoutbuffer.olen, stdoutbuffer.str);
 
     memset(recv, 0, recvlen);
     int found = 0;
@@ -298,8 +298,7 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     }
     fix_stdout_buffer(stdoutbuffer.str, stdoutbuffer.olen);
 
-
-    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\tRECV: \"%s%.*s%s\"\n", "\033[31m", (int)stdoutbuffer.olen, stdoutbuffer.str, "\033[0m");
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\e[0m\"\n", "\e[1;35m", "\e[0;95m", (int)stdoutbuffer.olen, stdoutbuffer.str);
 
     goto exit;
 

--- a/packages/atclient/tests/test_connection.c
+++ b/packages/atclient/tests/test_connection.c
@@ -13,10 +13,10 @@ int main()
     printf("host: %s\n", host);
     printf("port: %d\n", port);
 
-    atclient_connection ctx;
-    atclient_connection_init(&ctx);
+    atclient_connection connection;
+    atclient_connection_init(&connection);
 
-    ret = atclient_connection_connect(&ctx, host, port);
+    ret = atclient_connection_connect(&connection, host, port);
     printf("atclient_connection_connect: %d\n", ret);
     if (ret != 0)
     {
@@ -24,12 +24,14 @@ int main()
     }
 
     const unsigned long dstlen = 1024;
-    unsigned char *dst = malloc(sizeof(unsigned char) * dstlen);
-    memset(dst, 0, dstlen);
+    unsigned char dst[dstlen];
+    memset(dst, 0, sizeof(unsigned char) * dstlen);
     unsigned long olen = 0;
-    const char *cmd = "colin\r\n";
+
+    const unsigned char *cmd = "colin\r\n";
     const unsigned long cmdlen = strlen(cmd);
-    ret = atclient_connection_send(&ctx, (unsigned char *) cmd, cmdlen, dst, dstlen, &olen);
+
+    ret = atclient_connection_send(&connection, cmd, cmdlen, dst, dstlen, &olen);
     printf("atclient_connection_send: %d\n", ret);
     if (ret != 0)
     {
@@ -38,7 +40,7 @@ int main()
 
     printf("received: \"%.*s\"\n", (int) olen, dst);
 
-    ret = strncmp((char *)dst, "79b6d83f-5026-5fda-8299-5a0704bd2416.canary.atsign.zone:1029", olen);
+    ret = strncmp((char *) dst, "79b6d83f-5026-5fda-8299-5a0704bd2416.canary.atsign.zone:1029", olen);
     printf("strncmp: %d\n", ret);
     if (ret != 0)
     {
@@ -49,8 +51,7 @@ int main()
 
 exit:
 {
-    free(dst);
-    atclient_connection_free(&ctx);
+    atclient_connection_free(&connection);
     return ret;
 }
 }

--- a/packages/atclient/tests/test_connection.c
+++ b/packages/atclient/tests/test_connection.c
@@ -13,7 +13,7 @@ int main()
     printf("host: %s\n", host);
     printf("port: %d\n", port);
 
-    atclient_connection_ctx ctx;
+    atclient_connection ctx;
     atclient_connection_init(&ctx);
 
     ret = atclient_connection_connect(&ctx, host, port);

--- a/packages/atclient/tests/test_connection.c
+++ b/packages/atclient/tests/test_connection.c
@@ -16,6 +16,11 @@ int main()
     atclient_connection connection;
     atclient_connection_init(&connection);
 
+    const unsigned long dstlen = 1024;
+    unsigned char dst[dstlen];
+    memset(dst, 0, sizeof(unsigned char) * dstlen);
+    unsigned long olen = 0;
+    
     ret = atclient_connection_connect(&connection, host, port);
     printf("atclient_connection_connect: %d\n", ret);
     if (ret != 0)
@@ -23,10 +28,6 @@ int main()
         goto exit;
     }
 
-    const unsigned long dstlen = 1024;
-    unsigned char dst[dstlen];
-    memset(dst, 0, sizeof(unsigned char) * dstlen);
-    unsigned long olen = 0;
 
     const unsigned char *cmd = "colin\r\n";
     const unsigned long cmdlen = strlen(cmd);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- made repl better using new functions
- made atclient_start_root_connection cleaner using new functions
- made atclient_pkam_authenticate cleaner using new string functions

**- How I did it**

- created `atbytes.c` and `atbytes.h`
- added more methods to `atstr.c` and `atstr.h` 
- `atsign.c` and `atsign.h` -> `atclient_atsign_without_at_symbol`
- `atkeys.c` now uses constants from `constants.h`

- Refactored atclient_ctx to atclient
- Refactored atclient_connection_ctx to atclient_connection
- Refactored atlogger to atclient_atlogger

**- How to verify it**
Run: `./run.sh @jeremy_0`
![image](https://github.com/atsign-foundation/at_c/assets/79019866/4a1443b9-4e4d-47d6-a4ea-836ba74632f9)

