### PR TITLE
feat: atclient_delete(atkey)

### DIFF
--- a/packages/atclient/include/atclient/atclient.h
+++ b/packages/atclient/include/atclient/atclient.h
@@ -1,6 +1,7 @@
 #ifndef ATCLIENT_H
 #define ATCLIENT_H
 
+#include "atclient/atkey.h"
 #include "atclient/atkeys.h"
 #include "atclient/atsign.h"
 #include "atclient/connection.h"
@@ -55,10 +56,64 @@ int atclient_start_secondary_connection(atclient *ctx, const char *secondaryhost
  */
 int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, const char *atsign,
                                const unsigned long atsignlen);
-int atclient_put(atclient *ctx, const char *key, const char *value);
-int atclient_get(atclient *ctx, const char *key, char *value, const unsigned long valuelen);
-int atclient_delete(atclient *ctx, const char *key);
-void atclient_free(atclient *ctx);
+
+/**
+ * @brief Put a string value into your atServer.
+ * `atclient` must satisfy two conditions before calling this function:
+ * 1. initialized with atclient_init()
+ * 2. authenticated via atclient_pkam_authenticate()
+ *
+ * `atkey` must satisfy the following condition before calling this function:
+ * 1. initialized with atclient_atkey_init()
+ * 2. have populated values (such as a name, sharedby, sharedwith, etc,.) depending on what kind of atkey you want to be
+ * associated with your value.
+ *
+ * @param atclient the atclient context (must satisfy the two conditions stated above)
+ * @param atkey the populated atkey to put the value into (must satisfy the two conditions stated above)
+ * @param value the value to put into atServer
+ * @param valuelen the length of the value (most of the time you will use strlen() on a null-terminated string for this
+ * value)
+ * @return int 0 on success
+ */
+int atclient_put(const atclient atclient, const atclient_atkey atkey, const char *value, const size_t valuelen);
+
+/**
+ * @brief Get a string value from your atServer, or a valid value from another atServer (public atkey or shared atkey that is shared with you).
+ * `atclient` must satisfy two conditions before calling this function:
+ * 1. initialized with atclient_init()
+ * 2. authenticated via atclient_pkam_authenticate()
+ *
+ * `atkey` must satisfy the following condition before calling this function:
+ * 1. initialized with atclient_atkey_init()
+ * 2. have populated values (such as a name, sharedby, sharedwith, etc,.) depending on what kind of atkey you want to be
+ * associated with your value.
+ *
+ * @param atclient the atclient context (must satisfy the two conditions stated above)
+ * @param atkey the populated atkey to get the value from (must satisfy the two conditions stated above)
+ * @param value the buffer to hold value gotten from atServer
+ * @param valuelen the buffer length allocated for the value
+ * @param valueolen the output length of the value gotten from atServer
+ * @return int 0 on success
+ */
+int atclient_get(const atclient atclient, const atclient_atkey atkey, char *value, const size_t valuelen,
+                 size_t *valueolen);
+
+/**
+ * @brief Delete an atkey from your atserver
+ * `atclient` must satisfy two conditions before calling this function:
+ * 1. initialized with atclient_init()
+ * 2. authenticated via atclient_pkam_authenticate()
+ *
+ * `atkey` must satisfy the following condition before calling this function:
+ * 1. initialized with atclient_atkey_init()
+ * 2. have populated values (such as a name, sharedby, sharedwith, etc,.) depending on what kind of atkey you want to be
+ * associated with your value.
+ *
+ * @param atclient the atclient context (must satisfy the two conditions stated above)
+ * @param atkey the populated atkey to delete from atServer (must satisfy the two conditions stated above)
+ * @return int 0 on success
+ */
+int atclient_delete(const atclient atclient, const atclient_atkey atkey);
 
 /**
  * @brief Looks up the symmetric shared key which the atclient's atsign shared with the recipient's atsign.

--- a/packages/atclient/include/atclient/atclient.h
+++ b/packages/atclient/include/atclient/atclient.h
@@ -112,4 +112,6 @@ int atclient_create_shared_encryption_key(atclient *ctx, const atclient_atsign *
  */
 int atclient_get_public_encryption_key(atclient *ctx, const atclient_atsign *atsign, char *public_encryption_key);
 
+void atclient_free(atclient *ctx);
+
 #endif

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -287,7 +287,7 @@ int atclient_delete(const atclient atclient, const atclient_atkey atkey) {
     goto exit;
   }
 
-  ret = atclient_atstr_append(&cmdbuffer, "%.*s", (int) atkeystrolen, atkeystr);
+  ret = atclient_atstr_append(&cmdbuffer, "%.*s\n", (int) atkeystrolen, atkeystr);
   if (ret != 0) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_append: %d\n", ret);
     goto exit;

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -240,11 +240,6 @@ exit: {
 }
 }
 
-void atclient_free(atclient *ctx) {
-  atclient_connection_free(&(ctx->root_connection));
-  atclient_connection_free(&(ctx->secondary_connection));
-}
-
 int atclient_get_encryption_key_shared_by_me(atclient *ctx, const atclient_atsign *recipient,
                                              char *enc_key_shared_by_me, bool create_new_if_not_found) {
   int ret = 1;
@@ -538,4 +533,9 @@ int atclient_get_public_encryption_key(atclient *ctx, const atclient_atsign *ats
   }
 
   return 0;
+}
+
+void atclient_free(atclient *ctx) {
+  atclient_connection_free(&(ctx->root_connection));
+  atclient_connection_free(&(ctx->secondary_connection));
 }

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -2,6 +2,7 @@
 #include "atchops/aes.h"
 #include "atchops/rsa.h"
 #include "atclient/atbytes.h"
+#include "atclient/atkey.h"
 #include "atclient/atkeys.h"
 #include "atclient/atsign.h"
 #include "atclient/atstr.h"
@@ -238,6 +239,34 @@ exit: {
   atclient_atstr_free(&pkamcmd);
   return ret;
 }
+}
+
+int atclient_put(const atclient atclient, const atclient_atkey atkey, const char *value, const size_t valuelen) {
+  int ret = 1;
+
+  // TODO: implement
+
+  goto exit;
+exit: { return ret; }
+}
+
+int atclient_get(const atclient atclient, const atclient_atkey atkey, char *value, const size_t valuelen,
+                 size_t *valueolen) {
+  int ret = 1;
+
+  // TODO: implement
+
+  goto exit;
+exit: { return ret; }
+}
+
+int atclient_delete(const atclient atclient, const atclient_atkey atkey) {
+  int ret = 1;
+
+  // TODO: implement
+
+  goto exit;
+exit: { return ret; }
 }
 
 int atclient_get_encryption_key_shared_by_me(atclient *ctx, const atclient_atsign *recipient,

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -222,6 +222,14 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
     goto exit;
   }
 
+  // check for data:success
+  if (!atclient_stringutils_starts_with((char *)recv.bytes, recv.olen, "data:success", strlen("data:success"))) {
+    ret = 1;
+    atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "recv was \"%.*s\" and did not have prefix \"data:success\"\n",
+                          (int)recv.olen, recv.bytes);
+    goto exit;
+  }
+
   ret = 0;
 
   goto exit;

--- a/packages/atclient/src/atkey.c
+++ b/packages/atclient/src/atkey.c
@@ -89,7 +89,7 @@ int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, cons
   }
   // check if cached
   if (strncmp(token, "cached", strlen("cached")) == 0) {
-    atkey->metadata.iscached = true;
+    atclient_atkey_metadata_set_iscached(&(atkey->metadata), true);
     token = strtok_r(NULL, ":", &saveptr);
     if (token == NULL) {
       atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "tokens[1] is NULL\n");
@@ -100,7 +100,7 @@ int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, cons
 
   if (atclient_stringutils_starts_with(token, tokenlen, "public", strlen("public")) == 1) {
     // it is a public key
-    atkey->metadata.ispublic = true;
+    atclient_atkey_metadata_set_ispublic(&(atkey->metadata), true);
     atkey->atkeytype = ATCLIENT_ATKEY_TYPE_PUBLICKEY;
     // shift tokens array to the left
     token = strtok_r(NULL, ":", &saveptr);
@@ -129,7 +129,7 @@ int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, cons
   } else if (atclient_stringutils_starts_with(token, tokenlen, "_", strlen("_")) == 1) {
     // it is an internal key
     atkey->atkeytype = ATCLIENT_ATKEY_TYPE_SELFKEY;
-    atkey->metadata.ishidden = 1;
+    atclient_atkey_metadata_set_ishidden(&(atkey->metadata), true);
   } else {
     // it is a self key
     atkey->atkeytype = ATCLIENT_ATKEY_TYPE_SELFKEY;
@@ -221,7 +221,7 @@ int atclient_atkey_to_string(const atclient_atkey atkey, char *atkeystr, const u
   atclient_atstr string;
   atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
 
-  if (atkey.metadata.iscached == true) {
+  if (atkey.metadata.iscached) {
     ret = atclient_atstr_append(&string, "cached:");
     if (ret != 0) {
       atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_append_literal failed\n");
@@ -229,13 +229,13 @@ int atclient_atkey_to_string(const atclient_atkey atkey, char *atkeystr, const u
     }
   }
 
-  if (atkey.metadata.ispublic == true && atkey.atkeytype == ATCLIENT_ATKEY_TYPE_PUBLICKEY) {
+  if (atkey.metadata.ispublic && atkey.atkeytype == ATCLIENT_ATKEY_TYPE_PUBLICKEY) {
     ret = atclient_atstr_append(&string, "public:");
     if (ret != 0) {
       atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_append_literal failed\n");
       goto exit;
     }
-  } else if (atkey.metadata.ispublic == true || atkey.atkeytype == ATCLIENT_ATKEY_TYPE_PUBLICKEY) {
+  } else if (atkey.metadata.ispublic || atkey.atkeytype == ATCLIENT_ATKEY_TYPE_PUBLICKEY) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN,
                           "either atkey's metadata ispublic is not set to 1 or atkey's atkeytype is not set to "
                           "ATCLIENT_ATKEY_TYPE_PUBLICKEY for atkey: %.*s\n",
@@ -329,7 +329,7 @@ int atclient_atkey_create_publickey(atclient_atkey *atkey, const char *name, con
   }
 
   atkey->atkeytype = ATCLIENT_ATKEY_TYPE_PUBLICKEY;
-  atkey->metadata.ispublic = true;
+  atclient_atkey_metadata_set_ispublic(&(atkey->metadata), true);
 
   ret = atclient_atstr_set_literal(&(atkey->name), name, namelen);
   if (ret != 0) {


### PR DESCRIPTION
closes #125 

**- What I did**

- implemented `atclient_delete`

Misc changes:
- refactor: move `atclient_free(ctx)` to the bottom of atclient.c/.h
- atkey.c uses metadata functions instead of setting them explicitly in struct, which inherently includes checking/updating the initialized fields.
- pkam_authenticate would return 0 even if it did not properly authenticate, a check for `data:success` was added to remedy this bug

**- How to verify it**

## `atclient_delete` manual test

`atclient_delete` code
```c
#include <stdio.h>
#include <string.h>
#include <stdlib.h>
#include <atlogger/atlogger.h>
#include <atclient/metadata.h>
#include <atclient/atclient.h>
#include <atclient/atkey.h>
#include <atclient/atsign.h>

#define TAG "Debug"

// #define ATSIGN "@jeremy_0"
#define ATSIGN "@qt_thermostat"
#define ATKEYS_FILE_PATH "/Users/jeremytubongbanua/.atsign/keys/@qt_thermostat_key.atKeys"

int main()
{
    int ret = 1;

    atclient_atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);

    atclient atclient;
    atclient_init(&atclient);
    atclient_start_root_connection(&atclient, "root.atsign.org", 64);

    atclient_atsign atsign;
    atclient_atsign_init(&atsign, ATSIGN);

    atclient_atkey atkey;
    atclient_atkey_init(&atkey);
    if((ret = atclient_atkey_create_selfkey(&atkey, "test", strlen("test"), atsign.atsign, strlen(atsign.atsign), NULL, 0)) != 0) {
        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to create selfkey");
        goto exit;
    }

    atclient_atkeys atkeys;
    atclient_atkeys_init(&atkeys);
    atclient_atkeys_populate_from_path(&atkeys, ATKEYS_FILE_PATH);

    if((ret = atclient_pkam_authenticate(&atclient, atkeys, atsign.atsign, strlen(atsign.atsign))) != 0) {
        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to authenticate");
        goto exit;
    }

    if((ret = atclient_delete(atclient, atkey)) != 0) {
        atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to delete");
        goto exit;
    }

    ret = 0;
    goto exit;
exit: {
    atclient_free(&atclient);
    atclient_atsign_free(&atsign);
    atclient_atkey_free(&atkey);
    atclient_atkeys_free(&atkeys);
    return ret;
}
}

```

`atclient_delete` output
```
 [INFO] atclient | atclient_connection_connect: 0. Successfully connected to root
 [INFO] connection |    SENT: "qt_thermostat"
 [INFO] connection |    RECV: "d4ac3fd1-bcc5-5042-a975-a35514533508.swarm0002.atsign.zone:6667"
 [INFO] atclient | atclient_connection_connect: 0. Successfully connected to secondary
 [INFO] connection |    SENT: "from:qt_thermostat"
 [INFO] connection |    RECV: "data:_61c56f80-5e6c-4955-b3df-ea11081d97c4@qt_thermostat:0a369737-d5e3-4abf-b784-5c9f7428c349"
 [INFO] connection |    SENT: "pkam:hKOLMhqRteOLV7jyYyDt/Km6gWebwd1wDP6YUnw6jKoHMvH91+tK/vdTIjLaZRTnTbyt3wEJi23eFKIFzoesLRH6mYyRSYJmx+9LWUwqD1sMl7fgp840leqnUQdCIcSrTm0oexPslNlRMX2cIfIcavMLKunGF81H6xTC0Bi8xRdxukmqjCXahkcSONLJLn8IZm0+Tt94wAXJlERevjhbMMyRvn57vxr+7Z+TEyugrXhAooUZHzNuU39765r6dfVVyMrkRTjq7gc50sUCg9pAl5Ze/lB4QsVRUTDU1aJemyOgGEQJ2Ac8STnIIOjPP8+WFChXEB/OLlYDq+c1jpTwMQ=="
 [INFO] connection |    RECV: "data:success"
 [INFO] connection |    SENT: "delete:test@qt_thermostat"
 [INFO] connection |    RECV: "data:23"
```