### PR TITLE
docs: building source docs and misc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,47 @@
 
 ## Packages
 
-- [atchops](./packages/atchops/README.md) stands for cryptographic and hashing operations catered for the atProtocol, uses [MbedTLS crypto](https://github.com/Mbed-TLS/mbedtls) as a dependency.
+- [atchops](./packages/atchops/README.md) stands for "Cryptographic and Hashing Operations" catered for the atProtocol. atchops uses [MbedTLS crypto](https://github.com/Mbed-TLS/mbedtls) and other MbedTLS crypto libraries as a dependency.
 - [atclient](./packages/atclient/README.md) implements the atProtocol and will be the core dependency for most applications. atclient depends on [atchops](./packages/atchops/README.md) and [MbedTLS](https://github.com/Mbed-TLS/mbedtls).
 - [atclient_espidf](./packages/atclient_espidf/README.md) is a package for helping you build atclient for ESP-IDF (Espressif IoT Development Framework) based projects.
+- [atlogger](./packages/atlogger/README.md) is a tiny logging package.
+
+## Building Source
+
+Learn how to build atsdk from source code to be used as a library in your projects.
+
+### Installing on Linux/MacOS
+
+1. Get ahold of the source code either via git clone or from downloading the source from our releases:
+
+```sh
+git clone https://github.com/atsign-foundation/at_c.git
+cd at_c
+```
+
+2. CMake configure
+
+```sh
+cmake -S . -B build
+```
+
+3. Install
+
+This will run the install step and install the static libraries and include headers on your system. You may need to use `sudo`.
+
+```sh
+cmake --build build --target install
+```
+
+4. Building the source code will allow you to use the `atclient` library in your own CMake projects:
+
+```cmake
+# myproj is a target in your CMake project that depends on atsdk
+find_package(atsdk REQUIRED CONFIG)
+target_link_libraries(myproj PRIVATE atsdk::atclient)
+```
+
+The target `atsdk::atclient` is the atclient library that you can link to your project. It includes `atchops` and `atlogger` as dependencies already with it.
 
 ## Examples
 

--- a/packages/atchops/README.md
+++ b/packages/atchops/README.md
@@ -6,8 +6,6 @@
 
 ### Installing on Linux/MacOS
 
-Check out the [install.sh](./tools//install.sh) as an example.
-
 To build atchops standalone:
 
 1. Get ahold of the source code either via git clone or from downloading the source from our releases:
@@ -23,19 +21,7 @@ cd at_c/packages/atchops
 cmake -S . -B build
 ```
 
-Alternatively, if you have installed MbedTLS and from source already, you can avoid fetching it everytime with `ATCHOPS_FETCH_MBEDTLS=OFF`. Doing this drastically reduces the time it takes to configure the project:
-
-```sh
-cmake -S . -B build -DATCHOPS_FETCH_MBEDTLS=OFF
-```
-
-If you would not like the static libraries and include header files to be installed on your system directly, you can specify a custom install directory with `-DCMAKE_INSTALL_PREFIX=/path/to/install`:
-
-Example:
-
-```sh
-cmake -S . -B build -DCMAKE_INSTALL_PREFIX=./install
-```
+If you would not like the static libraries and include header files to be installed on your system directly, you can specify a custom install directory with `-DCMAKE_INSTALL_PREFIX=/path/to/install`. For example: `cmake -S . -B build -DCMAKE_INSTALL_PREFIX=./install`
 
 The command above will install the static libraries and include header files in the `install` directory in the root of the project. Installing without the `-DCMAKE_INSTALL_PREFIX=./install` flag in the configure step will install the static libraries, include headers, and any binaries in your system directories, such as `/usr/local/lib` and `/usr/local/include`.
 
@@ -67,6 +53,7 @@ Example of the install directory structure:
 
 3. Install.
 
+This will run the install step and install the static libraries and include headers on your system.
 
 ```sh
 cmake --build build --target install
@@ -79,8 +66,6 @@ You may need to use `sudo` depending on your system.
 ## Running Tests
 
 ### Running Tests on Linux/MacOS
-
-Check out the [run_ctest.sh](./tools/run_ctest.sh) as an example.
 
 1. Run the CMake configure step with `-DATCHOPS_BUILD_TESTS=ON` flag set to ON
 
@@ -97,18 +82,12 @@ cmake --build build --target all
 
 ```sh
 cd build/tests
-ctest --output-on-failure
+ctest --output-on-failure --timeout 10
 ```
 
 ## Contributing
 
 When creating source files, header files, or tests to certain packages, please follow the documentation in their according README files.
-
-### Creating Tests
-
-If you want to add a test in atclient, simply add a `test_*.c` file in the `tests` directory. CMake will automatically detect it and add it to the test suite. Ensure that the test file is named `test_*.c` or else it will not be detected.
-
-Ensure the file has a `int main(int argc, char **argv)` function and returns 0 on success and not 0 on failure.
 
 ### Adding New Source Files
 
@@ -131,3 +110,9 @@ target_sources(atchops PRIVATE
 Simply add the header inside of the `include/` directory. CMake will automatically detect it and add it to the include path.
 
 If it is added in a subdirectory (like `include/atchops/`), then the include path will be `atchops/` (e.g. `#include <atchops/new_header.h>`). If it is added in the root of the `include/` directory, then the include path will be the root of the `include/` directory (e.g. `#include <new_header.h>`).
+
+### Adding New Tests
+
+If you want to add a test in atclient, simply add a `test_*.c` file in the `tests` directory. CMake will automatically detect it and add it to the test suite. Ensure that the test file is named `test_*.c` or else it will not be detected.
+
+Ensure the file has a `int main(int argc, char **argv)` function and returns 0 on success and not 0 on failure.

--- a/packages/atclient/README.md
+++ b/packages/atclient/README.md
@@ -26,9 +26,9 @@ To build the source code you will need to have [CMake](https://cmake.org/) insta
 
 ### Installing on Linux/MacOS
 
-Check out the [run_ctest.sh](./tools/run_ctest.sh) as an example.
-
 1. Get ahold of the source code either via git clone or from downloading the source from our releases:
+
+Git clone sample:
 
 ```sh
 git clone https://github.com/atsign-foundation/at_c.git
@@ -37,17 +37,15 @@ cd at_c/packages/atclient
 
 2. CMake configure
 
+This is the configure step. -S specifies the source directory and -B specifies the build directory. The `.` specifies the current directory.
+
 ```sh
 cmake -S . -B build
 ```
 
-Alternatively, if you would not like the static libraries and include header files to be installed on your system directly, you can specify a custom install directory with `-DCMAKE_INSTALL_PREFIX=/path/to/install`:
+Alternatively, if you would not like the static libraries and include header files to be installed on your system directly, you can specify a custom install directory with `-DCMAKE_INSTALL_PREFIX=/path/to/install`.
 
-Example:
-
-```sh
-cmake -S . -B build -DCMAKE_INSTALL_PREFIX=./install
-```
+For example: `cmake -S . -B build -DCMAKE_INSTALL_PREFIX=./install`.
 
 The command above will install the static libraries and include header files in the `install` directory in the root of the project. Installing without the `-DCMAKE_INSTALL_PREFIX=./install` flag in the configure step will install the static libraries, include headers, and any binaries in your system directories, such as `/usr/local/lib` and `/usr/local/include`.
 
@@ -87,6 +85,8 @@ This is the same as doing `cd build && make install` if you are using something 
 
 You may need to use `sudo` depending on your system.
 
+This step will install the static libraries and include headers in your system directories, such as `/usr/local/lib` and `/usr/local/include`. But if you specified `-DCMAKE_INSTALL_PREFIX=./install`, it will install the static libraries and include headers in the `install` directory in the root of the project.
+
 4. Building the source code will allow you to use the `atclient` library in your own CMake projects:
 
 ```cmake
@@ -111,8 +111,6 @@ You may also specify a generator in the configure step with something like: `-G 
 
 ### Running Tests on Linux/MacOS
 
-Check out the [run_ctest.sh](./tools/run_ctest.sh) as an example.
-
 1. Get ahold of the source code either via git clone or from downloading the source from our releases:
 
 ```sh
@@ -126,7 +124,7 @@ cd at_c/packages/atclient
 cmake -S . -B build -DATCLIENT_BUILD_TESTS=ON
 ```
 
-3. Build (target is all by default)
+3. Build (target is all by default, so the following command will build all targets)
 
 ```sh
 cmake --build build
@@ -144,15 +142,11 @@ cd build/tests && ctest -V --timeout 10
 
 `-V` will output any stdout lines from the tests.
 
+You may also do something like `ctest --output-on-failure --test-dir build`, where `--output-on-failure` will output any stdout lines from the tests if they fail and `--test-dir build` specifies the directory where the tests are located (to avoid having to do `cd` beforehand).
+
 ## Contributing
 
 When creating source files, header files, or tests to certain packages, please follow the documentation in their according README files.
-
-### Creating Tests
-
-If you want to add a test in atclient, simply add a `test_*.c` file in the `tests` directory. CMake will automatically detect it and add it to the test suite. Ensure that the test file is named `test_*.c` or else it will not be detected.
-
-Ensure the file has a `int main(int argc, char **argv)` function and returns 0 on success and not 0 on failure.
 
 ### Adding New Source Files
 
@@ -175,3 +169,9 @@ target_sources(atclient PRIVATE
 Simply add the header inside of the `include/` directory. CMake will automatically detect it and add it to the include path.
 
 If it is added in a subdirectory (like `include/atclient/`), then the include path will be `atclient/` (e.g. `#include <atclient/new_header.h>`). Putting your header file in a subdirectory is recommended to help keep our header files consistent and avoid any naming conflicts.
+
+### Adding New Tests
+
+If you want to add a test in atclient, simply add a `test_*.c` file in the `tests` directory. CMake will automatically detect it and add it to the test suite. Ensure that the test file is named `test_*.c` or else it will not be detected.
+
+Ensure the file has a `int main(int argc, char **argv)` function and returns 0 on success and not 0 on failure.


### PR DESCRIPTION
**- What I did**
- Added instructions for building `atsdk` to `./README.md`
- Building `atclient` and `atchops` is still relevant, so I kept their respective documentation.
- Removed `-DATCHOPS_FETCH_MBEDTLS` docs

