### PR TITLE
chore: remove externally available atstr functions 

### DIFF
--- a/packages/atclient/include/atclient/atkey.h
+++ b/packages/atclient/include/atclient/atkey.h
@@ -53,16 +53,6 @@ void atclient_atkey_free(atclient_atkey *atkey);
 int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, const unsigned long atkeylen);
 
 /**
- * @brief populate an atkey struct given a string (atclient_atstr).
- *
- * @param atkey the atkey struct to populate, assumed that this was already initialized via atclient_atkey_init
- * @param atstr the atstr to derive from. For example, this atstr could've been created from a string like
- * 'public:bob@publickey'
- * @return int 0 on success, non-zero on failure
- */
-int atclient_atkey_from_atstr(atclient_atkey *atkey, const atclient_atstr atstr);
-
-/**
  * @brief convert an atkey struct to its string format
  *
  * @param atkey atkey struct to read, assumed that this was already initialized via atclient_atkey_init
@@ -73,15 +63,6 @@ int atclient_atkey_from_atstr(atclient_atkey *atkey, const atclient_atstr atstr)
  */
 int atclient_atkey_to_string(const atclient_atkey atkey, char *atkeystr, const unsigned long atkeystrlen,
                              unsigned long *atkeystrolen);
-
-/**
- * @brief convert an atkey struct to its atstr format
- *
- * @param atkey the atkey struct to read, assumed that this was already initialized via atclient_atkey_init
- * @param atstr the atstr to write to, assumed that this was already initialized via atclient_atstr_init
- * @return int 0 on success
- */
-int atclient_atkey_to_atstr(const atclient_atkey atkey, atclient_atstr *atstr);
 
 /**
  * @brief Populate an atkey struct representing a PublicKey AtKey with null terminated strings. An example of a Public

--- a/packages/atclient/include/atclient/atkeys.h
+++ b/packages/atclient/include/atclient/atkeys.h
@@ -82,23 +82,6 @@ int atclient_atkeys_populate_from_atkeysfile(atclient_atkeys *atkeys, atclient_a
 int atclient_atkeys_populate_from_path(atclient_atkeys *atkeys, const char *path);
 
 /**
- * @brief populates the struct by decrypting the encrypted RSA keys found in a populated atclient_atkeysfile struct
- *
- * @param atkeys the struct to populate
- * @param aespkampublickeystr the encrypted RSA public key (encrypted with AES-256 selfencryptionkey) in base64 format
- * @param aespkamprivatekeystr the encrypted RSA private key (encrypted with AES-256 selfencryptionkey) in base64 format
- * @param aesencryptpublickeystr  the encrypted RSA public key (encrypted with AES-256 selfencryptionkey) in base64
- * format
- * @param aesencryptprivatekeystr the encrypted RSA private key (encrypted with AES-256 selfencryptionkey) in base64
- * format
- * @param selfencryptionkeystr the AES-256 selfencryptionkey in base64 format
- * @return int 0 on success, non-zero on failure
- */
-int atclient_atkeys_populate_from_atstrs(atclient_atkeys *atkeys, atclient_atstr aespkampublickeystr,
-                                         atclient_atstr aespkamprivatekeystr, atclient_atstr aesencryptpublickeystr,
-                                         atclient_atstr aesencryptprivatekeystr, atclient_atstr selfencryptionkeystr);
-
-/**
  * @brief free memory allocated by the init function
  *
  * @param atkeys the atkeys struct to free

--- a/packages/atclient/src/atkey.c
+++ b/packages/atclient/src/atkey.c
@@ -213,10 +213,6 @@ exit: {
 }
 }
 
-int atclient_atkey_from_atstr(atclient_atkey *atkey, const atclient_atstr atstr) {
-  return atclient_atkey_from_string(atkey, atstr.str, atstr.olen);
-}
-
 int atclient_atkey_to_string(const atclient_atkey atkey, char *atkeystr, const unsigned long atkeystrlen,
                              unsigned long *atkeystrolen) {
   int ret = 1;
@@ -310,20 +306,6 @@ exit: {
   atclient_atstr_free(&string);
   return ret;
 }
-}
-
-int atclient_atkey_to_atstr(const atclient_atkey atkey, atclient_atstr *atstr) {
-  int ret = 1;
-
-  ret = atclient_atkey_to_string(atkey, atstr->str, atstr->olen, &(atstr->olen));
-  if (ret != 0) {
-    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
-    goto exit;
-  }
-
-  ret = 0;
-  goto exit;
-exit: { return ret; }
 }
 
 int atclient_atkey_create_publickey(atclient_atkey *atkey, const char *name, const size_t namelen, const char *sharedby,

--- a/packages/atclient/src/atkeys.c
+++ b/packages/atclient/src/atkeys.c
@@ -191,23 +191,6 @@ exit: {
 }
 }
 
-int atclient_atkeys_populate_from_atstrs(atclient_atkeys *atkeys, const atclient_atstr aespkampublickeystr,
-                                         const atclient_atstr aespkamprivatekeystr,
-                                         const atclient_atstr aesencryptpublickeystr,
-                                         const atclient_atstr aesencryptprivatekeystr,
-                                         const atclient_atstr selfencryptionkeystr) {
-  int ret = 1;
-
-  ret = atclient_atkeys_populate_from_strings(
-      atkeys, aespkampublickeystr.str, aespkampublickeystr.olen, aespkamprivatekeystr.str, aespkamprivatekeystr.olen,
-      aesencryptpublickeystr.str, aesencryptpublickeystr.olen, aesencryptprivatekeystr.str,
-      aesencryptprivatekeystr.olen, selfencryptionkeystr.str, selfencryptionkeystr.olen);
-
-  goto exit;
-
-exit: { return ret; }
-}
-
 void atclient_atkeys_free(atclient_atkeys *atkeys) {
   atclient_atstr_free(&(atkeys->pkampublickeystr));
   atchops_rsakey_publickey_free(&(atkeys->pkampublickey));


### PR DESCRIPTION
**- What I did**
- Refactored atkey.c/.h and atkeys.c/.h so the atstr functions (that are not used anywhere) cannot be used by the outside developer.

