### PR TITLE
chore: add fs watcher to rebuild atclient

### DIFF
--- a/packages/atclient/tools/dev.sh
+++ b/packages/atclient/tools/dev.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+script_dir="$(dirname -- "$(readlink -f -- "$0")")"
+package_dir="$script_dir/.."
+while true; do
+  # list for changes in the atclient directory
+  inotifywait -e modify,create,delete,move -r "$package_dir"
+  # rebuild the project
+  echo "Rebuilding atclient"
+  cmake -B "$package_dir/build" -S "$package_dir" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+  cmake --build "$package_dir/build" --target install
+  echo "Done rebuilding!"
+done


### PR DESCRIPTION
requires inotify-tools to be installed

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Just a little bash tool which rebuilds atclient whenever you make changes in that directory.
- I always forget to rebuild when I'm going back and forth between atclient & an example.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: add fs watcher to rebuild atclient
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
