### PR TITLE
ci: Add cppcheck workflow

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,20 @@
+name: Cppcheck
+on:
+  workflow_dispatch:
+  push:
+    branches: [trunk]
+  pull_request:
+    branches: [trunk]
+
+permissions:
+  contents: read
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Cppcheck
+        run: |
+          sudo apt install -y cppcheck
+          cppcheck .


### PR DESCRIPTION
Closes #114 

**- What I did**

Copied cppcheck workflow from at_esp32

**- How I did it**

`cp ../at_esp32/.github/workflows/cppcheck.yml .github/workflows/`

**- How to verify it**

Logs from this PR

**- Description for the changelog**

ci: Add cppcheck workflow
