### PR TITLE
chore: refine types and memory

### DIFF
--- a/packages/atchops/include/atchops/aes.h
+++ b/packages/atchops/include/atchops/aes.h
@@ -2,10 +2,11 @@
 #ifndef ATCHOPS_AES_H
 #define ATCHOPS_AES_H
 
-typedef enum atchops_aes_keysize {
+enum atchops_aes_size {
+  ATCHOPS_AES_NONE = 0,
   ATCHOPS_AES_128 = 128, // not tested
   ATCHOPS_AES_256 = 256,
-} atchops_aes_keysize;
+};
 
 /**
  * @brief Generate an AES key of size keylen bits
@@ -14,7 +15,7 @@ typedef enum atchops_aes_keysize {
  * @param keysize key length in bits (e.g. AES-256 = 256 => ATCHOPS_AES_256)
  * @return int 0 on success
  */
-int atchops_aes_generate_key(unsigned char *key, const atchops_aes_keysize keysize);
+int atchops_aes_generate_key(unsigned char *key, const enum atchops_aes_size keysize);
 
 /**
  * @brief Generate an AES key of size keylen bits encoded in base 64
@@ -26,6 +27,6 @@ int atchops_aes_generate_key(unsigned char *key, const atchops_aes_keysize keysi
  * @return int 0 on success
  */
 int atchops_aes_generate_keybase64(unsigned char *keybase64, const unsigned long keybase64len,
-                                   unsigned long *keybase64olen, atchops_aes_keysize keysize);
+                                   unsigned long *keybase64olen, const enum atchops_aes_size keysize);
 
 #endif

--- a/packages/atchops/include/atchops/aesctr.h
+++ b/packages/atchops/include/atchops/aesctr.h
@@ -17,7 +17,7 @@
  * @param ciphertextbase64olen the written length of the ciphertext buffer
  * @return int 0 on success
  */
-int atchops_aesctr_encrypt(const char *keybase64, const unsigned long keybase64len, const atchops_aes_keysize keybits,
+int atchops_aesctr_encrypt(const char *keybase64, const unsigned long keybase64len, const enum atchops_aes_size keybits,
                            unsigned char *iv, // always 16 bytes long
                            const unsigned char *plaintext, const unsigned long plaintextlen,
                            unsigned char *ciphertextbase64, const unsigned long ciphertextbase64len,
@@ -37,7 +37,7 @@ int atchops_aesctr_encrypt(const char *keybase64, const unsigned long keybase64l
  * @param plaintextolen the written length of the plaintext buffer
  * @return int 0 on success
  */
-int atchops_aesctr_decrypt(const char *keybase64, const unsigned long keybase64len, const atchops_aes_keysize keybits,
+int atchops_aesctr_decrypt(const char *keybase64, const unsigned long keybase64len, const enum atchops_aes_size keybits,
                            unsigned char *iv, // always 16 bytes long
                            const unsigned char *ciphertextbase64, const unsigned long ciphertextbase64len,
                            unsigned char *plaintext, const unsigned long plaintextlen, unsigned long *plaintextolen);

--- a/packages/atchops/include/atchops/rsa.h
+++ b/packages/atchops/include/atchops/rsa.h
@@ -4,6 +4,12 @@
 #include "atchops/rsakey.h"
 #include <mbedtls/md.h>
 
+enum atchops_rsa_size {
+  ATCHOPS_RSA_NONE = 0,
+  ATCHOPS_RSA_2048 = 2048,
+  ATCHOPS_RSA_4096 = 4096,
+};
+
 /**
  * @brief Sign a message with an RSA private key
  *
@@ -16,8 +22,8 @@
  * @param signatureolen the length of the signature buffer after signing
  * @return int 0 on success
  */
-int atchops_rsa_sign(atchops_rsakey_privatekey privatekey, mbedtls_md_type_t mdtype, const unsigned char *message,
-                     const unsigned long messagelen, unsigned char *signaturebase64,
+int atchops_rsa_sign(const atchops_rsakey_privatekey privatekey, const mbedtls_md_type_t mdtype,
+                     const unsigned char *message, const unsigned long messagelen, unsigned char *signaturebase64,
                      const unsigned long signaturebase64len, unsigned long *signaturebase64olen);
 
 /**
@@ -30,8 +36,8 @@ int atchops_rsa_sign(atchops_rsakey_privatekey privatekey, mbedtls_md_type_t mdt
  * @param result 1 if the signature is valid, 0 if the signature is invalid
  * @return int 0 on success
  */
-int atchops_rsa_verify(atchops_rsakey_publickey publickey, mbedtls_md_type_t mdtype, const unsigned char *signature,
-                       const unsigned long signaturelen, int *result);
+int atchops_rsa_verify(const atchops_rsakey_publickey publickey, const mbedtls_md_type_t mdtype,
+                       const unsigned char *signature, const unsigned long signaturelen, int *result);
 
 /**
  * @brief Encrypt bytes with an RSA public key
@@ -44,7 +50,7 @@ int atchops_rsa_verify(atchops_rsakey_publickey publickey, mbedtls_md_type_t mdt
  * @param ciphertextolen the length of the ciphertext buffer after encryption
  * @return int 0 on success
  */
-int atchops_rsa_encrypt(atchops_rsakey_publickey publickey, const unsigned char *plaintext,
+int atchops_rsa_encrypt(const atchops_rsakey_publickey publickey, const unsigned char *plaintext,
                         const unsigned long plaintextlen, unsigned char *ciphertextbase64,
                         const unsigned long ciphertextbase64len, unsigned long *ciphertextbase64olen);
 
@@ -59,7 +65,7 @@ int atchops_rsa_encrypt(atchops_rsakey_publickey publickey, const unsigned char 
  * @param plaintextolen the length of the plaintext buffer after decryption
  * @return int 0 on success
  */
-int atchops_rsa_decrypt(atchops_rsakey_privatekey privatekeystruct, const unsigned char *ciphertextbase64,
+int atchops_rsa_decrypt(const atchops_rsakey_privatekey privatekeystruct, const unsigned char *ciphertextbase64,
                         const unsigned long ciphertextbase64len, unsigned char *plaintext,
                         const unsigned long plaintextlen, unsigned long *plaintextolen);
 
@@ -71,6 +77,6 @@ int atchops_rsa_decrypt(atchops_rsakey_privatekey privatekeystruct, const unsign
  * @param keysize the size of the key to generate, e.g. 2048
  */
 int atchops_rsa_generate(atchops_rsakey_publickey *publickey, atchops_rsakey_privatekey *privatekey,
-                         const unsigned int keysize);
+                         const enum atchops_rsa_size keysize);
 
 #endif

--- a/packages/atchops/include/atchops/sha.h
+++ b/packages/atchops/include/atchops/sha.h
@@ -3,7 +3,7 @@
 
 #include <mbedtls/md.h>
 
-int atchops_sha_hash(mbedtls_md_type_t md_type, const unsigned char *input, const unsigned long inputlen,
-                     unsigned char *output, unsigned long outputlen, unsigned long *outputolen);
+int atchops_sha_hash(const mbedtls_md_type_t md_type, const unsigned char *input, const unsigned long inputlen,
+                     unsigned char *output, const unsigned long outputlen, unsigned long *outputolen);
 
 #endif

--- a/packages/atchops/src/aes.c
+++ b/packages/atchops/src/aes.c
@@ -5,7 +5,7 @@
 #include <mbedtls/entropy.h>
 #include <string.h>
 
-int atchops_aes_generate_key(unsigned char *key, const atchops_aes_keysize keysize) {
+int atchops_aes_generate_key(unsigned char *key, const enum atchops_aes_size keysize) {
   int ret = 1;
 
   const char *pers = ATCHOPS_RNG_PERSONALIZATION;
@@ -40,7 +40,7 @@ exit: {
 }
 
 int atchops_aes_generate_keybase64(unsigned char *keybase64, const unsigned long keybase64len,
-                                   unsigned long *keybase64olen, atchops_aes_keysize keysize) {
+                                   unsigned long *keybase64olen, const enum atchops_aes_size keysize) {
   int ret = 1;
 
   const unsigned long keylen = keysize / 8;

--- a/packages/atchops/src/aesctr.c
+++ b/packages/atchops/src/aesctr.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-int atchops_aesctr_encrypt(const char *keybase64, const unsigned long keybase64len, const atchops_aes_keysize keybits,
+int atchops_aesctr_encrypt(const char *keybase64, const unsigned long keybase64len, const enum atchops_aes_size keybits,
                            unsigned char *iv,
                            const unsigned char *plaintext, // plaintext to encrypt
                            const unsigned long plaintextlen,
@@ -88,7 +88,7 @@ exit: {
 }
 }
 
-int atchops_aesctr_decrypt(const char *keybase64, const unsigned long keybase64len, const atchops_aes_keysize keybits,
+int atchops_aesctr_decrypt(const char *keybase64, const unsigned long keybase64len, const enum atchops_aes_size keybits,
                            unsigned char *iv, const unsigned char *ciphertextbase64,
                            const unsigned long ciphertextbase64len, unsigned char *plaintext,
                            const unsigned long plaintextlen, unsigned long *plaintextolen) {

--- a/packages/atclient/include/atclient/atclient.h
+++ b/packages/atclient/include/atclient/atclient.h
@@ -75,7 +75,7 @@ int atclient_pkam_authenticate(atclient *ctx, const atclient_atkeys atkeys, cons
  * value)
  * @return int 0 on success
  */
-int atclient_put(const atclient *atclient, const atclient_atkey *atkey, const char *value, const size_t valuelen);
+int atclient_put(atclient *atclient, const atclient_atkey *atkey, const char *value, const size_t valuelen);
 
 /**
  * @brief Get a string value from your atServer.
@@ -95,7 +95,7 @@ int atclient_put(const atclient *atclient, const atclient_atkey *atkey, const ch
  * @param valueolen the output length of the value gotten from atServer
  * @return int 0 on success
  */
-int atclient_get_selfkey(const atclient *atclient, atclient_atkey *atkey, char *value, const size_t valuelen,
+int atclient_get_selfkey(atclient *atclient, atclient_atkey *atkey, char *value, const size_t valuelen,
                          size_t *valueolen);
 
 /**
@@ -116,7 +116,7 @@ int atclient_get_selfkey(const atclient *atclient, atclient_atkey *atkey, char *
  * @param valueolen the output length of the value gotten from atServer
  * @return int 0 on success
  */
-int atclient_get_publickey(const atclient *atclient, const atclient_atkey *atkey, char *value, const size_t valuelen,
+int atclient_get_publickey(atclient *atclient, const atclient_atkey *atkey, char *value, const size_t valuelen,
                            size_t *valueolen);
 
 /**
@@ -137,7 +137,7 @@ int atclient_get_publickey(const atclient *atclient, const atclient_atkey *atkey
  * @param valueolen the output length of the value gotten from atServer
  * @return int 0 on success
  */
-int atclient_get_sharedkey(const atclient *atclient, const atclient_atkey *atkey, char *value, const size_t valuelen,
+int atclient_get_sharedkey(atclient *atclient, const atclient_atkey *atkey, char *value, const size_t valuelen,
                            size_t *valueolen);
 
 /**
@@ -155,7 +155,7 @@ int atclient_get_sharedkey(const atclient *atclient, const atclient_atkey *atkey
  * @param atkey the populated atkey to delete from atServer (must satisfy the two conditions stated above)
  * @return int 0 on success
  */
-int atclient_delete(const atclient *atclient, const atclient_atkey *atkey);
+int atclient_delete(atclient *atclient, const atclient_atkey *atkey);
 
 /**
  * @brief Looks up the symmetric shared key which the atclient's atsign shared with the recipient's atsign.

--- a/packages/atclient/include/atclient/atkey.h
+++ b/packages/atclient/include/atclient/atkey.h
@@ -5,7 +5,7 @@
 #include "atclient/metadata.h"
 #include <stddef.h>
 
-#define ATKEY_GENERAL_BUFFER_SIZE 4096 // sufficient memory for keyName, namespace, sharedWith, and sharedBy strings
+#define ATKEY_GENERAL_BUFFER_SIZE 256 // 255 utf7 chars + '\0'
 
 typedef enum atclient_atkey_type {
   ATCLIENT_ATKEY_TYPE_UNKNOWN = 0,

--- a/packages/atclient/include/atclient/atkey.h
+++ b/packages/atclient/include/atclient/atkey.h
@@ -5,9 +5,6 @@
 #include "atclient/metadata.h"
 #include <stddef.h>
 
-#define ATCLIENT_MAX_ATKEY_LEN 256       // 255 utf7 chars + '\0'
-#define ATCLIENT_MAX_INNER_ATKEY_LEN 112 // 111 utf7 chars + '\0'
-
 typedef enum atclient_atkey_type {
   ATCLIENT_ATKEY_TYPE_UNKNOWN = 0,
   ATCLIENT_ATKEY_TYPE_PUBLICKEY,

--- a/packages/atclient/include/atclient/atkey.h
+++ b/packages/atclient/include/atclient/atkey.h
@@ -5,7 +5,8 @@
 #include "atclient/metadata.h"
 #include <stddef.h>
 
-#define ATKEY_GENERAL_BUFFER_SIZE 256 // 255 utf7 chars + '\0'
+#define ATCLIENT_MAX_ATKEY_LEN 256       // 255 utf7 chars + '\0'
+#define ATCLIENT_MAX_INNER_ATKEY_LEN 112 // 111 utf7 chars + '\0'
 
 typedef enum atclient_atkey_type {
   ATCLIENT_ATKEY_TYPE_UNKNOWN = 0,

--- a/packages/atclient/include/atclient/atkeys.h
+++ b/packages/atclient/include/atclient/atkeys.h
@@ -68,7 +68,7 @@ int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys, const char *a
  * @param atkeysfile the struct containing the encrypted RSA keys, typically already read from the *.atKeys file
  * @return int 0 on success, non-zero on failure
  */
-int atclient_atkeys_populate_from_atkeysfile(atclient_atkeys *atkeys, atclient_atkeysfile atkeysfile);
+int atclient_atkeys_populate_from_atkeysfile(atclient_atkeys *atkeys, const atclient_atkeysfile atkeysfile);
 
 /**
  * @brief populates the atkeys struct by reading the *.atKeys file,

--- a/packages/atclient/include/atclient/atkeysfile.h
+++ b/packages/atclient/include/atclient/atkeysfile.h
@@ -13,7 +13,7 @@ typedef struct atclient_atkeysfile {
 
 void atclient_atkeysfile_init(atclient_atkeysfile *atkeysfile);
 int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path);
-int atclient_atkeysfile_write(atclient_atkeysfile *atkeysfile, const char *path, const char *atsign);
+int atclient_atkeysfile_write(const atclient_atkeysfile *atkeysfile, const char *path, const char *atsign);
 void atclient_atkeysfile_free(atclient_atkeysfile *atkeysfile);
 
 #endif

--- a/packages/atclient/include/atclient/atsign.h
+++ b/packages/atclient/include/atclient/atsign.h
@@ -1,8 +1,7 @@
 #ifndef ATCLIENT_ATSIGN_H
 #define ATCLIENT_ATSIGN_H
 
-#define MAX_ATSIGN_CHARACTERS (55 + 1) // 55 + @
-#define MAX_ATSIGN_STR_BUFFER (MAX_ATSIGN_CHARACTERS * 6) + 1
+#define ATCLIENT_MAX_ATSIGN_LEN 57 // '@' + 55 utf7 chars + '\0'
 
 // Structure to represent the AtSign class
 typedef struct atclient_atsign {

--- a/packages/atclient/include/atclient/atsign.h
+++ b/packages/atclient/include/atclient/atsign.h
@@ -1,8 +1,6 @@
 #ifndef ATCLIENT_ATSIGN_H
 #define ATCLIENT_ATSIGN_H
 
-#define ATCLIENT_MAX_ATSIGN_LEN 57 // '@' + 55 utf7 chars + '\0'
-
 // Structure to represent the AtSign class
 typedef struct atclient_atsign {
   char *atsign;

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -2,12 +2,13 @@
 #define ATCLIENT_CONNECTION_H
 
 #include "atclient/atstr.h"
-#include "atclient/constants.h"
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/net_sockets.h>
 #include <mbedtls/ssl.h>
 
+#define ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE 128 // the size of the buffer for the host name
+//
 typedef struct atclient_connection {
   // char *host; // assume null terminated, example: "root.atsign.org"
   char host[ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE];

--- a/packages/atclient/include/atclient/constants.h
+++ b/packages/atclient/include/atclient/constants.h
@@ -2,10 +2,6 @@
 #ifndef ATCLIENT_CONSTANTS_H
 #define ATCLIENT_CONSTANTS_H
 
-#define ATSIGN_BUFFER_LENGTH                                                                                           \
-  56 // sufficient memory for atSigns (current infrastructure restricts to a maximum of 55 utf7 chars)
-
 // TODO: remove this
-#define ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE 128 // the size of the buffer for the host name
 
 #endif

--- a/packages/atclient/include/atclient/constants.h
+++ b/packages/atclient/include/atclient/constants.h
@@ -2,6 +2,12 @@
 #ifndef ATCLIENT_CONSTANTS_H
 #define ATCLIENT_CONSTANTS_H
 
-// TODO: remove this
-
+#define ATCLIENT_ATSIGN_INNER_LEN 55                                                             // 55 utf7 chars
+#define ATCLIENT_ATSIGN_FULL_LEN (1 + ATCLIENT_ATSIGN_INNER_LEN)                                 // '@' + 55 utf7 chars
+#define ATCLIENT_ATKEY_KEY_LEN 55                                                                // 55 utf7 chars
+#define ATCLIENT_ATKEY_NAMESPACE_LEN 55                                                          // 55 utf7 chars
+#define ATCLIENT_ATKEY_COMPOSITE_LEN (ATCLIENT_ATKEY_KEY_LEN + 1 + ATCLIENT_ATKEY_NAMESPACE_LEN) // {key}.{namespace}
+#define ATCLIENT_ATKEY_FULL_LEN                                                                                        \
+  (ATCLIENT_ATSIGN_FULL_LEN + 1 + ATCLIENT_ATKEY_COMPOSITE_LEN +                                                       \
+   ATCLIENT_ATSIGN_FULL_LEN) // {full_atsign}:{composite_key}{full_atsign}
 #endif

--- a/packages/atclient/include/atclient/constants.h
+++ b/packages/atclient/include/atclient/constants.h
@@ -2,10 +2,7 @@
 #ifndef ATCLIENT_CONSTANTS_H
 #define ATCLIENT_CONSTANTS_H
 
-#define ATSIGN_BUFFER_LENGTH 4096 // sufficient memory for atSigns
-
+// TODO: remove this
 #define ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE 128 // the size of the buffer for the host name
-#define ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE                                                        \
-  4096 // represents the buffer size of a decrypted RSA key in base64 format
 
 #endif

--- a/packages/atclient/include/atclient/constants.h
+++ b/packages/atclient/include/atclient/constants.h
@@ -2,6 +2,9 @@
 #ifndef ATCLIENT_CONSTANTS_H
 #define ATCLIENT_CONSTANTS_H
 
+#define ATSIGN_BUFFER_LENGTH                                                                                           \
+  56 // sufficient memory for atSigns (current infrastructure restricts to a maximum of 55 utf7 chars)
+
 // TODO: remove this
 #define ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE 128 // the size of the buffer for the host name
 

--- a/packages/atclient/include/atclient/metadata.h
+++ b/packages/atclient/include/atclient/metadata.h
@@ -260,6 +260,7 @@ int atclient_atkey_metadata_from_jsonstr(atclient_atkey_metadata *metadata, cons
 int atclient_atkey_metadata_to_jsonstr(const atclient_atkey_metadata metadata, char *metadatastr,
                                        const size_t metadatastrlen, size_t *metadatastrolen);
 
+// TODO: get a buffer size calculator function for this, so buffer can be pre-computed rather than over allocated
 /**
  * @brief Creates a fragment which can be included in any atProtocol commands which use metadata (e.g. update,
  * update:meta and notify)

--- a/packages/atclient/include/atlogger/atlogger.h
+++ b/packages/atclient/include/atlogger/atlogger.h
@@ -1,13 +1,14 @@
-
 #ifndef ATCLIENT_ATLOGGER_H
 #define ATCLIENT_ATLOGGER_H
 
 typedef enum atclient_atlogger_logging_level {
-  ATLOGGER_LOGGING_LEVEL_NONE = 0, // literally nothing, not verbose at all
-  ATLOGGER_LOGGING_LEVEL_ERROR,    // only errors, not that verbose
-  ATLOGGER_LOGGING_LEVEL_WARN,     // errors and warnings , verbose only when something's up
-  ATLOGGER_LOGGING_LEVEL_INFO,     // errors, warnings and info, pretty verbose
-  ATLOGGER_LOGGING_LEVEL_DEBUG     // everything, very verbose
+  ATLOGGER_LOGGING_LEVEL_NONE = 0,   // literally nothing, not verbose at all
+  ATLOGGER_LOGGING_LEVEL_ERROR = 10, // only errors, not that verbose
+  ATLOGGER_LOGGING_LEVEL_WARN = 20,  // errors and warnings , verbose only when something's up
+
+  // TODO: add FINE / FINER
+  ATLOGGER_LOGGING_LEVEL_INFO = 50,   // errors, warnings and info, pretty verbose
+  ATLOGGER_LOGGING_LEVEL_DEBUG = 100, // everything, very verbose
 } atclient_atlogger_logging_level;
 
 atclient_atlogger_logging_level atlogger_get_logging_level();

--- a/packages/atclient/include/atlogger/atlogger.h
+++ b/packages/atclient/include/atlogger/atlogger.h
@@ -1,18 +1,17 @@
 #ifndef ATCLIENT_ATLOGGER_H
 #define ATCLIENT_ATLOGGER_H
 
-typedef enum atclient_atlogger_logging_level {
+enum atclient_atlogger_logging_level {
   ATLOGGER_LOGGING_LEVEL_NONE = 0,   // literally nothing, not verbose at all
   ATLOGGER_LOGGING_LEVEL_ERROR = 10, // only errors, not that verbose
   ATLOGGER_LOGGING_LEVEL_WARN = 20,  // errors and warnings , verbose only when something's up
-
   // TODO: add FINE / FINER
   ATLOGGER_LOGGING_LEVEL_INFO = 50,   // errors, warnings and info, pretty verbose
   ATLOGGER_LOGGING_LEVEL_DEBUG = 100, // everything, very verbose
-} atclient_atlogger_logging_level;
+};
 
-atclient_atlogger_logging_level atlogger_get_logging_level();
-void atclient_atlogger_set_logging_level(atclient_atlogger_logging_level level);
-void atclient_atlogger_log(const char *tag, atclient_atlogger_logging_level level, const char *format, ...);
+enum atclient_atlogger_logging_level atlogger_get_logging_level();
+void atclient_atlogger_set_logging_level(const enum atclient_atlogger_logging_level level);
+void atclient_atlogger_log(const char *tag, const enum atclient_atlogger_logging_level level, const char *format, ...);
 
 #endif

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -1,7 +1,5 @@
 #include "atclient/atclient.h"
 #include "atchops/aes.h"
-#include "atchops/aesctr.h"
-#include "atchops/base64.h"
 #include "atchops/rsa.h"
 #include "atclient/atbytes.h"
 #include "atclient/atkey.h"
@@ -12,7 +10,6 @@
 #include "atclient/stringutils.h"
 #include "atlogger/atlogger.h"
 #include <cJSON/cJSON.h>
-#include <limits.h>
 #include <mbedtls/md.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -252,14 +249,14 @@ exit: {
 }
 }
 
-int atclient_put(const atclient *atclient, const atclient_atkey *atkey, const char *value, const size_t valuelen) {
+int atclient_put(atclient *atclient, const atclient_atkey *atkey, const char *value, const size_t valuelen) {
   int ret = 1;
 
   goto exit;
 exit: { return ret; }
 }
 
-int atclient_get_selfkey(const atclient *atclient, atclient_atkey *atkey, char *value, const size_t valuelen,
+int atclient_get_selfkey(atclient *atclient, atclient_atkey *atkey, char *value, const size_t valuelen,
                          size_t *valueolen) {
   int ret = 1;
 
@@ -269,7 +266,7 @@ int atclient_get_selfkey(const atclient *atclient, atclient_atkey *atkey, char *
 exit: { return ret; }
 }
 
-int atclient_get_publickey(const atclient *atclient, const atclient_atkey *atkey, char *value, const size_t valuelen,
+int atclient_get_publickey(atclient *atclient, const atclient_atkey *atkey, char *value, const size_t valuelen,
                            size_t *valueolen) {
   int ret = 1;
 
@@ -280,7 +277,7 @@ int atclient_get_publickey(const atclient *atclient, const atclient_atkey *atkey
 exit: { return ret; }
 }
 
-int atclient_get_sharedkey(const atclient *atclient, const atclient_atkey *atkey, char *value, const size_t valuelen,
+int atclient_get_sharedkey(atclient *atclient, const atclient_atkey *atkey, char *value, const size_t valuelen,
                            size_t *valueolen) {
   int ret = 1;
 
@@ -290,7 +287,7 @@ int atclient_get_sharedkey(const atclient *atclient, const atclient_atkey *atkey
 exit: { return ret; }
 }
 
-int atclient_delete(const atclient *atclient, const atclient_atkey *atkey) {
+int atclient_delete(atclient *atclient, const atclient_atkey *atkey) {
   int ret = 1;
 
   atclient_atstr cmdbuffer;

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -291,16 +291,16 @@ int atclient_delete(atclient *atclient, const atclient_atkey *atkey) {
   int ret = 1;
 
   atclient_atstr cmdbuffer;
-  atclient_atstr_init_literal(&cmdbuffer, ATKEY_GENERAL_BUFFER_SIZE + strlen("delete:"), "delete:");
+  atclient_atstr_init_literal(&cmdbuffer, ATCLIENT_MAX_ATSIGN_LEN + strlen("delete:"), "delete:");
 
-  char atkeystr[ATKEY_GENERAL_BUFFER_SIZE];
-  memset(atkeystr, 0, sizeof(char) * ATKEY_GENERAL_BUFFER_SIZE);
+  char atkeystr[ATCLIENT_MAX_ATSIGN_LEN];
+  memset(atkeystr, 0, sizeof(char) * ATCLIENT_MAX_ATSIGN_LEN);
   size_t atkeystrolen = 0;
 
   unsigned char recv[4096] = {0};
   size_t recvolen = 0;
 
-  ret = atclient_atkey_to_string(*atkey, atkeystr, ATKEY_GENERAL_BUFFER_SIZE, &atkeystrolen);
+  ret = atclient_atkey_to_string(*atkey, atkeystr, ATCLIENT_MAX_ATSIGN_LEN, &atkeystrolen);
   if (ret != 0) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string: %d\n", ret);
     goto exit;

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -7,6 +7,7 @@
 #include "atclient/atsign.h"
 #include "atclient/atstr.h"
 #include "atclient/connection.h"
+#include "atclient/constants.h"
 #include "atclient/stringutils.h"
 #include "atlogger/atlogger.h"
 #include <cJSON/cJSON.h>
@@ -291,16 +292,16 @@ int atclient_delete(atclient *atclient, const atclient_atkey *atkey) {
   int ret = 1;
 
   atclient_atstr cmdbuffer;
-  atclient_atstr_init_literal(&cmdbuffer, ATCLIENT_MAX_ATSIGN_LEN + strlen("delete:"), "delete:");
+  atclient_atstr_init_literal(&cmdbuffer, ATCLIENT_ATKEY_FULL_LEN + strlen("delete:"), "delete:");
 
-  char atkeystr[ATCLIENT_MAX_ATSIGN_LEN];
-  memset(atkeystr, 0, sizeof(char) * ATCLIENT_MAX_ATSIGN_LEN);
+  char atkeystr[ATCLIENT_ATKEY_FULL_LEN];
+  memset(atkeystr, 0, sizeof(char) * ATCLIENT_ATKEY_FULL_LEN);
   size_t atkeystrolen = 0;
 
   unsigned char recv[4096] = {0};
   size_t recvolen = 0;
 
-  ret = atclient_atkey_to_string(*atkey, atkeystr, ATCLIENT_MAX_ATSIGN_LEN, &atkeystrolen);
+  ret = atclient_atkey_to_string(*atkey, atkeystr, ATCLIENT_ATKEY_FULL_LEN, &atkeystrolen);
   if (ret != 0) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string: %d\n", ret);
     goto exit;

--- a/packages/atclient/src/atkey.c
+++ b/packages/atclient/src/atkey.c
@@ -1,6 +1,7 @@
 #include "atclient/atkey.h"
 #include "atclient/atsign.h"
 #include "atclient/atstr.h"
+#include "atclient/constants.h"
 #include "atclient/metadata.h"
 #include "atclient/stringutils.h"
 #include "atlogger/atlogger.h"
@@ -11,14 +12,12 @@
 
 #define TAG "atkey"
 
-#define ATKEY_GENERAL_BUFFER_SIZE 4096 // sufficient memory for keyName, namespace, sharedWith, and sharedBy strings
-
 void atclient_atkey_init(atclient_atkey *atkey) {
   memset(atkey, 0, sizeof(atclient_atkey));
-  atclient_atstr_init(&(atkey->name), ATKEY_GENERAL_BUFFER_SIZE);
-  atclient_atstr_init(&(atkey->namespacestr), ATKEY_GENERAL_BUFFER_SIZE);
-  atclient_atstr_init(&(atkey->sharedby), ATKEY_GENERAL_BUFFER_SIZE);
-  atclient_atstr_init(&(atkey->sharedwith), ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&(atkey->name), ATCLIENT_ATKEY_KEY_LEN + 1);
+  atclient_atstr_init(&(atkey->namespacestr), ATCLIENT_ATKEY_NAMESPACE_LEN + 1);
+  atclient_atstr_init(&(atkey->sharedby), ATCLIENT_ATKEY_FULL_LEN);
+  atclient_atstr_init(&(atkey->sharedwith), ATCLIENT_ATKEY_FULL_LEN);
 
   atclient_atkey_metadata_init(&(atkey->metadata));
 }
@@ -142,8 +141,8 @@ int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, cons
     goto exit;
   }
   tokenlen = strlen(token);
-  char nameandnamespacestr[ATCLIENT_MAX_INNER_ATKEY_LEN];
-  memset(nameandnamespacestr, 0, sizeof(char) * ATCLIENT_MAX_INNER_ATKEY_LEN);
+  char nameandnamespacestr[ATCLIENT_ATKEY_COMPOSITE_LEN + 1];
+  memset(nameandnamespacestr, 0, sizeof(char) * ATCLIENT_ATKEY_COMPOSITE_LEN + 1);
   memcpy(nameandnamespacestr, token, tokenlen);
   if (strchr(nameandnamespacestr, '.') != NULL) {
     // there is a namespace
@@ -192,10 +191,10 @@ int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, cons
     goto exit;
   }
   tokenlen = strlen(token);
-  char sharedbystr[ATCLIENT_MAX_INNER_ATKEY_LEN];
-  memset(sharedbystr, 0, sizeof(char) * ATCLIENT_MAX_INNER_ATKEY_LEN);
+  char sharedbystr[ATCLIENT_ATKEY_FULL_LEN + 1];
+  memset(sharedbystr, 0, sizeof(char) * ATCLIENT_ATKEY_FULL_LEN + 1);
   unsigned long sharedbystrolen = 0;
-  ret = atclient_atsign_with_at_symbol(sharedbystr, ATCLIENT_MAX_INNER_ATKEY_LEN, &sharedbystrolen, token, tokenlen);
+  ret = atclient_atsign_with_at_symbol(sharedbystr, ATCLIENT_ATSIGN_FULL_LEN, &sharedbystrolen, token, tokenlen);
   if (ret != 0) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atsign_with_at_symbol failed\n");
     goto exit;
@@ -218,7 +217,7 @@ int atclient_atkey_to_string(const atclient_atkey atkey, char *atkeystr, const u
   int ret = 1;
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   if (atkey.metadata.iscached) {
     ret = atclient_atstr_append(&string, "cached:");

--- a/packages/atclient/src/atkey.c
+++ b/packages/atclient/src/atkey.c
@@ -1,14 +1,13 @@
 #include "atclient/atkey.h"
 #include "atclient/atsign.h"
 #include "atclient/atstr.h"
-#include "atclient/constants.h"
 #include "atclient/metadata.h"
 #include "atclient/stringutils.h"
 #include "atlogger/atlogger.h"
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 
 #define TAG "atkey"
 
@@ -143,8 +142,8 @@ int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, cons
     goto exit;
   }
   tokenlen = strlen(token);
-  char nameandnamespacestr[ATSIGN_BUFFER_LENGTH];
-  memset(nameandnamespacestr, 0, sizeof(char) * ATSIGN_BUFFER_LENGTH);
+  char nameandnamespacestr[MAX_ATSIGN_CHARACTERS];
+  memset(nameandnamespacestr, 0, sizeof(char) * MAX_ATSIGN_CHARACTERS);
   memcpy(nameandnamespacestr, token, tokenlen);
   if (strchr(nameandnamespacestr, '.') != NULL) {
     // there is a namespace
@@ -193,10 +192,10 @@ int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, cons
     goto exit;
   }
   tokenlen = strlen(token);
-  char sharedbystr[ATSIGN_BUFFER_LENGTH];
-  memset(sharedbystr, 0, sizeof(char) * ATSIGN_BUFFER_LENGTH);
+  char sharedbystr[MAX_ATSIGN_CHARACTERS];
+  memset(sharedbystr, 0, sizeof(char) * MAX_ATSIGN_CHARACTERS);
   unsigned long sharedbystrolen = 0;
-  ret = atclient_atsign_with_at_symbol(sharedbystr, ATSIGN_BUFFER_LENGTH, &sharedbystrolen, token, tokenlen);
+  ret = atclient_atsign_with_at_symbol(sharedbystr, MAX_ATSIGN_CHARACTERS, &sharedbystrolen, token, tokenlen);
   if (ret != 0) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atsign_with_at_symbol failed\n");
     goto exit;
@@ -246,8 +245,7 @@ int atclient_atkey_to_string(const atclient_atkey atkey, char *atkeystr, const u
       atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_append_literal failed\n");
       goto exit;
     }
-  } else if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_SELFKEY ||
-             atkey.atkeytype == ATCLIENT_ATKEY_TYPE_UNKNOWN) {
+  } else if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_SELFKEY || atkey.atkeytype == ATCLIENT_ATKEY_TYPE_UNKNOWN) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey's atkeytype is %d: %.*s\n", atkey.atkeytype,
                           (int)atkey.name.olen, atkey.name.str);
     ret = 1;

--- a/packages/atclient/src/atkey.c
+++ b/packages/atclient/src/atkey.c
@@ -142,8 +142,8 @@ int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, cons
     goto exit;
   }
   tokenlen = strlen(token);
-  char nameandnamespacestr[MAX_ATSIGN_CHARACTERS];
-  memset(nameandnamespacestr, 0, sizeof(char) * MAX_ATSIGN_CHARACTERS);
+  char nameandnamespacestr[ATCLIENT_MAX_INNER_ATKEY_LEN];
+  memset(nameandnamespacestr, 0, sizeof(char) * ATCLIENT_MAX_INNER_ATKEY_LEN);
   memcpy(nameandnamespacestr, token, tokenlen);
   if (strchr(nameandnamespacestr, '.') != NULL) {
     // there is a namespace
@@ -192,10 +192,10 @@ int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, cons
     goto exit;
   }
   tokenlen = strlen(token);
-  char sharedbystr[MAX_ATSIGN_CHARACTERS];
-  memset(sharedbystr, 0, sizeof(char) * MAX_ATSIGN_CHARACTERS);
+  char sharedbystr[ATCLIENT_MAX_INNER_ATKEY_LEN];
+  memset(sharedbystr, 0, sizeof(char) * ATCLIENT_MAX_INNER_ATKEY_LEN);
   unsigned long sharedbystrolen = 0;
-  ret = atclient_atsign_with_at_symbol(sharedbystr, MAX_ATSIGN_CHARACTERS, &sharedbystrolen, token, tokenlen);
+  ret = atclient_atsign_with_at_symbol(sharedbystr, ATCLIENT_MAX_INNER_ATKEY_LEN, &sharedbystrolen, token, tokenlen);
   if (ret != 0) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atsign_with_at_symbol failed\n");
     goto exit;

--- a/packages/atclient/src/atkeys.c
+++ b/packages/atclient/src/atkeys.c
@@ -1,9 +1,9 @@
 #include "atclient/atkeys.h"
 #include "atclient/atstr.h"
-#include "atclient/constants.h"
 #include "atlogger/atlogger.h"
 #include <atchops/aesctr.h>
 #include <atchops/iv.h>
+#include <atchops/rsa.h>
 #include <atchops/rsakey.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,19 +13,19 @@
 void atclient_atkeys_init(atclient_atkeys *atkeys) {
   memset(atkeys, 0, sizeof(atclient_atkeys));
 
-  atclient_atstr_init(&(atkeys->pkampublickeystr), ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE);
+  atclient_atstr_init(&(atkeys->pkampublickeystr), ATCHOPS_RSA_4096);
   atchops_rsakey_publickey_init(&(atkeys->pkampublickey));
 
-  atclient_atstr_init(&(atkeys->pkamprivatekeystr), ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE);
+  atclient_atstr_init(&(atkeys->pkamprivatekeystr), ATCHOPS_RSA_4096);
   atchops_rsakey_privatekey_init(&(atkeys->pkamprivatekey));
 
-  atclient_atstr_init(&(atkeys->encryptpublickeystr), ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE);
+  atclient_atstr_init(&(atkeys->encryptpublickeystr), ATCHOPS_RSA_4096);
   atchops_rsakey_publickey_init(&(atkeys->encryptpublickey));
 
-  atclient_atstr_init(&(atkeys->encryptprivatekeystr), ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE);
+  atclient_atstr_init(&(atkeys->encryptprivatekeystr), ATCHOPS_RSA_4096);
   atchops_rsakey_privatekey_init(&(atkeys->encryptprivatekey));
 
-  atclient_atstr_init(&(atkeys->selfencryptionkeystr), ATCLIENT_CONSTANTS_DECRYPTED_BASE64_RSA_KEY_BUFFER_SIZE);
+  atclient_atstr_init(&(atkeys->selfencryptionkeystr), ATCHOPS_RSA_4096);
 }
 
 int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys, const char *aespkampublickeystr,
@@ -144,7 +144,7 @@ exit: {
 }
 }
 
-int atclient_atkeys_populate_from_atkeysfile(atclient_atkeys *atkeys, atclient_atkeysfile atkeysfile) {
+int atclient_atkeys_populate_from_atkeysfile(atclient_atkeys *atkeys, const atclient_atkeysfile atkeysfile) {
   int ret = 1;
 
   ret = atclient_atkeys_populate_from_strings(

--- a/packages/atclient/src/atkeysfile.c
+++ b/packages/atclient/src/atkeysfile.c
@@ -134,7 +134,7 @@ exit: {
 }
 }
 
-int atclient_atkeysfile_write(atclient_atkeysfile *atkeysfile, const char *path, const char *atsign) {
+int atclient_atkeysfile_write(const atclient_atkeysfile *atkeysfile, const char *path, const char *atsign) {
   int ret = 1;
 
   // guarantee that all values are null terminated and are of correct length

--- a/packages/atclient/src/atlogger.c
+++ b/packages/atclient/src/atlogger.c
@@ -14,10 +14,11 @@
 static char *prefix;
 
 typedef struct atlogger_ctx {
-  atclient_atlogger_logging_level level;
+  enum atclient_atlogger_logging_level level;
 } atlogger_ctx;
 
-static void atlogger_get_prefix(atclient_atlogger_logging_level logging_level, char *prefix, unsigned long prefixlen) {
+static void atlogger_get_prefix(enum atclient_atlogger_logging_level logging_level, char *prefix,
+                                unsigned long prefixlen) {
   memset(prefix, 0, prefixlen);
   switch (logging_level) {
   case ATLOGGER_LOGGING_LEVEL_INFO: {
@@ -54,17 +55,17 @@ static atlogger_ctx *atlogger_get_instance() {
   return ctx;
 }
 
-atclient_atlogger_logging_level atlogger_get_logging_level() {
+enum atclient_atlogger_logging_level atlogger_get_logging_level() {
   atlogger_ctx *ctx = atlogger_get_instance();
   return ctx->level;
 }
 
-void atclient_atlogger_set_logging_level(atclient_atlogger_logging_level level) {
+void atclient_atlogger_set_logging_level(const enum atclient_atlogger_logging_level level) {
   atlogger_ctx *ctx = atlogger_get_instance();
   ctx->level = level;
 }
 
-void atclient_atlogger_log(const char *tag, atclient_atlogger_logging_level level, const char *format, ...) {
+void atclient_atlogger_log(const char *tag, const enum atclient_atlogger_logging_level level, const char *format, ...) {
   atlogger_ctx *ctx = atlogger_get_instance();
 
   if (level > ctx->level) {

--- a/packages/atclient/src/atsign.c
+++ b/packages/atclient/src/atsign.c
@@ -1,4 +1,5 @@
 #include "atclient/atsign.h"
+#include "atclient/constants.h"
 #include "atlogger/atlogger.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -9,8 +10,9 @@
 int atclient_atsign_init(atclient_atsign *atsign, const char *atsign_str) {
   int ret = 0;
 
+  const unsigned long maxatlen = ATCLIENT_ATSIGN_FULL_LEN + 1;
   // atsign_str is longer than expected or null/empty
-  if ((strlen(atsign_str) > ATCLIENT_MAX_ATSIGN_LEN) || (atsign_str == NULL) || (strlen(atsign_str) == 0)) {
+  if ((strlen(atsign_str) > maxatlen) || (atsign_str == NULL) || (strlen(atsign_str) == 0)) {
     ret = 1;
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atsign_init: %d\n", ret);
     return ret;
@@ -19,7 +21,6 @@ int atclient_atsign_init(atclient_atsign *atsign, const char *atsign_str) {
   memset(atsign, 0, sizeof(atclient_atsign));
   atsign->atsign = malloc(strlen(atsign_str) + 1);
 
-  const unsigned long maxatlen = ATCLIENT_MAX_ATSIGN_LEN;
   unsigned long atolen = 0;
   ret = atclient_atsign_with_at_symbol(atsign->atsign, maxatlen, &(atolen), atsign_str, strlen(atsign_str));
   if (ret != 0) {

--- a/packages/atclient/src/atsign.c
+++ b/packages/atclient/src/atsign.c
@@ -10,7 +10,7 @@ int atclient_atsign_init(atclient_atsign *atsign, const char *atsign_str) {
   int ret = 0;
 
   // atsign_str is longer than expected or null/empty
-  if ((strlen(atsign_str) > MAX_ATSIGN_STR_BUFFER) || (atsign_str == NULL) || (strlen(atsign_str) == 0)) {
+  if ((strlen(atsign_str) > ATCLIENT_MAX_ATSIGN_LEN) || (atsign_str == NULL) || (strlen(atsign_str) == 0)) {
     ret = 1;
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atsign_init: %d\n", ret);
     return ret;
@@ -19,7 +19,7 @@ int atclient_atsign_init(atclient_atsign *atsign, const char *atsign_str) {
   memset(atsign, 0, sizeof(atclient_atsign));
   atsign->atsign = malloc(strlen(atsign_str) + 1);
 
-  const unsigned long maxatlen = MAX_ATSIGN_STR_BUFFER;
+  const unsigned long maxatlen = ATCLIENT_MAX_ATSIGN_LEN;
   unsigned long atolen = 0;
   ret = atclient_atsign_with_at_symbol(atsign->atsign, maxatlen, &(atolen), atsign_str, strlen(atsign_str));
   if (ret != 0) {

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -3,7 +3,6 @@
 #include "atchops/constants.h"
 #include "atclient/atstr.h"
 #include "atclient/cacerts.h"
-#include "atclient/constants.h"
 #include "atlogger/atlogger.h"
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>

--- a/packages/atclient/src/metadata.c
+++ b/packages/atclient/src/metadata.c
@@ -1063,12 +1063,12 @@ void atclient_atkey_metadata_free(atclient_atkey_metadata *metadata) {
   }
 
   if (atclient_atkey_metadata_is_sharedkeystatus_initialized(*metadata)) {
-    atclient_atsign_free(&metadata->sharedkeystatus);
+    atclient_atstr_free(&metadata->sharedkeystatus);
     metadata->initializedfields[2] &= ~ATKEY_METADATA_SHAREDKEYSTATUS_INITIALIZED;
   }
 
   if (atclient_atkey_metadata_is_sharedkeyenc_initialized(*metadata)) {
-    atclient_atsign_free(&metadata->sharedkeyenc);
+    atclient_atstr_free(&metadata->sharedkeyenc);
     metadata->initializedfields[2] &= ~ATKEY_METADATA_SHAREDKEYENC_INITIALIZED;
   }
 
@@ -1088,7 +1088,7 @@ void atclient_atkey_metadata_free(atclient_atkey_metadata *metadata) {
   }
 
   if (atclient_atkey_metadata_is_enckeyname_initialized(*metadata)) {
-    atclient_atsign_free(&metadata->enckeyname);
+    atclient_atstr_free(&metadata->enckeyname);
     metadata->initializedfields[2] &= ~ATKEY_METADATA_ENCKEYNAME_INITIALIZED;
   }
 
@@ -1103,7 +1103,7 @@ void atclient_atkey_metadata_free(atclient_atkey_metadata *metadata) {
   }
 
   if (atclient_atkey_metadata_is_skeenckeyname_initialized(*metadata)) {
-    atclient_atsign_free(&metadata->skeenckeyname);
+    atclient_atstr_free(&metadata->skeenckeyname);
     metadata->initializedfields[3] &= ~ATKEY_METADATA_SKEENCKEYNAME_INITIALIZED;
   }
 

--- a/packages/atclient/tests/test_atkey_create.c
+++ b/packages/atclient/tests/test_atkey_create.c
@@ -1,4 +1,5 @@
 #include "atclient/atkey.h"
+#include "atclient/constants.h"
 #include "atlogger/atlogger.h"
 #include <string.h>
 
@@ -10,8 +11,8 @@ static int test_create_publickey() {
   atclient_atkey atkey;
   atclient_atkey_init(&atkey);
 
-  char atkeystr[ATKEY_GENERAL_BUFFER_SIZE];
-  memset(atkeystr, 0, ATKEY_GENERAL_BUFFER_SIZE);
+  char atkeystr[ATCLIENT_ATKEY_FULL_LEN + 1];
+  memset(atkeystr, 0, ATCLIENT_ATKEY_FULL_LEN + 1);
 
   const char *expected = "public:test@alice";
   const size_t expectedlen = strlen(expected);
@@ -44,7 +45,7 @@ static int test_create_publickey() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(atkey, atkeystr, ATKEY_GENERAL_BUFFER_SIZE, &expectedolen);
+  ret = atclient_atkey_to_string(atkey, atkeystr, ATCLIENT_ATKEY_FULL_LEN, &expectedolen);
   if (ret != 0) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string: %d\n", ret);
     ret = 1;
@@ -78,8 +79,8 @@ static int test_create_selfkey() {
   atclient_atkey atkey;
   atclient_atkey_init(&atkey);
 
-  char atkeystr[ATKEY_GENERAL_BUFFER_SIZE];
-  memset(atkeystr, 0, ATKEY_GENERAL_BUFFER_SIZE);
+  char atkeystr[ATCLIENT_ATKEY_FULL_LEN];
+  memset(atkeystr, 0, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = "name@jeremy";
   const size_t expectedlen = strlen(expected);
@@ -112,7 +113,7 @@ static int test_create_selfkey() {
   }
 
   unsigned long atkeystrolen = 0;
-  ret = atclient_atkey_to_string(atkey, atkeystr, ATKEY_GENERAL_BUFFER_SIZE, &atkeystrolen);
+  ret = atclient_atkey_to_string(atkey, atkeystr, ATCLIENT_ATKEY_FULL_LEN, &atkeystrolen);
   if (ret != 0) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string: %d\n", ret);
     ret = 1;
@@ -143,8 +144,8 @@ static int test_create_sharedkey() {
   atclient_atkey atkey;
   atclient_atkey_init(&atkey);
 
-  char atkeystr[ATKEY_GENERAL_BUFFER_SIZE];
-  memset(atkeystr, 0, ATKEY_GENERAL_BUFFER_SIZE);
+  char atkeystr[ATCLIENT_ATKEY_FULL_LEN];
+  memset(atkeystr, 0, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = "@jeremy:name.wavi@chess69lovely";
   const size_t expectedlen = strlen(expected);
@@ -192,7 +193,7 @@ static int test_create_sharedkey() {
   }
 
   unsigned long atkeystrolen = 0;
-  ret = atclient_atkey_to_string(atkey, atkeystr, ATKEY_GENERAL_BUFFER_SIZE, &atkeystrolen);
+  ret = atclient_atkey_to_string(atkey, atkeystr, ATCLIENT_ATKEY_FULL_LEN, &atkeystrolen);
   if (ret != 0) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string: %d\n", ret);
     ret = 1;

--- a/packages/atclient/tests/test_atkey_from_string.c
+++ b/packages/atclient/tests/test_atkey_from_string.c
@@ -1,7 +1,6 @@
 #include "atclient/atkey.h"
 #include "atlogger/atlogger.h"
 #include <stdbool.h>
-#include <stdio.h>
 #include <string.h>
 
 #define TAG "test_atkey_from_string"

--- a/packages/atclient/tests/test_atkey_to_string.c
+++ b/packages/atclient/tests/test_atkey_to_string.c
@@ -1,7 +1,8 @@
 #include "atclient/atkey.h"
+#include "atclient/constants.h"
 #include "atlogger/atlogger.h"
-#include <string.h>
 #include <stdbool.h>
+#include <string.h>
 
 #define TAG "test_atkey_to_string"
 
@@ -39,7 +40,7 @@ static int test1a() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = TEST_ATKEY_TO_STRING_1A;
   const unsigned long expectedlen = strlen(expected);
@@ -90,7 +91,7 @@ static int test1b() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = TEST_ATKEY_TO_STRING_1B; // "public:publickey@alice"
   const unsigned long expectedlen = strlen(expected);
@@ -136,7 +137,7 @@ static int test1c() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = TEST_ATKEY_TO_STRING_1C; // "public:name.wavi@jeremy"
   const unsigned long expectedlen = strlen(expected);
@@ -188,7 +189,7 @@ static int test1d() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = TEST_ATKEY_TO_STRING_1D; // "cached:public:name.wavi@jeremy"
   const unsigned long expectedlen = strlen(expected);
@@ -241,7 +242,7 @@ static int test2a() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = TEST_ATKEY_TO_STRING_2A; // "@alice:name.wavi@bob"
   const unsigned long expectedlen = strlen(expected);
@@ -290,7 +291,7 @@ static int test2b() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = TEST_ATKEY_TO_STRING_2B; // "cached:@bob:name@alice"
   const unsigned long expectedlen = strlen(expected);
@@ -342,7 +343,7 @@ static int test2c() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = TEST_ATKEY_TO_STRING_2C; // "@bob:name@alice"
   const unsigned long expectedlen = strlen(expected);
@@ -400,7 +401,7 @@ static int test2d() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = TEST_ATKEY_TO_STRING_2D; // "cached:@bob:name.wavi@alice"
   const unsigned long expectedlen = strlen(expected);
@@ -458,7 +459,7 @@ static int test3a() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = TEST_ATKEY_TO_STRING_3A; // "_lastnotificationid@alice123_4😘"
   const unsigned long expectedlen = strlen(expected);
@@ -510,7 +511,7 @@ static int test4a() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   const char *expected = TEST_ATKEY_TO_STRING_4A; // "name@alice"
   const unsigned long expectedlen = strlen(expected);
@@ -562,7 +563,7 @@ static int test4b() {
   atclient_atkey_init(&atkey);
 
   atclient_atstr string;
-  atclient_atstr_init(&string, ATKEY_GENERAL_BUFFER_SIZE);
+  atclient_atstr_init(&string, ATCLIENT_ATKEY_FULL_LEN);
 
   // TODO: implement test
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- make things const where possible
- leave some TODOs with improvements to be made
- remove typedefs from some enums which shouldn't need to be stored (often) by the developer
  - e.g. aes/rsa key size enums
- removed unused buffer sizes and moved needed ones to their associated header file
  - kept constants.h, since it will be used by monitor/notify
- removed root connection from atclient so it can be used by multiple secondary connections
  - e.g. monitor thread only needs root to do pkam auth then it can release it back to the main connection
**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: refine types and memory
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
