### PR TITLE
chore: remove unnecessary error print that wasn't even an error

### DIFF
--- a/packages/atclient/tests/test_atkey_metadata.c
+++ b/packages/atclient/tests/test_atkey_metadata.c
@@ -269,8 +269,6 @@ static int test_atkey_metadata_to_protocolstr() {
     goto exit;
   }
 
-  atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "protocolfragment: \"%s\"\n", protocolfragment);
-
   if (strlen(protocolfragment) != protocolfragmentolen) {
     atclient_atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                           "strlen(protocolfragment) != protocolfragmentolen: %lu != %lu", strlen(protocolfragment),


### PR DESCRIPTION
**- What I did**
- there was a atclient_log that was using ERROR, but it really an error, so I removed it

