### PR TITLE
chore: rename len to size and olen to len

### DIFF
--- a/examples/desktop/crud/get_publickey.c
+++ b/examples/desktop/crud/get_publickey.c
@@ -65,13 +65,13 @@ int main() {
     goto exit;
   }
 
-  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.len, &atkeystr.olen)) != 0) {
+  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.size, &atkeystr.len)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to convert to string");
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.olen,
-                        (int)atkeystr.olen, atkeystr.str);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.len,
+                        (int)atkeystr.len, atkeystr.str);
 
   ret = atclient_get_publickey(&atclient, &atkey, value, valuelen, &valueolen, true);
   if (ret != 0) {

--- a/examples/desktop/crud/get_selfkey.c
+++ b/examples/desktop/crud/get_selfkey.c
@@ -70,13 +70,13 @@ int main() {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Created self key\n");
   }
 
-  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.len, &atkeystr.olen)) != 0) {
+  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.size, &atkeystr.len)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to convert to string\n");
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.olen,
-                        (int)atkeystr.olen, atkeystr.str);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.len,
+                        (int)atkeystr.len, atkeystr.str);
 
   ret = atclient_get_selfkey(&atclient, &atkey, value, valuelen, &(valueolen));
   if (ret != 0) {

--- a/examples/desktop/crud/get_sharedkey.c
+++ b/examples/desktop/crud/get_sharedkey.c
@@ -82,21 +82,21 @@ int main() {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Created shared key\n");
   }
 
-  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.len, &atkeystr.olen)) != 0) {
+  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.size, &atkeystr.len)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to convert to string\n");
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.olen,
-                        (int)atkeystr.olen, atkeystr.str);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.len,
+                        (int)atkeystr.len, atkeystr.str);
 
-  ret = atclient_get_sharedkey(&atclient, &atkey, value.str, value.len, &value.olen, NULL, false);
+  ret = atclient_get_sharedkey(&atclient, &atkey, value.str, value.size, &value.len, NULL, false);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to get shared key");
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "value.str (%lu): \"%.*s\"\n", value.olen, (int)value.olen,
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "value.str (%lu): \"%.*s\"\n", value.len, (int)value.len,
                         value.str);
 
   const size_t value_hash_len = 32;
@@ -104,7 +104,7 @@ int main() {
   memset(value_hash, 0, value_hash_len);
   size_t value_hash_olen = 0;
 
-  ret = atchops_sha_hash(MBEDTLS_MD_SHA256, (const unsigned char *)value.str, value.olen, value_hash);
+  ret = atchops_sha_hash(MBEDTLS_MD_SHA256, (const unsigned char *)value.str, value.len, value_hash);
   if (ret != 0) {
     printf("atchops_sha_hash (failed): %d\n", ret);
     goto exit;

--- a/examples/desktop/crud/put_publickey.c
+++ b/examples/desktop/crud/put_publickey.c
@@ -64,13 +64,13 @@ int main() {
   atclient_atkey_metadata_set_ttl(&atkey.metadata, 60 * 1000 * 10); // 10 minutes
   atclient_atkey_metadata_set_ccd(&atkey.metadata, true);
 
-  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.len, &atkeystr.olen)) != 0) {
+  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.size, &atkeystr.len)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to convert to string");
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.olen,
-                        (int)atkeystr.olen, atkeystr.str);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.len,
+                        (int)atkeystr.len, atkeystr.str);
 
   if ((ret = atclient_put(&atclient, &atkey, ATKEY_VALUE, strlen(ATKEY_VALUE), NULL) != 0)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to put public key");

--- a/examples/desktop/crud/put_selfkey.c
+++ b/examples/desktop/crud/put_selfkey.c
@@ -63,13 +63,13 @@ int main() {
 
   atclient_atkey_metadata_set_ttl(&atkey.metadata, 60 * 1000 * 10); // 10 minutes
 
-  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.len, &atkeystr.olen)) != 0) {
+  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.size, &atkeystr.len)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to convert to string");
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.olen,
-                        (int)atkeystr.olen, atkeystr.str);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.len,
+                        (int)atkeystr.len, atkeystr.str);
 
   if ((ret = atclient_put(&atclient, &atkey, ATKEY_VALUE, strlen(ATKEY_VALUE), NULL) != 0)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to put public key");

--- a/examples/desktop/crud/put_sharedkey.c
+++ b/examples/desktop/crud/put_sharedkey.c
@@ -68,12 +68,12 @@ int main()
 
     atclient_atkey_metadata_set_ttl(&atkey.metadata, 60*1000*10); // 10 minutes
 
-    if((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.len, &atkeystr.olen)) != 0) {
+    if((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.size, &atkeystr.len)) != 0) {
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to convert to string");
         goto exit;
     }
 
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Putting atkeystr.str (%lu): \"%.*s\"\n", atkeystr.olen, (int) atkeystr.olen, atkeystr.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Putting atkeystr.str (%lu): \"%.*s\"\n", atkeystr.len, (int) atkeystr.len, atkeystr.str);
 
     if((ret = atclient_put(&atclient, &atkey, ATKEY_VALUE, strlen(ATKEY_VALUE), NULL) != 0)) {
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to put public key");

--- a/examples/desktop/events/notify.c
+++ b/examples/desktop/events/notify.c
@@ -63,13 +63,13 @@ int main() {
 
   atclient_atkey_metadata_set_ccd(&atkey.metadata, true);
 
-  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.len, &atkeystr.olen)) != 0) {
+  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.size, &atkeystr.len)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to convert to string");
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.olen,
-                        (int)atkeystr.olen, atkeystr.str);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.len,
+                        (int)atkeystr.len, atkeystr.str);
 
   atclient_notify_params notify_params;
   atclient_notify_params_init(&notify_params);

--- a/examples/desktop/repl/src/main.c
+++ b/examples/desktop/repl/src/main.c
@@ -114,7 +114,7 @@ int main(int argc, char *argv[]) {
       continue;
     }
     ret =
-        atclient_connection_send(&atclient.secondary_connection, cmd.bytes, cmd.olen, recv.bytes, recv.len, &recv.olen);
+        atclient_connection_send(&atclient.secondary_connection, cmd.bytes, cmd.len, recv.bytes, recv.size, &recv.len);
     if (ret != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                             "atclient_connection_send: %d | failed to send command\n", ret);

--- a/packages/atchops/include/atchops/aes.h
+++ b/packages/atchops/include/atchops/aes.h
@@ -13,7 +13,7 @@ enum atchops_aes_size {
  * @brief Generate an AES key of size keylen bits
  *
  * @param key key buffer of size (keylen/8) bytes
- * @param keysize key length in bits (e.g. AES-256 = 256 => ATCHOPS_AES_256)
+ * @param keybits key length in bits (e.g. AES-256 = 256 => ATCHOPS_AES_256)
  * @return int 0 on success
  */
 int atchops_aes_generate_key(unsigned char *key, const enum atchops_aes_size keybits);
@@ -22,12 +22,12 @@ int atchops_aes_generate_key(unsigned char *key, const enum atchops_aes_size key
  * @brief Generate an AES key of size keylen bits encoded in base 64
  *
  * @param keybase64 key buffer to hold base64 string
- * @param keybase64len the allocated length of the key buffer
- * @param keybase64olen the written length of the key buffer
- * @param keysize the AES key length in bits (e.g. AES-256 = 256 => ATCHOPS_AES_256)
+ * @param keybase64size the allocated length of the key buffer
+ * @param keybase64len the written length of the key buffer
+ * @param keybits the AES key length in bits (e.g. AES-256 = 256 => ATCHOPS_AES_256)
  * @return int 0 on success
  */
-int atchops_aes_generate_keybase64(unsigned char *keybase64, const size_t keybase64len,
-                                   size_t *keybase64olen, const enum atchops_aes_size keybits);
+int atchops_aes_generate_keybase64(unsigned char *keybase64, const size_t keybase64size,
+                                   size_t *keybase64len, const enum atchops_aes_size keybits);
 
 #endif

--- a/packages/atchops/include/atchops/base64.h
+++ b/packages/atchops/include/atchops/base64.h
@@ -7,26 +7,26 @@
  * @brief Base64 encode some bytes
  *
  * @param src src bytes that you want to encode
- * @param srclen the length of the src bytes
+ * @param srcsize the length of the src bytes
  * @param dst the buffer where the base64 encoded result will be
- * @param dstlen the buffer length
- * @param writtenlen the length of the result after operation
+ * @param dstsize the buffer length
+ * @param dstlen the length of the result after operation
  * @return int 0 on success
  */
-int atchops_base64_encode(const unsigned char *src, const size_t srclen, unsigned char *dst,
-                          size_t dstlen, size_t *writtenlen);
+int atchops_base64_encode(const unsigned char *src, const size_t srcsize, unsigned char *dst,
+                          size_t dstsize, size_t *dstlen);
 
 /**
  * @brief Base64 decode some bytes
  *
  * @param src src bytes that you want to decode
- * @param srclen the length of the src bytes
+ * @param srcsize the length of the src bytes
  * @param dst the buffer where the base64 decoded result will be
- * @param dstlen the buffer length
- * @param writtenlen the length of the result after operation
+ * @param dstsize the buffer length
+ * @param dstlen the length of the result after operation
  * @return int 0 on success
  */
-int atchops_base64_decode(const unsigned char *src, const size_t srclen, unsigned char *dst,
-                          size_t dstlen, size_t *writtenlen);
+int atchops_base64_decode(const unsigned char *src, const size_t srcsize, unsigned char *dst,
+                          size_t dstsize, size_t *dstlen);
 
 #endif

--- a/packages/atchops/include/atchops/iv.h
+++ b/packages/atchops/include/atchops/iv.h
@@ -18,10 +18,10 @@ int atchops_iv_generate(unsigned char *iv);
  * @brief Generates a random initialization vector and encodes it in base64
  *
  * @param ivbase64 the buffer to store the generated IV
- * @param ivbase64len the length of the buffer
- * @param ivbase64olen the length of the generated IV
+ * @param ivbase64size the length of the buffer
+ * @param ivbase64len the length of the generated IV
  * @return int 0 on success, non-zero on failure
  */
-int atchops_iv_generate_base64(unsigned char *ivbase64, const size_t ivbase64len, size_t *ivbase64olen);
+int atchops_iv_generate_base64(unsigned char *ivbase64, const size_t ivbase64size, size_t *ivbase64len);
 
 #endif

--- a/packages/atchops/src/aes.c
+++ b/packages/atchops/src/aes.c
@@ -53,7 +53,7 @@ int atchops_aes_generate_keybase64(unsigned char *keybase64, const size_t keybas
     goto exit;
   }
 
-  ret = atchops_base64_encode(key, keysize, keybase64, keybase64size, keybase64size);
+  ret = atchops_base64_encode(key, keysize, keybase64, keybase64size, keybase64len);
   if (ret != 0) {
     goto exit;
   }

--- a/packages/atchops/src/aes.c
+++ b/packages/atchops/src/aes.c
@@ -40,8 +40,8 @@ exit: {
 }
 }
 
-int atchops_aes_generate_keybase64(unsigned char *keybase64, const size_t keybase64len,
-                                   size_t *keybase64olen, const enum atchops_aes_size keybits) {
+int atchops_aes_generate_keybase64(unsigned char *keybase64, const size_t keybase64size,
+                                   size_t *keybase64len, const enum atchops_aes_size keybits) {
   int ret = 1;
 
   const size_t keysize = keybits / 8;
@@ -53,7 +53,7 @@ int atchops_aes_generate_keybase64(unsigned char *keybase64, const size_t keybas
     goto exit;
   }
 
-  ret = atchops_base64_encode(key, keysize, keybase64, keybase64len, keybase64olen);
+  ret = atchops_base64_encode(key, keysize, keybase64, keybase64size, keybase64size);
   if (ret != 0) {
     goto exit;
   }

--- a/packages/atchops/src/base64.c
+++ b/packages/atchops/src/base64.c
@@ -3,11 +3,11 @@
 #include <stddef.h>
 
 int atchops_base64_encode(const unsigned char *src, const size_t srclen, unsigned char *dst,
-                          const size_t dstlen, size_t *writtenlen) {
-  return mbedtls_base64_encode(dst, dstlen, writtenlen, src, srclen);
+                          const size_t dstsize, size_t *dstlen) {
+  return mbedtls_base64_encode(dst, dstsize, dstlen, src, srclen);
 }
 
 int atchops_base64_decode(const unsigned char *src, const size_t srclen, unsigned char *dst,
-                          const size_t dstlen, size_t *writtenlen) {
-  return mbedtls_base64_decode(dst, dstlen, writtenlen, src, srclen);
+                          const size_t dstsize, size_t *dstlen) {
+  return mbedtls_base64_decode(dst, dstsize, dstlen, src, srclen);
 }

--- a/packages/atchops/src/iv.c
+++ b/packages/atchops/src/iv.c
@@ -33,7 +33,7 @@ exit: {
 }
 }
 
-int atchops_iv_generate_base64(unsigned char *ivbase64, const size_t ivbase64len, size_t *ivbase64olen) {
+int atchops_iv_generate_base64(unsigned char *ivbase64, const size_t ivbase64size, size_t *ivbase64len) {
   int ret = 1;
 
   unsigned char iv[ATCHOPS_IV_BUFFER_SIZE];
@@ -43,7 +43,7 @@ int atchops_iv_generate_base64(unsigned char *ivbase64, const size_t ivbase64len
     goto exit;
   }
 
-  ret = atchops_base64_encode(iv, ATCHOPS_IV_BUFFER_SIZE, ivbase64, ivbase64len, ivbase64olen);
+  ret = atchops_base64_encode(iv, ATCHOPS_IV_BUFFER_SIZE, ivbase64, ivbase64size, ivbase64len);
   if (ret != 0) {
     goto exit;
   }

--- a/packages/atchops/tests/test_aesctr.c
+++ b/packages/atchops/tests/test_aesctr.c
@@ -45,10 +45,9 @@ int main() {
     goto exit;
   }
 
-  memset(iv, 0, 16);
+  memset(iv, 0, sizeof(unsigned char) * 16);
   ret = atchops_aesctr_decrypt(key, ATCHOPS_AES_256, iv, ciphertext, ciphertextlen, plaintext2,
                                plaintext2size, &plaintext2len);
-  // printf("decrypted (%lu) %.*s\n", olen, (int) olen, plaintext2);
   if (ret != 0) {
     printf("atchops_aesctr_decrypt (failed): %d\n", ret);
     goto exit;

--- a/packages/atchops/tests/test_base64.c
+++ b/packages/atchops/tests/test_base64.c
@@ -33,7 +33,7 @@
   "1PmBPlOW3v8Dwr1BGuu9a7fruisMrl88LuPVXgxBpjANa4aq3nVmcZ2WMduDEgH1bWWqaciT3IkYm/"                                     \
   "97QMIQRyFTfQ5tWY9ZcsP9DKluqM222whKBsLz3sL4F9gL5L2HECz3y5EGX4J5QSrU4y4Y8HE5KNz9SqwlTdYSj87dm/"                       \
   "e5l8mVNVR8gMFtzbd9MqNaCoNPm8GfWvx+QIctKNR3zEjxqWrMkiyezZU0PxC98eeHIkef0s1OPcDLMRiwIl"
-#define DST_BYTES_ALLOCATED 4096
+#define DST_SIZE 4096
 
 int main() {
   int retval;
@@ -42,41 +42,37 @@ int main() {
   const size_t srclen = strlen(src);
   printf("src (%lu): %s\n", srclen, src);
 
-  size_t dstlen = DST_BYTES_ALLOCATED;
-  unsigned char *dst = malloc(sizeof(unsigned char) * dstlen);
-  memset(dst, 0, dstlen);
+  const size_t dstsize = DST_SIZE;
+  unsigned char dst[dstsize];
+  memset(dst, 0, sizeof(unsigned char) * dstsize);
+  size_t dstlen = 0;
 
-  size_t dstlen2 = DST_BYTES_ALLOCATED;
-  unsigned char *dst2 = malloc(sizeof(unsigned char) * dstlen);
-  memset(dst2, 0, dstlen2);
+  const size_t dst2size = DST_SIZE;
+  unsigned char dst2[dst2size];
+  memset(dst2, 0, sizeof(unsigned char) * dst2size);
+  size_t dst2len = 0;
 
-  size_t *olen = malloc(sizeof(size_t));
-  *olen = 0;
-
-  retval = atchops_base64_decode((unsigned char *)src, srclen, dst, dstlen, olen);
+  retval = atchops_base64_decode((unsigned char *) src, srclen, dst, dstsize, &dstlen);
   if (retval) {
     printf("atchops_base64_decode (failed): %d\n", retval);
     goto ret;
   }
-  printf("base64 decoded (%lu):", *olen);
-  for (int i = 0; i < *olen; i++) {
+  printf("base64 decoded (%lu):", dstlen);
+  for (int i = 0; i < dstlen; i++) {
     printf("%02x ", dst[i]);
   }
   printf("\n");
 
-  retval = atchops_base64_encode(dst, *olen, dst2, dstlen2, olen);
+  retval = atchops_base64_encode(dst, dstlen, dst2, dst2size, &dst2len);
   if (retval) {
     printf("atchops_base64_encode (failed): %d\n", retval);
     goto ret;
   }
-  printf("base64 encoded (%lu): %s\n", (*olen), dst2);
+  printf("base64 encoded (%lu): %s\n", (dst2len), dst2);
 
   goto ret;
 
 ret: {
-  free(dst);
-  free(dst2);
-  free(olen);
   return retval;
 }
 }

--- a/packages/atchops/tests/test_iv.c
+++ b/packages/atchops/tests/test_iv.c
@@ -1,12 +1,20 @@
 #include "atchops/iv.h"
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stddef.h>
 
 int main() {
   int ret = 1;
+
   unsigned char iv[ATCHOPS_IV_BUFFER_SIZE];
+  memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_BUFFER_SIZE);
+
+  const size_t ivbase64size = 1024;
+  unsigned char ivbase64[ivbase64size];
+  memset(ivbase64, 0, sizeof(unsigned char) * ivbase64size);
+  size_t ivbase64len = 0;
+
   ret = atchops_iv_generate(iv);
   if (ret != 0) {
     printf("atchops_iv_generate (failed): %d\n", ret);
@@ -18,16 +26,12 @@ int main() {
   }
   printf("\n");
 
-  const size_t ivbase64len = 4096;
-  unsigned char *ivbase64 = malloc(sizeof(unsigned char) * ivbase64len);
-  memset(ivbase64, 0, ivbase64len);
-  size_t ivbase64olen = 0;
-  ret = atchops_iv_generate_base64(ivbase64, ivbase64len, &ivbase64olen);
+  ret = atchops_iv_generate_base64(ivbase64, ivbase64size, &ivbase64len);
   if (ret != 0) {
     printf("atchops_iv_generate_base64 (failed): %d\n", ret);
     goto exit;
   }
-  printf("ivbase64 (%lu): %s\n", ivbase64olen, ivbase64);
+  printf("ivbase64 (%lu): %s\n", ivbase64len, ivbase64);
 
 exit: { return ret; }
 }

--- a/packages/atchops/tests/test_rsadecrypt.c
+++ b/packages/atchops/tests/test_rsadecrypt.c
@@ -46,7 +46,11 @@ int main() {
   atchops_rsakey_privatekey privatekey;
   atchops_rsakey_privatekey_init(&privatekey);
 
-  // printf("1\n");
+  const size_t plaintextsize = 4096;
+  unsigned char plaintext[plaintextsize];
+  memset(plaintext, 0, sizeof(unsigned char) * plaintextsize);
+  size_t plaintextlen = 0;
+
   ret = atchops_rsakey_populate_privatekey(&privatekey, privatekeybase64, privatekeybase64len);
   if (ret != 0) {
     printf("atchops_rsakey_populate_privatekey (failed): %d\n", ret);
@@ -54,13 +58,8 @@ int main() {
   }
   printf("atchops_rsakey_populate_privatekey (success): %d\n", ret);
 
-  size_t plaintextlen = 8192;
-  unsigned char *plaintext = malloc(sizeof(unsigned char) * plaintextlen);
-  memset(plaintext, 0, plaintextlen);
-  size_t plaintextolen = 0;
-
-  ret = atchops_rsa_decrypt(privatekey, (const unsigned char *)ciphertext, ciphertextlen, plaintext, plaintextlen,
-                            &plaintextolen);
+  ret = atchops_rsa_decrypt(privatekey, (const unsigned char *)ciphertext, ciphertextlen, plaintext, plaintextsize,
+                            &plaintextlen);
   if (ret != 0) {
     printf("atchops_rsa_decrypt (failed): %d\n", ret);
     goto ret;
@@ -71,7 +70,6 @@ int main() {
   goto ret;
 
 ret: {
-  free(plaintext);
   return ret;
 }
 }

--- a/packages/atchops/tests/test_rsaencrypt.c
+++ b/packages/atchops/tests/test_rsaencrypt.c
@@ -25,6 +25,11 @@ int main() {
   const char *plaintext = PLAINTEXT;
   const size_t plaintextlen = strlen(plaintext);
 
+  const size_t ciphertextsize = 1024;
+  unsigned char ciphertext[ciphertextsize];
+  memset(ciphertext, 0, sizeof(unsigned char) * ciphertextsize);
+  size_t ciphertextlen = 0;
+
   atchops_rsakey_publickey publickey;
   atchops_rsakey_publickey_init(&publickey);
 
@@ -35,14 +40,8 @@ int main() {
   }
   printf("atchops_rsakey_populate_publickey (success): %d\n", ret);
 
-  const size_t ciphertextlen = 1024;
-  unsigned char *ciphertext = calloc(ciphertextlen, sizeof(unsigned char));
-  memset(ciphertext, 0, ciphertextlen);
-  size_t ciphertextolen = 0;
-
-  // printf("encrypting...\n");
-  ret = atchops_rsa_encrypt(publickey, (const unsigned char *)plaintext, plaintextlen, ciphertext, ciphertextlen,
-                            &ciphertextolen);
+  ret = atchops_rsa_encrypt(publickey, (const unsigned char *)plaintext, plaintextlen, ciphertext, ciphertextsize,
+                            &ciphertextlen);
   if (ret != 0) {
     printf("atchops_rsa_encrypt (failed): %d\n", ret);
     goto ret;
@@ -53,7 +52,6 @@ int main() {
   goto ret;
 
 ret: {
-  free(ciphertext);
   return ret;
 }
 }

--- a/packages/atclient/include/atclient/atbytes.h
+++ b/packages/atclient/include/atclient/atbytes.h
@@ -8,9 +8,9 @@
  * @brief Represents a buffer of bytes. Similar to atclient_atstr
  */
 typedef struct atclient_atbytes {
-  size_t len;    // the allocated length of the buffer
+  size_t size;    // the allocated length of the buffer
   unsigned char *bytes; // the buffer of bytes (pointer to the first byte in the buffer on the heap)
-  size_t olen;   // the output length of the buffer
+  size_t len;   // the output length of the buffer
 } atclient_atbytes;
 
 /**

--- a/packages/atclient/include/atclient/atkey.h
+++ b/packages/atclient/include/atclient/atkey.h
@@ -67,12 +67,12 @@ size_t atclient_atkey_strlen(const atclient_atkey *atkey);
  *
  * @param atkey atkey struct to read, assumed that this was already initialized via atclient_atkey_init
  * @param atkeystr buffer to write to, assumed that this was already allocated
- * @param atkeystrlen buffer allocated size
- * @param atkeystrolen the written (output) length of the atkeystr
+ * @param atkeystrsize buffer allocated size
+ * @param atkeystrlen the written (output) length of the atkeystr
  * @return int 0 on success
  */
-int atclient_atkey_to_string(const atclient_atkey *atkey, char *atkeystr, const size_t atkeystrlen,
-                             size_t *atkeystrolen);
+int atclient_atkey_to_string(const atclient_atkey *atkey, char *atkeystr, const size_t atkeystrsize,
+                             size_t *atkeystrlen);
 
 /**
  * @brief Populate an atkey struct representing a PublicKey AtKey with null terminated strings. An example of a Public

--- a/packages/atclient/include/atclient/atsign.h
+++ b/packages/atclient/include/atclient/atsign.h
@@ -12,25 +12,34 @@ typedef struct atclient_atsign {
 // Function to initialize an AtSign object
 int atclient_atsign_init(atclient_atsign *atsign, const char *atsign_str);
 
-// int atclient_atsign_populate_from_str(atclient_atsign *atsign, const char* atsign_str);
-
 // Function to free the memory used by an AtSign object
 void atclient_atsign_free(atclient_atsign *atsign);
+
 /**
- * @brief populates *atsign and *atsignolen with the atsign without the prefixed `@` symbol . Calling this function will
+ * @brief populates *atsign and *atsignlen with the atsign without the prefixed `@` symbol . Calling this function will
  * guarantee that *atsign is always withot a prefixed `@` symbol, whether if it started with one or not.
  *
  * @param atsign the atsign to populate (there will be no prefixed `@` symbol. example: @bob -> bob)
- * @param atsignlen the buffer size
- * @param atsignolen the actually written size
+ * @param atsignsize the buffer size
+ * @param atsignlen the actually written size of the atsign
  * @param originalatsign the atsign that supposedly has the prefixed `@` symbol you would like to remove
  * @param originalatsignlen the string length of the atsign being read
- * @return int 0 on success, 1 on if atsignlen is not large enough, 2 on if the originalatsignlen length passed is <= 0.
+ * @return int 0 on success, 1 on if atsignsize is not large enough, 2 on if the originalatsignlen length passed is <= 0.
  */
-int atclient_atsign_without_at_symbol(char *atsign, const size_t atsignlen, size_t *atsignolen,
+int atclient_atsign_without_at_symbol(char *atsign, const size_t atsignsize, size_t *atsignlen,
                                       const char *originalatsign, const size_t originalatsignlen);
 
-int atclient_atsign_with_at_symbol(char *atsign, const size_t atsignlen, size_t *atsignolen,
+/**
+ * @brief populates *atsign and *atsignlen with the atsign with the prefixed `@` symbol. Calling this function will
+ *
+ * @param atsign the atsign buffer to populate
+ * @param atsignsize the buffer size
+ * @param atsignlen the actually written size of the atsign
+ * @param originalatsign the atsign that supposedly has the prefixed `@` symbol you would like to remove 
+ * @param originalatsignlen the string length of the atsign being read
+ * @return int 0 on success
+ */
+int atclient_atsign_with_at_symbol(char *atsign, const size_t atsignsize, size_t *atsignlen,
                                    const char *originalatsign, const size_t originalatsignlen);
 
 #endif

--- a/packages/atclient/include/atclient/atstr.h
+++ b/packages/atclient/include/atclient/atstr.h
@@ -7,19 +7,19 @@
  * @brief Represents a string that is allocated on the heap
  */
 typedef struct atclient_atstr {
-  size_t len;  // buffer length
+  size_t size;  // buffer length
   char *str;          // string
-  size_t olen; // output length (length of string)
+  size_t len; // output length (length of string)
 } atclient_atstr;
 
 /**
  * @brief Initialize an atstr
  *
  * @param atstr pointer to atstr to initialize
- * @param bufferlen length of buffer to allocate in bytes (recommended to use a number that is a power of 2). the
- * bufferlen is the length of the buffer generated. we do not add 1 for null terminator.
+ * @param buffersize length of buffer to allocate in bytes (recommended to use a number that is a power of 2). the
+ * buffersize is the length of the buffer generated. we do not add 1 for null terminator.
  */
-void atclient_atstr_init(atclient_atstr *atstr, const size_t bufferlen);
+void atclient_atstr_init(atclient_atstr *atstr, const size_t buffersize);
 
 /**
  * @brief initialize an atstr with a literal string
@@ -27,7 +27,7 @@ void atclient_atstr_init(atclient_atstr *atstr, const size_t bufferlen);
  * @param atstr the atstr struct to populate
  * @param str the string to set atstr to. best to use string literals here. (or a null-terminated string)
  */
-int atclient_atstr_init_literal(atclient_atstr *atstr, const size_t bufferlen, const char *format, ...);
+int atclient_atstr_init_literal(atclient_atstr *atstr, const size_t buffersize, const char *format, ...);
 
 /**
  * @brief set an atstr to an empty string
@@ -41,9 +41,9 @@ void atclient_atstr_reset(atclient_atstr *atstr);
  *
  * @param atstr the atstr struct to populate
  * @param str the string to set atstr to
- * @param len the length of the string
+ * @param size the length of the string
  */
-int atclient_atstr_set(atclient_atstr *atstr, const char *str, const size_t len);
+int atclient_atstr_set(atclient_atstr *atstr, const char *str, const size_t size);
 
 /**
  * @brief Set an atstr to a literal string, assumed to be null-terminated

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -46,12 +46,12 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
  * @param src the data to send
  * @param srclen the length of the data to send
  * @param recv the buffer to receive data
- * @param recvlen the length of the buffer to receive data
- * @param olen the length of the data received
+ * @param recvsize the length of the buffer to receive data
+ * @param recvlen the length of the data received (output)
  * @return int 0 on success, otherwise error
  */
 int atclient_connection_send(atclient_connection *ctx, const unsigned char *src, const size_t srclen,
-                             unsigned char *recv, const size_t recvlen, size_t *olen);
+                             unsigned char *recv, const size_t recvsize, size_t *recvlen);
 
 /**
  * @brief disconnect a connection

--- a/packages/atclient/include/atclient/metadata.h
+++ b/packages/atclient/include/atclient/metadata.h
@@ -243,12 +243,12 @@ void atclient_atkey_metadata_init(atclient_atkey_metadata *metadata);
  * @param metadata the metadata struct to populate
  * @param metadatastr the metadata string (usually taken from meta commands such as llookup:meta:<atkey> or
  * plookup:meta:<atkey<)
- * @param metadatastrlen the string length of the metadata string. Can be obtained from something like
+ * @param metadatastrsize the string length of the metadata string. Can be obtained from something like
  * strlen(metadatastr)
  * @return int 0 on success
  */
 int atclient_atkey_metadata_from_jsonstr(atclient_atkey_metadata *metadata, const char *metadatastr,
-                                         const size_t metadatastrlen);
+                                         const size_t metadatastrsize);
 /**
  * @brief Populates the metadata struct from a cJSON pointer. This function is good for debugging.
  *
@@ -262,12 +262,12 @@ void atclient_atkey_metadata_from_cjson_node(atclient_atkey_metadata *metadata, 
  *
  * @param metadata the metadata struct to convert to a string
  * @param metadatastr the buffer to write the metadata to
- * @param metadatastrlen the allocated length of the metadatastr buffer
- * @param metadatastrolen the length of the metadata string written to metadatastr once the operation is complete
+ * @param metadatastrsize the allocated length of the metadatastr buffer
+ * @param metadatastrlen the length of the metadata string written to metadatastr once the operation is complete
  * @return int 0 on success
  */
 int atclient_atkey_metadata_to_jsonstr(const atclient_atkey_metadata *metadata, char *metadatastr,
-                                       const size_t metadatastrlen, size_t *metadatastrolen);
+                                       const size_t metadatastrsize, size_t *metadatastrlen);
 
 size_t atclient_atkey_metadata_protocol_strlen(const atclient_atkey_metadata *metadata);
 /**
@@ -276,12 +276,12 @@ size_t atclient_atkey_metadata_protocol_strlen(const atclient_atkey_metadata *me
  *
  * @param metadata the metadata struct to read from
  * @param metadatastr the buffer to write the metadata to
- * @param metadatastrlen the allocated length of the metadatastr buffer
- * @param metadatastrolen the length of the metadata string written to metadatastr once the operation is complete
+ * @param metadatastrsize the allocated length of the metadatastr buffer
+ * @param metadatastrlen the length of the metadata string written to metadatastr once the operation is complete
  * @return int 0 on success
  */
 int atclient_atkey_metadata_to_protocol_str(const atclient_atkey_metadata *metadata, char *metadatastr,
-                                            const size_t metadatastrlen, size_t *metadatastrolen);
+                                            const size_t metadatastrsize, size_t *metadatastrlen);
 
 bool atclient_atkey_metadata_is_createdby_initialized(const atclient_atkey_metadata *metadata);
 bool atclient_atkey_metadata_is_updatedby_initialized(const atclient_atkey_metadata *metadata);

--- a/packages/atclient/include/atclient/stringutils.h
+++ b/packages/atclient/include/atclient/stringutils.h
@@ -9,12 +9,12 @@
  * @param string string to read from
  * @param stringlen the length of the string (use strlen(string) if it is null-terminated)
  * @param out the output buffer
- * @param outlen the size of the output buffer that you allocated
- * @param outolen the output length of the output buffer that is actually used
+ * @param outsize the size of the output buffer that you allocated
+ * @param outlen the output length of the output buffer that is actually used
  * @return int 0 on success, non-zero on failure
  */
 int atclient_stringutils_trim_whitespace(const char *string, const size_t stringlen, char *out,
-                                         const size_t outlen, size_t *outolen);
+                                         const size_t outsize, size_t *outlen);
 
 /**
  * @brief returns 1 (true) if the string starts with the prefix, 0 (false) otherwise

--- a/packages/atclient/src/atbytes.c
+++ b/packages/atclient/src/atbytes.c
@@ -9,27 +9,27 @@
 
 void atclient_atbytes_init(atclient_atbytes *atbytes, const size_t atbyteslen) {
   memset(atbytes, 0, sizeof(atclient_atbytes));
-  atbytes->len = atbyteslen;
-  atbytes->bytes = malloc(sizeof(unsigned char) * atbytes->len);
-  atbytes->olen = 0;
+  atbytes->size = atbyteslen;
+  atbytes->bytes = malloc(sizeof(unsigned char) * atbytes->size);
+  atbytes->len = 0;
 }
 
 void atclient_atbytes_reset(atclient_atbytes *atbytes) {
-  memset(atbytes->bytes, 0, sizeof(unsigned char) * atbytes->len);
-  atbytes->olen = 0;
+  memset(atbytes->bytes, 0, sizeof(unsigned char) * atbytes->size);
+  atbytes->len = 0;
 }
 
 int atclient_atbytes_set(atclient_atbytes *atbytes, const unsigned char *bytes, const size_t byteslen) {
   int ret = 1;
-  if (byteslen > atbytes->len) {
+  if (byteslen > atbytes->size) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                           "byteslen is greater than atbyteslen. byteslen: %lu, atbyteslen: %lu\n", byteslen,
-                          atbytes->len);
+                          atbytes->size);
     ret = 1;
     goto exit;
   }
   memcpy(atbytes->bytes, bytes, byteslen);
-  atbytes->olen = byteslen;
+  atbytes->len = byteslen;
   ret = 0;
   goto exit;
 exit: { return ret; }
@@ -37,21 +37,21 @@ exit: { return ret; }
 
 int atclient_atbytes_convert(atclient_atbytes *atbytes, const char *str, const size_t strlen) {
   int ret = 1;
-  if (strlen > atbytes->len) {
+  if (strlen > atbytes->size) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "strlen is greater than atbyteslen. strlen: %lu, atbyteslen: %lu\n", strlen, atbytes->len);
+                          "strlen is greater than atbyteslen. strlen: %lu, atbyteslen: %lu\n", strlen, atbytes->size);
     ret = 1;
     goto exit;
   }
   memcpy(atbytes->bytes, (unsigned char *)str, strlen);
-  atbytes->olen = strlen;
+  atbytes->len = strlen;
   ret = 0;
   goto exit;
 exit: { return ret; }
 }
 
 int atclient_atbytes_convert_atstr(atclient_atbytes *atbytes, const atclient_atstr atstr) {
-  int ret = atclient_atbytes_convert(atbytes, atstr.str, atstr.olen);
+  int ret = atclient_atbytes_convert(atbytes, atstr.str, atstr.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atbytes_convert failed");
     goto exit;

--- a/packages/atclient/src/atclient_delete.c
+++ b/packages/atclient/src/atclient_delete.c
@@ -17,34 +17,36 @@ int atclient_delete(atclient *atclient, const atclient_atkey *atkey) {
 
   char atkeystr[ATCLIENT_ATKEY_FULL_LEN];
   memset(atkeystr, 0, sizeof(char) * ATCLIENT_ATKEY_FULL_LEN);
-  size_t atkeystrolen = 0;
+  size_t atkeystrlen = 0;
 
-  unsigned char recv[4096] = {0};
-  size_t recvolen = 0;
+  const size_t recvsize = 4096;
+  unsigned char recv[4096];
+  memset(recv, 0, sizeof(unsigned char) * recvsize);
+  size_t recvlen = 0;
 
-  ret = atclient_atkey_to_string(atkey, atkeystr, ATCLIENT_ATKEY_FULL_LEN, &atkeystrolen);
+  ret = atclient_atkey_to_string(atkey, atkeystr, ATCLIENT_ATKEY_FULL_LEN, &atkeystrlen);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string: %d\n", ret);
     goto exit;
   }
 
-  ret = atclient_atstr_append(&cmdbuffer, "%.*s\n", (int)atkeystrolen, atkeystr);
+  ret = atclient_atstr_append(&cmdbuffer, "%.*s\n", (int)atkeystrlen, atkeystr);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_append: %d\n", ret);
     goto exit;
   }
 
-  ret = atclient_connection_send(&(atclient->secondary_connection), (unsigned char *)cmdbuffer.str, cmdbuffer.olen,
-                                 recv, 4096, &recvolen);
+  ret = atclient_connection_send(&(atclient->secondary_connection), (unsigned char *)cmdbuffer.str, cmdbuffer.len,
+                                 recv, 4096, &recvlen);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n", ret);
     goto exit;
   }
 
-  if (!atclient_stringutils_starts_with((char *)recv, recvolen, "data:", 5)) {
+  if (!atclient_stringutils_starts_with((char *)recv, recvlen, "data:", 5)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "recv was \"%.*s\" and did not have prefix \"data:\"\n",
-                          (int)recvolen, recv);
+                          (int)recvlen, recv);
     goto exit;
   }
 

--- a/packages/atclient/src/atkeysfile.c
+++ b/packages/atclient/src/atkeysfile.c
@@ -141,19 +141,19 @@ int atclient_atkeysfile_write(const atclient_atkeysfile *atkeysfile, const char 
 
   // guarantee that all values are null terminated and are of correct length
   atclient_atstr aespkampublickey;
-  atclient_atstr_init(&aespkampublickey, atkeysfile->aespkampublickeystr.olen + 1);
+  atclient_atstr_init(&aespkampublickey, atkeysfile->aespkampublickeystr.len + 1);
 
   atclient_atstr aespkamprivatekey;
-  atclient_atstr_init(&aespkamprivatekey, atkeysfile->aespkamprivatekeystr.olen + 1);
+  atclient_atstr_init(&aespkamprivatekey, atkeysfile->aespkamprivatekeystr.len + 1);
 
   atclient_atstr aesencryptprivatekey;
-  atclient_atstr_init(&aesencryptprivatekey, atkeysfile->aesencryptprivatekeystr.olen + 1);
+  atclient_atstr_init(&aesencryptprivatekey, atkeysfile->aesencryptprivatekeystr.len + 1);
 
   atclient_atstr aesencryptpublickey;
-  atclient_atstr_init(&aesencryptpublickey, atkeysfile->aesencryptpublickeystr.olen + 1);
+  atclient_atstr_init(&aesencryptpublickey, atkeysfile->aesencryptpublickeystr.len + 1);
 
   atclient_atstr selfencryptionkey;
-  atclient_atstr_init(&selfencryptionkey, atkeysfile->selfencryptionkeystr.olen + 1);
+  atclient_atstr_init(&selfencryptionkey, atkeysfile->selfencryptionkeystr.len + 1);
 
   // create cJSON object
   cJSON *root = cJSON_CreateObject();
@@ -164,7 +164,7 @@ int atclient_atkeysfile_write(const atclient_atkeysfile *atkeysfile, const char 
   cJSON_AddStringToObject(root, "selfEncryptionKey", selfencryptionkey.str);
 
   ret =
-      atclient_atstr_set(&aespkampublickey, atkeysfile->aespkampublickeystr.str, atkeysfile->aespkampublickeystr.olen);
+      atclient_atstr_set(&aespkampublickey, atkeysfile->aespkampublickeystr.str, atkeysfile->aespkampublickeystr.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                           "atclient_atstr_set: %d | failed to set aespkampublickeystr\n", ret);
@@ -172,7 +172,7 @@ int atclient_atkeysfile_write(const atclient_atkeysfile *atkeysfile, const char 
   }
 
   ret = atclient_atstr_set(&aespkamprivatekey, atkeysfile->aespkamprivatekeystr.str,
-                           atkeysfile->aespkamprivatekeystr.olen);
+                           atkeysfile->aespkamprivatekeystr.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                           "atclient_atstr_set: %d | failed to set aespkamprivatekeystr\n", ret);
@@ -180,7 +180,7 @@ int atclient_atkeysfile_write(const atclient_atkeysfile *atkeysfile, const char 
   }
 
   ret = atclient_atstr_set(&aesencryptprivatekey, atkeysfile->aesencryptprivatekeystr.str,
-                           atkeysfile->aesencryptprivatekeystr.olen);
+                           atkeysfile->aesencryptprivatekeystr.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                           "atclient_atstr_set: %d | failed to set aesencryptprivatekeystr\n", ret);
@@ -188,7 +188,7 @@ int atclient_atkeysfile_write(const atclient_atkeysfile *atkeysfile, const char 
   }
 
   ret = atclient_atstr_set(&aesencryptpublickey, atkeysfile->aesencryptpublickeystr.str,
-                           atkeysfile->aesencryptpublickeystr.olen);
+                           atkeysfile->aesencryptpublickeystr.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                           "atclient_atstr_set: %d | failed to set aesencryptpublickeystr\n", ret);
@@ -196,7 +196,7 @@ int atclient_atkeysfile_write(const atclient_atkeysfile *atkeysfile, const char 
   }
 
   ret = atclient_atstr_set(&selfencryptionkey, atkeysfile->selfencryptionkeystr.str,
-                           atkeysfile->selfencryptionkeystr.olen);
+                           atkeysfile->selfencryptionkeystr.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                           "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n", ret);
@@ -204,9 +204,9 @@ int atclient_atkeysfile_write(const atclient_atkeysfile *atkeysfile, const char 
   }
 
   // check that atkeysfile has populated values
-  if (atkeysfile->aespkamprivatekeystr.olen == 0 || atkeysfile->aespkampublickeystr.olen == 0 ||
-      atkeysfile->aesencryptprivatekeystr.olen == 0 || atkeysfile->aesencryptpublickeystr.olen == 0 ||
-      atkeysfile->selfencryptionkeystr.olen == 0) {
+  if (atkeysfile->aespkamprivatekeystr.len == 0 || atkeysfile->aespkampublickeystr.len == 0 ||
+      atkeysfile->aesencryptprivatekeystr.len == 0 || atkeysfile->aesencryptpublickeystr.len == 0 ||
+      atkeysfile->selfencryptionkeystr.len == 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkeysfile has not been populated with values\n");
     ret = 1;
     goto exit;

--- a/packages/atclient/src/metadata.c
+++ b/packages/atclient/src/metadata.c
@@ -533,7 +533,7 @@ void atclient_atkey_metadata_from_cjson_node(atclient_atkey_metadata *metadata, 
 }
 
 int atclient_atkey_metadata_to_jsonstr(const atclient_atkey_metadata *metadata, char *metadatastr,
-                                       const size_t metadatastrlen, size_t *metadatastrolen) {
+                                       const size_t metadatastrsize, size_t *metadatastrlen) {
   int ret = 1;
 
   cJSON *root = cJSON_CreateObject();
@@ -660,15 +660,15 @@ int atclient_atkey_metadata_to_jsonstr(const atclient_atkey_metadata *metadata, 
     goto exit;
   }
 
-  if (strlen(jsonstr) > metadatastrlen) {
+  if (strlen(jsonstr) > metadatastrsize) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadatastr buffer too small: %lu > %lu\n", strlen(jsonstr),
-                 metadatastrlen);
+                 metadatastrsize);
     free(jsonstr);
     goto exit;
   }
 
   strcpy(metadatastr, jsonstr);
-  *metadatastrolen = strlen(jsonstr);
+  *metadatastrlen = strlen(jsonstr);
   free(jsonstr);
 
   ret = 0;
@@ -795,66 +795,66 @@ size_t atclient_atkey_metadata_isencrypted_strlen(const atclient_atkey_metadata 
 
 size_t atclient_atkey_metadata_datasignature_strlen(const atclient_atkey_metadata *metadata) {
   return 15 // :dataSignature:
-         + metadata->datasignature.olen;
+         + metadata->datasignature.len;
 }
 
 size_t atclient_atkey_metadata_sharedkeystatus_strlen(const atclient_atkey_metadata *metadata) {
   return 17 // :sharedKeyStatus:
-         + metadata->sharedkeystatus.olen;
+         + metadata->sharedkeystatus.len;
 }
 
 size_t atclient_atkey_metadata_sharedkeyenc_strlen(const atclient_atkey_metadata *metadata) {
   return 14 // :sharedKeyEnc:
-         + metadata->sharedkeyenc.olen;
+         + metadata->sharedkeyenc.len;
 }
 
 size_t atclient_atkey_metadata_pubkeyhash_strlen(const atclient_atkey_metadata *metadata) {
   return 6 // :hash:
-         + metadata->pubkeyhash.olen;
+         + metadata->pubkeyhash.len;
 }
 
 size_t atclient_atkey_metadata_pubkeyalgo_strlen(const atclient_atkey_metadata *metadata) {
   return 6 // :algo:
-         + metadata->pubkeyalgo.olen;
+         + metadata->pubkeyalgo.len;
 }
 
 size_t atclient_atkey_metadata_encoding_strlen(const atclient_atkey_metadata *metadata) {
   return 10 // :encoding:
-         + metadata->encoding.olen;
+         + metadata->encoding.len;
 }
 
 size_t atclient_atkey_metadata_enckeyname_strlen(const atclient_atkey_metadata *metadata) {
   return 12 // :encKeyName:
-         + metadata->enckeyname.olen;
+         + metadata->enckeyname.len;
 }
 
 size_t atclient_atkey_metadata_encalgo_strlen(const atclient_atkey_metadata *metadata) {
   return 9 // :encAlgo:
-         + metadata->encalgo.olen;
+         + metadata->encalgo.len;
 }
 
 size_t atclient_atkey_metadata_ivnonce_strlen(const atclient_atkey_metadata *metadata) {
   return 9 // :ivNonce:
-         + metadata->ivnonce.olen;
+         + metadata->ivnonce.len;
 }
 
 size_t atclient_atkey_metadata_skeenckeyname_strlen(const atclient_atkey_metadata *metadata) {
   return 15 // :skeEncKeyName:
-         + metadata->skeenckeyname.olen;
+         + metadata->skeenckeyname.len;
 }
 
 size_t atclient_atkey_metadata_skeencalgo_strlen(const atclient_atkey_metadata *metadata) {
   return 12 // :skeEncAlgo:
-         + metadata->skeencalgo.olen;
+         + metadata->skeencalgo.len;
 }
 
 int atclient_atkey_metadata_to_protocol_str(const atclient_atkey_metadata *metadata, char *metadatastr,
-                                            const size_t metadatastrlen, size_t *metadatastrolen) {
+                                            const size_t metadatastrsize, size_t *metadatastrlen) {
   int ret = 1;
   size_t pos = 0;
   size_t len = atclient_atkey_metadata_protocol_strlen(metadata);
-  if (len > metadatastrlen) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadatastr buffer too small: %lu > %lu\n", len, metadatastrlen);
+  if (len > metadatastrsize) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadatastr buffer too small: %lu > %lu\n", len, metadatastrsize);
     return 1;
   }
 
@@ -905,57 +905,57 @@ int atclient_atkey_metadata_to_protocol_str(const atclient_atkey_metadata *metad
 
   if (atclient_atkey_metadata_is_datasignature_initialized(metadata)) {
     sprintf(metadatastr + pos, ":dataSignature:%s", metadata->datasignature.str);
-    pos += 15 + metadata->datasignature.olen;
+    pos += 15 + metadata->datasignature.len;
   }
 
   if (atclient_atkey_metadata_is_sharedkeystatus_initialized(metadata)) {
     sprintf(metadatastr + pos, ":sharedKeyStatus:%s", metadata->sharedkeystatus.str);
-    pos += 17 + metadata->sharedkeystatus.olen;
+    pos += 17 + metadata->sharedkeystatus.len;
   }
 
   if (atclient_atkey_metadata_is_sharedkeyenc_initialized(metadata)) {
     sprintf(metadatastr + pos, ":sharedKeyEnc:%s", metadata->sharedkeyenc.str);
-    pos += 14 + metadata->sharedkeyenc.olen;
+    pos += 14 + metadata->sharedkeyenc.len;
   }
 
   if (atclient_atkey_metadata_is_pubkeyhash_initialized(metadata)) {
     sprintf(metadatastr + pos, ":hash:%s", metadata->pubkeyhash.str);
-    pos += 6 + metadata->pubkeyhash.olen;
+    pos += 6 + metadata->pubkeyhash.len;
   }
 
   if (atclient_atkey_metadata_is_pubkeyalgo_initialized(metadata)) {
     sprintf(metadatastr + pos, ":algo:%s", metadata->pubkeyalgo.str);
-    pos += 6 + metadata->pubkeyalgo.olen;
+    pos += 6 + metadata->pubkeyalgo.len;
   }
 
   if (atclient_atkey_metadata_is_encoding_initialized(metadata)) {
     sprintf(metadatastr + pos, ":encoding:%s", metadata->encoding.str);
-    pos += 10 + metadata->encoding.olen;
+    pos += 10 + metadata->encoding.len;
   }
 
   if (atclient_atkey_metadata_is_enckeyname_initialized(metadata)) {
     sprintf(metadatastr + pos, ":encKeyName:%s", metadata->enckeyname.str);
-    pos += 12 + metadata->enckeyname.olen;
+    pos += 12 + metadata->enckeyname.len;
   }
 
   if (atclient_atkey_metadata_is_encalgo_initialized(metadata)) {
     sprintf(metadatastr + pos, ":encAlgo:%s", metadata->encalgo.str);
-    pos += 9 + metadata->encalgo.olen;
+    pos += 9 + metadata->encalgo.len;
   }
 
   if (atclient_atkey_metadata_is_ivnonce_initialized(metadata)) {
     sprintf(metadatastr + pos, ":ivNonce:%s", metadata->ivnonce.str);
-    pos += 9 + metadata->ivnonce.olen;
+    pos += 9 + metadata->ivnonce.len;
   }
 
   if (atclient_atkey_metadata_is_skeenckeyname_initialized(metadata)) {
     sprintf(metadatastr + pos, ":skeEncKeyName:%s", metadata->skeenckeyname.str);
-    pos += 15 + metadata->skeenckeyname.olen;
+    pos += 15 + metadata->skeenckeyname.len;
   }
 
   if (atclient_atkey_metadata_is_skeencalgo_initialized(metadata)) {
     sprintf(metadatastr + pos, ":skeEncAlgo:%s", metadata->skeencalgo.str);
-    pos += 12 + metadata->skeencalgo.olen;
+    pos += 12 + metadata->skeencalgo.len;
   }
 
   if (strlen(metadatastr) != len) {
@@ -965,7 +965,7 @@ int atclient_atkey_metadata_to_protocol_str(const atclient_atkey_metadata *metad
     goto exit;
   }
 
-  *metadatastrolen = len;
+  *metadatastrlen = len;
 
   ret = 0;
   goto exit;

--- a/packages/atclient/src/notification.c
+++ b/packages/atclient/src/notification.c
@@ -161,12 +161,12 @@ int atclient_notify(atclient *ctx, atclient_notify_params *params) {
   off += 2;
 
   // Step 4 send the command
-  const size_t recvlen = 4096;
-  unsigned char recv[recvlen];
-  memset(recv, 0, sizeof(unsigned char) * recvlen);
-  size_t recvolen = 0;
+  const size_t recvsize = 4096;
+  unsigned char recv[recvsize];
+  memset(recv, 0, sizeof(unsigned char) * recvsize);
+  size_t recvlen = 0;
 
-  res = atclient_connection_send(&ctx->secondary_connection, (const unsigned char *)cmd, off, recv, recvlen, &recvolen);
+  res = atclient_connection_send(&ctx->secondary_connection, (const unsigned char *)cmd, off, recv, recvsize, &recvlen);
   if (res != 0) {
     atlogger_log("atclient | notify", ATLOGGER_LOGGING_LEVEL_WARN,
                           "atclient_connection_send failed with code %d\n", res);

--- a/packages/atclient/src/stringutils.c
+++ b/packages/atclient/src/stringutils.c
@@ -4,8 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-int atclient_stringutils_trim_whitespace(const char *string, const size_t stringlen, char *out, const size_t outlen,
-                                         size_t *outolen) {
+int atclient_stringutils_trim_whitespace(const char *string, const size_t stringlen, char *out, const size_t outsize,
+                                         size_t *outlen) {
   int ret = 1;
 
   if (string == NULL) {
@@ -29,15 +29,15 @@ int atclient_stringutils_trim_whitespace(const char *string, const size_t string
     end--;
   }
 
-  *outolen = end - start + 1;
+  *outlen = end - start + 1;
 
-  if (*outolen >= outlen) {
+  if (*outlen >= outsize) {
     ret = 1;
     goto exit;
   }
 
-  strncpy(out, start, *outolen);
-  out[*outolen] = '\0';
+  strncpy(out, start, *outlen);
+  out[*outlen] = '\0';
 
   ret = 0;
   goto exit;

--- a/packages/atclient/tests/test_atkey_from_string.c
+++ b/packages/atclient/tests/test_atkey_from_string.c
@@ -66,13 +66,13 @@ static int test1a() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "publickey", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "publickey", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not publickey, it is \"%s\"\n",
                           atkey.name.str);
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@bob", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@bob", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @bob, it is \"%s\"\n",
                           atkey.sharedby.str);
     goto exit;
@@ -120,30 +120,30 @@ static int test1b() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "publickey", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "publickey", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not publickey, it is \"%s\"\n",
                           atkey.name.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n",
                           atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.namespacestr.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.olen is not 0, it is %lu\n",
-                          atkey.namespacestr.olen);
+  if (atkey.namespacestr.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.len is not 0, it is %lu\n",
+                          atkey.namespacestr.len);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.sharedwith.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.olen is not 0, it is %lu\n",
-                          atkey.sharedwith.olen);
+  if (atkey.sharedwith.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
+                          atkey.sharedwith.len);
     ret = 1;
     goto exit;
   }
@@ -192,27 +192,27 @@ static int test1c() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "name", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "name", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is \"%s\"\n", atkey.name.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@jeremy", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@jeremy", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @jeremy, it is \"%s\"\n",
                           atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.sharedwith.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.olen is not 0, it is %lu\n",
-                          atkey.sharedwith.olen);
+  if (atkey.sharedwith.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
+                          atkey.sharedwith.len);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.olen) != 0) {
+  if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
                           atkey.namespacestr.str);
     ret = 1;
@@ -262,29 +262,29 @@ static int test1d() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "name", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "name", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is \"%s\"\n", atkey.name.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@jeremy", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@jeremy", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @jeremy, it is \"%s\"\n",
                           atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.sharedwith.olen != 0 && strlen(atkey.sharedwith.str) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.olen is not 0, it is %lu\n",
-                          atkey.sharedwith.olen);
+  if (atkey.sharedwith.len != 0 && strlen(atkey.sharedwith.str) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
+                          atkey.sharedwith.len);
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.str is not empty, it is \"%s\"\n",
                           atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.olen) != 0) {
+  if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
                           atkey.namespacestr.str);
     ret = 1;
@@ -335,28 +335,28 @@ static int test2a() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "name.wavi", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "name.wavi", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name.wavi, it is \"%s\"\n",
                           atkey.name.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@bob", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@bob", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @bob, it is \"%s\"\n",
                           atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedwith.str, "@alice", atkey.sharedwith.olen) != 0) {
+  if (strncmp(atkey.sharedwith.str, "@alice", atkey.sharedwith.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith is not @alice, it is \"%s\"\n",
                           atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.olen) != 0) {
+  if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
                           atkey.namespacestr.str);
     ret = 1;
@@ -406,29 +406,29 @@ static int test2b() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "name", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "name", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is \"%s\"\n", atkey.name.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n",
                           atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedwith.str, "@bob", atkey.sharedwith.olen) != 0) {
+  if (strncmp(atkey.sharedwith.str, "@bob", atkey.sharedwith.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith is not @bob, it is \"%s\"\n",
                           atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.namespacestr.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.olen is not 0, it is %lu\n",
-                          atkey.namespacestr.olen);
+  if (atkey.namespacestr.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.len is not 0, it is %lu\n",
+                          atkey.namespacestr.len);
     ret = 1;
     goto exit;
   }
@@ -473,29 +473,29 @@ static int test2c() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "name", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "name", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is \"%s\"\n", atkey.name.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n",
                           atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedwith.str, "@bob", atkey.sharedwith.olen) != 0) {
+  if (strncmp(atkey.sharedwith.str, "@bob", atkey.sharedwith.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith is not @bob, it is \"%s\"\n",
                           atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.namespacestr.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.olen is not 0, it is %lu\n",
-                          atkey.namespacestr.olen);
+  if (atkey.namespacestr.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.len is not 0, it is %lu\n",
+                          atkey.namespacestr.len);
     ret = 1;
     goto exit;
   }
@@ -543,27 +543,27 @@ static int test2d() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "name", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "name", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is \"%s\"\n", atkey.name.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n",
                           atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedwith.str, "@bob", atkey.sharedwith.olen) != 0) {
+  if (strncmp(atkey.sharedwith.str, "@bob", atkey.sharedwith.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith is not @bob, it is \"%s\"\n",
                           atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.olen) != 0) {
+  if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
                           atkey.namespacestr.str);
     ret = 1;
@@ -613,30 +613,30 @@ static int test3a() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "_lastnotificationid", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "_lastnotificationid", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not _lastnotificationid, it is \"%s\"\n",
                           atkey.name.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@alice123_4😘", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@alice123_4😘", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice123_4😘, it is \"%s\"\n",
                           atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.sharedwith.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.olen is not 0, it is %lu\n",
-                          atkey.sharedwith.olen);
+  if (atkey.sharedwith.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
+                          atkey.sharedwith.len);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.namespacestr.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.olen is not 0, it is %lu\n",
-                          atkey.namespacestr.olen);
+  if (atkey.namespacestr.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.len is not 0, it is %lu\n",
+                          atkey.namespacestr.len);
     ret = 1;
     goto exit;
   }
@@ -685,31 +685,31 @@ static int test4a() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "name", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "name", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is \"%s\"\n", atkey.name.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n",
                           atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.sharedwith.olen != 0 && strlen(atkey.sharedwith.str) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.olen is not 0, it is %lu\n",
-                          atkey.sharedwith.olen);
+  if (atkey.sharedwith.len != 0 && strlen(atkey.sharedwith.str) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
+                          atkey.sharedwith.len);
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.str is not empty, it is \"%s\"\n",
                           atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.namespacestr.olen != 0 && strlen(atkey.namespacestr.str) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.olen is not 0, it is %lu\n",
-                          atkey.namespacestr.olen);
+  if (atkey.namespacestr.len != 0 && strlen(atkey.namespacestr.str) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.len is not 0, it is %lu\n",
+                          atkey.namespacestr.len);
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.str is not empty, it is \"%s\"\n",
                           atkey.namespacestr.str);
     ret = 1;
@@ -759,29 +759,29 @@ static int test4b() {
     goto exit;
   }
 
-  if (strncmp(atkey.name.str, "name", atkey.name.olen) != 0) {
+  if (strncmp(atkey.name.str, "name", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is \"%s\"\n", atkey.name.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.sharedby.str, "@jeremy_0", atkey.sharedby.olen) != 0) {
+  if (strncmp(atkey.sharedby.str, "@jeremy_0", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @jeremy_0, it is \"%s\"\n",
                           atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
-  if (atkey.sharedwith.olen != 0 && strlen(atkey.sharedwith.str) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.olen is not 0, it is %lu\n",
-                          atkey.sharedwith.olen);
+  if (atkey.sharedwith.len != 0 && strlen(atkey.sharedwith.str) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
+                          atkey.sharedwith.len);
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.str is not empty, it is \"%s\"\n",
                           atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
-  if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.olen) != 0) {
+  if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
                           atkey.namespacestr.str);
     ret = 1;

--- a/packages/atclient/tests/test_atkey_metadata.c
+++ b/packages/atclient/tests/test_atkey_metadata.c
@@ -61,9 +61,9 @@ static int test_atkey_metadata_from_jsonstr() {
     goto exit;
   }
 
-  if (metadata.createdat.olen <= 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.createdat.olen <= 0: %lu",
-                          metadata.createdat.olen);
+  if (metadata.createdat.len <= 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.createdat.len <= 0: %lu",
+                          metadata.createdat.len);
     ret = 1;
     goto exit;
   }
@@ -75,9 +75,9 @@ static int test_atkey_metadata_from_jsonstr() {
     goto exit;
   }
 
-  if (metadata.updatedat.olen <= 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.updatedat.olen <= 0: %lu",
-                          metadata.updatedat.olen);
+  if (metadata.updatedat.len <= 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.updatedat.len <= 0: %lu",
+                          metadata.updatedat.len);
     ret = 1;
     goto exit;
   }
@@ -89,9 +89,9 @@ static int test_atkey_metadata_from_jsonstr() {
     goto exit;
   }
 
-  if (metadata.expiresat.olen <= 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.expiresat.olen <= 0: %lu",
-                          metadata.expiresat.olen);
+  if (metadata.expiresat.len <= 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.expiresat.len <= 0: %lu",
+                          metadata.expiresat.len);
     ret = 1;
     goto exit;
   }
@@ -103,9 +103,9 @@ static int test_atkey_metadata_from_jsonstr() {
     goto exit;
   }
 
-  if (metadata.status.olen != strlen("active")) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.status.olen != strlen(active): %lu",
-                          metadata.status.olen);
+  if (metadata.status.len != strlen("active")) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.status.len != strlen(active): %lu",
+                          metadata.status.len);
     ret = 1;
     goto exit;
   }
@@ -146,91 +146,91 @@ static int test_atkey_metadata_from_jsonstr() {
     goto exit;
   }
 
-  if (metadata.availableat.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.availableat.olen != 0: %lu",
-                          metadata.availableat.olen);
+  if (metadata.availableat.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.availableat.len != 0: %lu",
+                          metadata.availableat.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.refreshat.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.refreshat.olen != 0: %lu",
-                          metadata.refreshat.olen);
+  if (metadata.refreshat.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.refreshat.len != 0: %lu",
+                          metadata.refreshat.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.datasignature.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.datasignature.olen != 0: %lu",
-                          metadata.datasignature.olen);
+  if (metadata.datasignature.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.datasignature.len != 0: %lu",
+                          metadata.datasignature.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.sharedkeystatus.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.sharedkeystatus.olen != 0: %lu",
-                          metadata.sharedkeystatus.olen);
+  if (metadata.sharedkeystatus.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.sharedkeystatus.len != 0: %lu",
+                          metadata.sharedkeystatus.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.sharedkeyenc.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.sharedkeyenc.olen != 0: %lu",
-                          metadata.sharedkeyenc.olen);
+  if (metadata.sharedkeyenc.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.sharedkeyenc.len != 0: %lu",
+                          metadata.sharedkeyenc.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.pubkeyhash.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.pubkeyhash.olen != 0: %lu",
-                          metadata.pubkeyhash.olen);
+  if (metadata.pubkeyhash.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.pubkeyhash.len != 0: %lu",
+                          metadata.pubkeyhash.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.pubkeyalgo.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.pubkeyalgo.olen != 0: %lu",
-                          metadata.pubkeyalgo.olen);
+  if (metadata.pubkeyalgo.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.pubkeyalgo.len != 0: %lu",
+                          metadata.pubkeyalgo.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.encoding.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.encoding.olen != 0: %lu",
-                          metadata.encoding.olen);
+  if (metadata.encoding.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.encoding.len != 0: %lu",
+                          metadata.encoding.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.enckeyname.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.enckeyname.olen != 0: %lu",
-                          metadata.enckeyname.olen);
+  if (metadata.enckeyname.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.enckeyname.len != 0: %lu",
+                          metadata.enckeyname.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.encalgo.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.encalgo.olen != 0: %lu", metadata.encalgo.olen);
+  if (metadata.encalgo.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.encalgo.len != 0: %lu", metadata.encalgo.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.ivnonce.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.ivnonce.olen != 0: %lu", metadata.ivnonce.olen);
+  if (metadata.ivnonce.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.ivnonce.len != 0: %lu", metadata.ivnonce.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.skeenckeyname.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.skeenckeyname.olen != 0: %lu",
-                          metadata.skeenckeyname.olen);
+  if (metadata.skeenckeyname.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.skeenckeyname.len != 0: %lu",
+                          metadata.skeenckeyname.len);
     ret = 1;
     goto exit;
   }
 
-  if (metadata.skeencalgo.olen != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.skeencalgo.olen != 0: %lu",
-                          metadata.skeencalgo.olen);
+  if (metadata.skeencalgo.len != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.skeencalgo.len != 0: %lu",
+                          metadata.skeencalgo.len);
     ret = 1;
     goto exit;
   }
@@ -258,29 +258,29 @@ static int test_atkey_metadata_to_protocolstr() {
   atclient_atkey_metadata_set_iscached(&metadata, true);
   atclient_atkey_metadata_set_ivnonce(&metadata, "abcdefghijk", strlen("abcdefghijk"));
 
-  const size_t protocolfragmentlen = 1024;
-  char protocolfragment[protocolfragmentlen];
-  memset(protocolfragment, 0, sizeof(char) * protocolfragmentlen);
-  size_t protocolfragmentolen = 0;
+  const size_t protocolfragmentsize = 1024;
+  char protocolfragment[protocolfragmentsize];
+  memset(protocolfragment, 0, sizeof(char) * protocolfragmentsize);
+  size_t protocolfragmentlen = 0;
 
   ret =
-      atclient_atkey_metadata_to_protocol_str(&metadata, protocolfragment, protocolfragmentlen, &protocolfragmentolen);
+      atclient_atkey_metadata_to_protocol_str(&metadata, protocolfragment, protocolfragmentsize, &protocolfragmentlen);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_metadata_to_protocolstr failed");
     goto exit;
   }
 
-  if (strlen(protocolfragment) != protocolfragmentolen) {
+  if (strlen(protocolfragment) != protocolfragmentlen) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "strlen(protocolfragment) != protocolfragmentolen: %lu != %lu", strlen(protocolfragment),
-                          protocolfragmentolen);
+                          "strlen(protocolfragment) != protocolfragmentlen: %lu != %lu", strlen(protocolfragment),
+                          protocolfragmentlen);
     ret = 1;
     goto exit;
   }
 
-  if (protocolfragmentolen != expectedlen) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "protocolfragmentolen != expectedlen: %lu != %lu",
-                          protocolfragmentolen, expectedlen);
+  if (protocolfragmentlen != expectedlen) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "protocolfragmentlen != expectedlen: %lu != %lu",
+                          protocolfragmentlen, expectedlen);
     ret = 1;
     goto exit;
   }
@@ -307,10 +307,10 @@ static int test_atkey_metadata_to_jsonstr() {
   atclient_atkey_metadata metadata;
   atclient_atkey_metadata_init(&metadata);
 
-  const size_t jsonstrlen = 4096;
-  char jsonstr[jsonstrlen];
-  memset(jsonstr, 0, sizeof(char) * jsonstrlen);
-  size_t jsonstrlenout = 0;
+  const size_t jsonstrsize = 4096;
+  char jsonstr[jsonstrsize];
+  memset(jsonstr, 0, sizeof(char) * jsonstrsize);
+  size_t jsonstrlen = 0;
 
   ret = atclient_atkey_metadata_from_jsonstr(&metadata, TEST_ATKEY_METADATA_FROM_JSONSTR,
                                              strlen(TEST_ATKEY_METADATA_FROM_JSONSTR));
@@ -319,7 +319,7 @@ static int test_atkey_metadata_to_jsonstr() {
     goto exit;
   }
 
-  ret = atclient_atkey_metadata_to_jsonstr(&metadata, jsonstr, jsonstrlen, &jsonstrlenout);
+  ret = atclient_atkey_metadata_to_jsonstr(&metadata, jsonstr, jsonstrsize, &jsonstrlen);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_metadata_to_jsonstr failed");
     goto exit;

--- a/packages/atclient/tests/test_atkey_to_string.c
+++ b/packages/atclient/tests/test_atkey_to_string.c
@@ -62,7 +62,7 @@ static int test1a() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(&atkey, string.str, string.len, &string.olen);
+  ret = atclient_atkey_to_string(&atkey, string.str, string.size, &string.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
     goto exit;
@@ -112,7 +112,7 @@ static int test1b() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(&atkey, string.str, string.len, &string.olen);
+  ret = atclient_atkey_to_string(&atkey, string.str, string.size, &string.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
     goto exit;
@@ -164,7 +164,7 @@ static int test1c() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(&atkey, string.str, string.len, &string.olen);
+  ret = atclient_atkey_to_string(&atkey, string.str, string.size, &string.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
     goto exit;
@@ -217,7 +217,7 @@ static int test1d() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(&atkey, string.str, string.len, &string.olen);
+  ret = atclient_atkey_to_string(&atkey, string.str, string.size, &string.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
     goto exit;
@@ -274,7 +274,7 @@ static int test2a() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(&atkey, string.str, string.len, &string.olen);
+  ret = atclient_atkey_to_string(&atkey, string.str, string.size, &string.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
     goto exit;
@@ -318,7 +318,7 @@ static int test2b() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(&atkey, string.str, string.len, &string.olen);
+  ret = atclient_atkey_to_string(&atkey, string.str, string.size, &string.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
     goto exit;
@@ -369,15 +369,15 @@ static int test2c() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(&atkey, string.str, string.len, &string.olen);
+  ret = atclient_atkey_to_string(&atkey, string.str, string.size, &string.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
     goto exit;
   }
 
   // namespace should be empty
-  if (atkey.namespacestr.olen > 0 || strlen(atkey.namespacestr.str) > 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "namespacestr.olen > 0: %d\n", atkey.namespacestr.olen);
+  if (atkey.namespacestr.len > 0 || strlen(atkey.namespacestr.str) > 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "namespacestr.len > 0: %d\n", atkey.namespacestr.len);
     ret = 1;
     goto exit;
   }
@@ -434,7 +434,7 @@ static int test2d() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(&atkey, string.str, string.len, &string.olen);
+  ret = atclient_atkey_to_string(&atkey, string.str, string.size, &string.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
     goto exit;
@@ -479,15 +479,15 @@ static int test3a() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(&atkey, string.str, string.len, &string.olen);
+  ret = atclient_atkey_to_string(&atkey, string.str, string.size, &string.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
     goto exit;
   }
 
-  if (atkey.namespacestr.olen > 0 || strlen(atkey.namespacestr.str) > 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "namespacestr.olen > 0: %d or strlen(%s) > 0\n",
-                          atkey.namespacestr.olen, atkey.namespacestr.str);
+  if (atkey.namespacestr.len > 0 || strlen(atkey.namespacestr.str) > 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "namespacestr.len > 0: %d or strlen(%s) > 0\n",
+                          atkey.namespacestr.len, atkey.namespacestr.str);
     ret = 1;
     goto exit;
   }
@@ -531,15 +531,15 @@ static int test4a() {
     goto exit;
   }
 
-  ret = atclient_atkey_to_string(&atkey, string.str, string.len, &string.olen);
+  ret = atclient_atkey_to_string(&atkey, string.str, string.size, &string.len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_to_string failed\n");
     goto exit;
   }
 
-  if (atkey.namespacestr.olen > 0 || strlen(atkey.namespacestr.str) > 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "namespacestr.olen > 0: %d or strlen(%s) > 0\n",
-                          atkey.namespacestr.olen, atkey.namespacestr.str);
+  if (atkey.namespacestr.len > 0 || strlen(atkey.namespacestr.str) > 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "namespacestr.len > 0: %d or strlen(%s) > 0\n",
+                          atkey.namespacestr.len, atkey.namespacestr.str);
     ret = 1;
     goto exit;
   }

--- a/packages/atclient/tests/test_stringutils.c
+++ b/packages/atclient/tests/test_stringutils.c
@@ -11,20 +11,20 @@ int main() {
 
   atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
 
-  const size_t outlen = 4096;
-  char *out = (char *)malloc(sizeof(char) * outlen);
-  memset(out, 0, sizeof(char) * outlen);
-  size_t outolen = 0;
+  const size_t outsize = 4096;
+  char *out = (char *)malloc(sizeof(char) * outsize);
+  memset(out, 0, sizeof(char) * outsize);
+  size_t outlen = 0;
 
-  const size_t stringlen = 4096;
-  char *string = (char *)malloc(sizeof(char) * stringlen);
-  memset(string, 0, sizeof(char) * stringlen);
+  const size_t stringsize = 4096;
+  char *string = (char *)malloc(sizeof(char) * stringsize);
+  memset(string, 0, sizeof(char) * stringsize);
   strcpy(string, "@bob");
 
-  const size_t tokenslen = 64;
-  char *tokens[tokenslen];
-  memset(tokens, 0, sizeof(char *) * tokenslen); // set all pointers to NULL (0
-  size_t tokensolen = 0;
+  const size_t tokenssize = 64;
+  char *tokens[tokenssize];
+  memset(tokens, 0, sizeof(char *) * tokenssize); // set all pointers to NULL (0
+  size_t tokenslen = 0;
 
   int startswith;
 
@@ -69,7 +69,7 @@ int main() {
   // 3. trim whitespace and newline
   strcpy(string, "   scan jeremy_0\n ");
   const char *expectedresult = "scan jeremy_0";
-  ret = atclient_stringutils_trim_whitespace(string, strlen(string), out, outlen, &outolen);
+  ret = atclient_stringutils_trim_whitespace(string, strlen(string), out, outsize, &outlen);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_stringutils_trim_whitespace: %d | %s\n", ret,
                           string);


### PR DESCRIPTION
closes #140 

**- What I did**
- Refactored `len` to `size` and `olen` to `len`

**- How I did it**
- With refactor tool in VSCode

**- How to verify it**
- Tests pass
