### PR TITLE
test: test_aes_generate

### DIFF
--- a/packages/atchops/src/aes.c
+++ b/packages/atchops/src/aes.c
@@ -15,9 +15,10 @@ int atchops_aes_generate_key(unsigned char *key, const atchops_aes_keysize keysi
     // note: To use the AES generator, you need to have the modules enabled in the mbedtls/config.h files (MBEDTLS_CTR_DRBG_C and MBEDTLS_ENTROPY_C), see How do I configure Mbed TLS. https://mbed-tls.readthedocs.io/en/latest/kb/how-to/generate-an-aes-key/
 
     mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+
     mbedtls_entropy_context entropy;
     mbedtls_entropy_init(&entropy);
-    mbedtls_ctr_drbg_init(&ctr_drbg);
 
     if ((ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
                                      (unsigned char *)pers, strlen(pers))) != 0)
@@ -44,9 +45,9 @@ int atchops_aes_generate_keybase64(unsigned char *keybase64, const unsigned long
 {
     int ret = 1;
 
-    const unsigned long keybytes = keysize / 8;
-    unsigned char key[keybytes];
-    memset(key, 0, keybytes);
+    const unsigned long keylen = keysize / 8;
+    unsigned char key[keylen];
+    memset(key, 0, keylen);
 
     ret = atchops_aes_generate_key(key, keysize);
     if (ret != 0)
@@ -54,7 +55,7 @@ int atchops_aes_generate_keybase64(unsigned char *keybase64, const unsigned long
         goto exit;
     }
 
-    ret = atchops_base64_encode(key, keybytes, keybase64, keybase64len, keybase64olen);
+    ret = atchops_base64_encode(key, keylen, keybase64, keybase64len, keybase64olen);
     if (ret != 0)
     {
         goto exit;

--- a/packages/atchops/tests/test_aes_generate.c
+++ b/packages/atchops/tests/test_aes_generate.c
@@ -1,12 +1,93 @@
 
+#include "atchops/aes.h"
+#include "atchops/iv.h"
+#include "atchops/aesctr.h"
+#include <stdio.h>
+#include <string.h>
+
+#define PLAINTEXT "Hello World!\n"
 
 int main()
 {
 
     int ret = 1;
 
-    ret = 0; // TODO: Implement
+    const unsigned long keybase64len = 4096;
+    unsigned char keybase64[keybase64len];
+    memset(keybase64, 0, keybase64len);
+    unsigned long keybase64olen = 0;
 
+    const unsigned long ciphertextlen = 4096;
+    unsigned char ciphertext[ciphertextlen];
+    memset(ciphertext, 0, sizeof(unsigned char) * ciphertextlen);
+    unsigned long ciphertextolen = 0;
+
+    unsigned char iv[ATCHOPS_IV_BUFFER_SIZE];
+
+    const unsigned long plaintext2len = 4096;
+    unsigned char plaintext2[plaintext2len];
+    memset(plaintext2, 0, sizeof(unsigned char) * plaintext2len);
+    unsigned long plaintext2olen = 0;
+
+    ret = atchops_aes_generate_keybase64(keybase64, keybase64len, &keybase64olen, ATCHOPS_AES_256);
+    if (ret != 0)
+    {
+        printf("Error generating key\n");
+        printf("keybase64: %.*s\n", (int) keybase64olen, keybase64);
+        goto exit;
+    }
+
+    if(keybase64olen == 0)
+    {
+        printf("keybase64olen is %lu\n", keybase64olen);
+        ret = 1;
+        goto exit;
+    }
+
+    if(strlen(keybase64) != keybase64olen)
+    {
+        printf("keybase64olen is %lu when it should be %lu\n", keybase64olen, strlen(keybase64));
+        ret = 1;
+        goto exit;
+    }
+
+    printf("key %lu: %s\n", strlen(keybase64), keybase64);
+
+    memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_BUFFER_SIZE);
+    ret = atchops_aesctr_encrypt(keybase64, keybase64olen, ATCHOPS_AES_256, iv, PLAINTEXT, strlen(PLAINTEXT), ciphertext, ciphertextlen, &ciphertextolen);
+    if (ret != 0)
+    {
+        printf("Error encrypting\n");
+        printf("ciphertext: %.*s\n", (int) ciphertextolen, ciphertext);
+        goto exit;
+    }
+
+    if(ciphertextolen == 0)
+    {
+        printf("ciphertextolen is %lu\n", ciphertextolen);
+        ret = 1;
+        goto exit;
+    }
+
+    if(strlen(ciphertext) != ciphertextolen)
+    {
+        printf("ciphertextolen is %lu when it should be %lu\n", ciphertextolen, strlen(ciphertext));
+        ret = 1;
+        goto exit;
+    }
+
+    memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_BUFFER_SIZE);
+    ret = atchops_aesctr_decrypt(keybase64, keybase64olen, ATCHOPS_AES_256, iv, ciphertext, ciphertextolen, plaintext2, plaintext2len, &plaintext2olen);
+    if (ret != 0)
+    {
+        printf("Error decrypting\n");
+        goto exit;
+    }
+
+
+    printf("plaintext2: %s\n", plaintext2);
+
+    ret = 0;
     goto exit;
 
 exit:


### PR DESCRIPTION
closes #75

**- What I did**

- Added test_aes_generate test case.
- This test creates a new aes key, then uses it to encrypt and decrypt a value
- Small refactor in aes.c

**- How I did it**

- Making a new test
- See changes

**- How to verify it**

- New test 'test_aes_generate.c'

**- Description for the changelog**

Sample test case

```sh
test 1
      Start  1: test_aes_generate

1: Test command: /Users/jeremytubongbanua/GitHub/at_c/packages/atchops/build/tests/test_aes_generate
1: Working Directory: /Users/jeremytubongbanua/GitHub/at_c/packages/atchops/build/tests
1: Test timeout computed to be: 10000000
1: key 44: TFJWmrLawRBv32Oh3y556EHWsnICuxT6r6MKFx+IdbA=
1: plaintext2: Hello World!
1: 
 1/12 Test  #1: test_aes_generate ................   Passed    0.15 sec
```
