### PR TITLE
chore: ignore compile commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ CMakeScripts
 cmake_install.cmake
 .cache/
 
+compile_commands.json
+
 /*build*/
 install/
 bin/


### PR DESCRIPTION
a local file which contains commands for clangd to resolve during development

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- This file is generated at build time by clang, and contains information based on the local system, so it shouldn't be committed
- clangd (the server) uses it to know where to find symbols and stuff.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: ignore compile commands
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
