### PR TITLE
feat: fixed at_talk

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,11 +45,11 @@ jobs:
         run: |
           tools/install.sh
 
-      # - name: Build at_talk
-      #   working-directory: examples/desktop/at_talk
-      #   run: |
-      #     cmake -S . -B build
-      #     cmake --build build
+      - name: Build at_talk
+        working-directory: examples/desktop/at_talk
+        run: |
+          cmake -S . -B build
+          cmake --build build
 
       - name: Build all CRUD examples
         working-directory: examples/desktop/crud

--- a/examples/desktop/at_talk/README.md
+++ b/examples/desktop/at_talk/README.md
@@ -1,0 +1,46 @@
+# at_talk
+
+## Description
+
+at_talk is a simple demo of using notify/monitor for two atSigns to talk to each other end-to-end encrypted.
+
+## Quick Start
+
+Open two terminals. Replace `@bob` and `@alice` with your atSigns. It is assumed that each of the terminals has read access to the existing .atKeys files that are found in `~/.atsign/keys/`.
+
+On terminal 1:
+
+```sh
+./run.sh -f @bob -t @alice
+```
+
+On terminal 2;
+
+```sh
+./run.sh -f @alice -t @bob
+```
+
+## Demo
+
+Here's an example of two atSigns talking to each other. In this case, I have keys to `@soccer0` and `@soccer99`. My atKeys were placed in `~/.atsign/keys/` (so my key files were ~/.atsign/keys/@soccer_0_key.atKeys and ~/.atsign/keys/@soccer_99_key.atKeys).
+
+Terminal 1:
+
+```
+$ ./run.sh -f @soccer0 -t @soccer99
+Setup (1/3) .. (2/3) .. (3/3).
+@soccer0 -> Here's an example of at_talk in action.
+@soccer0 -> 
+@soccer99: Cool isn't it?
+```
+
+Terminal 2:
+
+```
+$ ./run.sh -f @soccer99 -t @soccer0
+Setup (1/3) .. (2/3) .. (3/3).
+@soccer99 -> 
+@soccer0: Here's an example of at_talk in action.
+Cool isn't it?
+@soccer99 -> 
+```

--- a/examples/desktop/at_talk/src/main.c
+++ b/examples/desktop/at_talk/src/main.c
@@ -19,462 +19,234 @@
 #define ROOT_HOST "root.atsign.org"
 #define ROOT_PORT 64
 
-#define ATKEYSFILE_PATH "/home/realvarx/.atsign/keys/@expensiveferret_key.atKeys"
-#define ATSIGN "@expensiveferret"
-#define RECIPIENT "@secondaryjackal"
-#define ATKEY_NAME "attalk"
-#define ATKEY_NAMESPACE "ai6bh"
+#define ATKEY_NAME "at_talk"
+#define ATKEY_NAMESPACE "at_talk"
+
+#define MONITOR_REGEX ".*"
 
 #define TAG "at_talk"
 
-static int attalk_get_both_shared_encryption_keys(atclient *ctx, const atclient_atsign *recipient,
-                                                  char *enc_key_shared_by_me, char *enc_key_shared_by_other);
-
-static int attalk_send_message(atclient *ctx, const atclient_atsign *recipient, char *enc_key_shared_by_me,
-                               const char *message);
-
-static int attalk_recv_message(atclient_monitor_message *message, char* enc_key_shared_by_other);
-
-static int *monitor_handler(char *enc_key_shared_by_other);
-
-static void *heartbeat_handler(void *monitor_connection);
+static int parse_args(int argc, char **argv, char **from_atsign, char **to_atsign);
+static int get_atkeys_path(const char *atsign, const size_t atsignlen, char **atkeyspath);
+static void *monitor_handler(atclient *atclient2);
+static int attalk_send_message(atclient *ctx, const char *recipient_atsign, const char *message,
+                               const size_t messagelen);
+static void attalk_recv_message(atclient_monitor_message *message);
 
 int main(int argc, char **argv) {
   int ret = 0;
 
-  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
+  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);
 
-  // Init atclient
-  atclient atclient;
-  atclient_init(&atclient);
+  char *atkeyspath1 = NULL;
 
-  // Init myatsign: the atsign that you'd like to use as a client
-  // and assign it to the atclient "atsign" parameter
-  atclient_atsign myatsign;
-  ret = atclient_atsign_init(&myatsign, ATSIGN);
-  if (ret != 0) {
-    atclient_free(&atclient);
-    return ret;
-  }
-  atclient.atsign = myatsign;
+  char *from_atsign = NULL;
+  char *to_atsign = NULL;
 
-  // Init atkeysfile and read keys
-  atclient_atkeysfile atkeysfile;
-  atclient_atkeysfile_init(&atkeysfile);
-  ret = atclient_atkeysfile_read(&atkeysfile, ATKEYSFILE_PATH);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeys_file_read: %d\n", ret);
-    atclient_free(&atclient);
-    atclient_atkeysfile_free(&atkeysfile);
-    return ret;
-  }
+  atclient_atkeys atkeys1;
+  atclient_atkeys_init(&atkeys1);
 
-  // Init atkeys and assign them to the atclient "atkeys" parameter
-  atclient_atkeys atkeys;
-  atclient_atkeys_init(&atkeys);
-  ret = atclient_atkeys_populate_from_atkeysfile(&atkeys, atkeysfile);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeys_populate_from_atkeysfile: %d\n", ret);
-    goto exit1;
-  }
-
-  // Root connection and pkam auth
   atclient_connection root_conn;
   atclient_connection_init(&root_conn);
-  atclient_connection_connect(&root_conn, "root.atsign.org", 64);
 
-  ret = atclient_pkam_authenticate(&atclient, &root_conn, &atkeys, ATSIGN);
-  if (ret != 0) {
-    goto exit2;
-  }
+  atclient atclient1;
+  atclient_init(&atclient1);
 
-  // Init recipient's atsign
-  atclient_atsign recipient;
-  ret = atclient_atsign_init(&recipient, RECIPIENT);
-  if (ret != 0) {
-    goto exit2;
-  }
-
-  // Init variables and get the encryption keys
-
-  char *enc_key_shared_by_me = malloc(45);
-  char *enc_key_shared_by_other = malloc(45);
-  ret = attalk_get_both_shared_encryption_keys(&atclient, &recipient, enc_key_shared_by_me, enc_key_shared_by_other);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "attalk_get_both_shared_encryption_keys failed: %d\n", ret);
-  }
-
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "enc_key_shared_by_me: %s\n", enc_key_shared_by_me);
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "enc_key_shared_by_other: %s\n", enc_key_shared_by_other);
+  atclient monitor;
+  atclient_init(&monitor);
 
   pthread_t tid;
-  ret = pthread_create(&tid, NULL, monitor_handler, enc_key_shared_by_other);
+
+  if ((ret = parse_args(argc, argv, &from_atsign, &to_atsign)) != 0) {
+    printf("Issue with parsing arguments\n");
+    goto exit;
+  }
+
+  if ((ret = get_atkeys_path(from_atsign, strlen(from_atsign), &atkeyspath1)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Issue with getting atkeys path for %s\n", from_atsign);
+    goto exit;
+  }
+
+  if ((ret = atclient_atkeys_populate_from_path(&atkeys1, atkeyspath1)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeys_file_read: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = atclient_connection_connect(&root_conn, ROOT_HOST, ROOT_PORT)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_connect: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = atclient_pkam_authenticate(&atclient1, &root_conn, &atkeys1, from_atsign)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_pkam_authenticate: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = atclient_monitor_pkam_authenticate(&monitor, &root_conn, &atkeys1, from_atsign)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_pkam_authenticate: %d\n", ret);
+    goto exit;
+  }
+
+  ret = pthread_create(&tid, NULL, monitor_handler, &monitor);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to create monitor_handler\n");
     return ret;
   }
 
   char *line = NULL;
-  size_t len = 0;
+  size_t linelen = 0;
   size_t read;
 
-  while ((read = getline(&line, &len, stdin)) != -1) {
+  while ((read = getline(&line, &linelen, stdin)) != -1) {
 
     if (line[read - 1] == '\n') {
       line[read - 1] = '\0';
     }
 
-    ret = attalk_send_message(&atclient, &recipient, enc_key_shared_by_me, line);
+    ret = attalk_send_message(&atclient1, to_atsign, line, linelen);
   }
 
-  return ret;
-
-exit1 : {
-  atclient_free(&atclient);
-  atclient_atkeysfile_free(&atkeysfile);
-  atclient_atkeys_free(&atkeys);
-  return ret;
-}
-exit2 : {
-  atclient_free(&atclient);
-  atclient_atkeysfile_free(&atkeysfile);
-  atclient_atkeys_free(&atkeys);
-  atclient_connection_disconnect(&(atclient.secondary_connection));
+  ret = 0;
+  goto exit;
+exit: {
+  // free everything
+  atclient_atkeys_free(&atkeys1);
+  atclient_free(&atclient1);
+  atclient_free(&monitor);
   atclient_connection_free(&root_conn);
+  free(atkeyspath1);
+  ret = pthread_cancel(tid);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "pthread exit: %d\n", ret);
   return ret;
 }
 }
 
-static int attalk_get_both_shared_encryption_keys(atclient *ctx, const atclient_atsign *recipient,
-                                                  char *enc_key_shared_by_me, char *enc_key_shared_by_other) {
-  int ret = -1;
-
-  ret = atclient_get_shared_encryption_key_shared_by_me(ctx, recipient, enc_key_shared_by_me, true);
-  if (ret != 0) {
-    free(enc_key_shared_by_me);
-    return ret;
+static int parse_args(int argc, char **argv, char **from_atsign, char **to_atsign) {
+  if (argc < 5) {
+    fprintf(stderr, "Usage: %s -f <from_atsign> -t <to_atsign>\n", argv[0]);
+    return 1;
   }
 
-  ret = atclient_get_shared_encryption_key_shared_by_other(ctx, recipient, enc_key_shared_by_other);
-  if (ret != 0) {
-    free(enc_key_shared_by_me);
-    free(enc_key_shared_by_other);
-    return ret;
+  int c;
+  while ((c = getopt(argc, argv, "f:t:")) != -1) {
+    switch (c) {
+    case 'f':
+      *from_atsign = optarg;
+      break;
+    case 't':
+      *to_atsign = optarg;
+      break;
+    default:
+      fprintf(stderr, "Usage: %s -f <from_atsign> -t <to_atsign>\n", argv[0]);
+      return 1;
+    }
   }
 
-  ret = 0;
-  return ret;
+  if (*from_atsign == NULL || *to_atsign == NULL) {
+    fprintf(stderr, "Usage: %s -f <from_atsign> -t <to_atsign>\n", argv[0]);
+    return 1;
+  }
+  return 0;
+}
+static int get_atkeys_path(const char *atsign, const size_t atsignlen, char **atkeyspath) {
+  // get home path
+  char *home = getenv("HOME");
+  if (home == NULL) {
+    return 1;
+  }
+
+  // allocate memory for atkeys path
+  char *atkeys_path = (char *)malloc(strlen(home) + strlen("/.atsign/keys/") + atsignlen + strlen("_key.atkeys") + 1);
+  if (atkeys_path == NULL) {
+    return 1;
+  }
+
+  // create atkeys path
+  sprintf(atkeys_path, "%s/.atsign/keys/%.*s_key.atkeys", home, (int)atsignlen, atsign);
+
+  *atkeyspath = atkeys_path;
+  return 0;
 }
 
-static int *monitor_handler(char *enc_key_shared_by_other) {
+static void *monitor_handler(atclient *atclient2) {
+  int ret = 0;
 
-  int ret = -1;
+  atclient_monitor_message *message;
 
-  // Init atclient
-  atclient atclient;
-  atclient_init(&atclient);
-
-  // Init myatsign: the atsign that you'd like to use as a client
-  // and assign it to the atclient "atsign" parameter
-  atclient_atsign myatsign;
-  ret = atclient_atsign_init(&myatsign, ATSIGN);
-  if (ret != 0) {
-    atclient_free(&atclient);
-    return ret;
-  }
-  atclient.atsign = myatsign;
-
-  // Init atkeysfile and read keys
-  atclient_atkeysfile atkeysfile;
-  atclient_atkeysfile_init(&atkeysfile);
-  ret = atclient_atkeysfile_read(&atkeysfile, ATKEYSFILE_PATH);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeys_file_read: %d\n", ret);
-    atclient_free(&atclient);
-    atclient_atkeysfile_free(&atkeysfile);
-    return ret;
+  if ((ret = atclient_monitor_start(atclient2, MONITOR_REGEX, strlen(MONITOR_REGEX))) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to start monitor: %d\n", ret);
+    goto exit;
   }
 
-  // Init atkeys and assign them to the atclient "atkeys" parameter
-  atclient_atkeys atkeys;
-  atclient_atkeys_init(&atkeys);
-  ret = atclient_atkeys_populate_from_atkeysfile(&atkeys, atkeysfile);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeys_populate_from_atkeysfile: %d\n", ret);
-    return ret;
-  }
+  bool loop = true;
 
-  // Root connection and pkam auth
-  atclient_connection root_conn;
-  atclient_connection_init(&root_conn);
-  atclient_connection_connect(&root_conn, "root.atsign.org", 64);
-
-  ret = atclient_pkam_authenticate(&atclient, &root_conn, &atkeys, ATSIGN);
-  if (ret != 0) {
-    return ret;
-  }
-
-  // Init recipient's atsign
-  atclient_atsign recipient;
-  ret = atclient_atsign_init(&recipient, RECIPIENT);
-  if (ret != 0) {
-    return ret;
-  }
-
-  printf("Starting monitor\n");
-  struct atclient monitor_ctx;
-  atclient_monitor_init(&monitor_ctx);
-  // ret = atclient_monitor_start(&monitor_ctx, &root_conn, myatsign.atsign, &atkeys, ".*", strlen(".*"));
-  // if (ret != 0) {
-  //   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Monitor crashed\n");
-  //   return ret;
-  // }
-  printf("Monitor started!\n");
-
-  printf("Starting heartbeat\n");
-  pthread_t tid;
-  ret = pthread_create(&tid, NULL, heartbeat_handler, &monitor_ctx);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to create heartbeat_handler\n");
-    return ret;
-  }
-  printf("Heartbeat started!\n");
-  if (ret < 0) {
-    return ret;
-  }
-
-  if ((ret = atclient_pkam_authenticate(&atclient, &root_conn, &atkeys, myatsign.atsign)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to authenticate\n");
-    return ret;
-  }
-
-  printf("Starting main monitor loop\n");
-  atclient_monitor_message *message = NULL;
-  atclient_monitor_message_init(&message);
-  while (true) {
-
-    int mon_ret = atclient_monitor_read(&monitor_ctx, &atclient, &message);
-    if (mon_ret != 0) {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read monitor message: %d\n", mon_ret);
-      continue;
+  while (loop) {
+    ret = atclient_monitor_read(atclient2, atclient2, &message);
+    if (ret != 0) {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_monitor_for_notification: %d\n", ret);
+      loop = false;
+      break;
     }
 
-    switch (message.type) {
-    case ATCLIENT_MONITOR_MESSAGE_TYPE_NONE:
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: none\n");
-      break;
-    case ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION:
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: notification\n");
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message id: %s\n", message.notification.id);
-
-      if (strncmp(message.notification.id, "-1", strlen(message.notification.id))) {
-        ret = attalk_recv_message(&message, enc_key_shared_by_other);
-      }
-
-      break;
-    case ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE:
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: data\n");
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message body: %s\n", message.data_response);
-      break;
-    case ATCLIENT_MONITOR_MESSAGE_TYPE_ERROR_RESPONSE:
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: error\n");
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message body: %s\n", message.error_response);
-      break;
-    }
-    atclient_monitor_message_free(&message);
+    attalk_recv_message(message);
   }
-  printf("Main monitor loop complete!\n");
 
-  ret = 0;
-  return ret;
+exit: {
+  atclient_monitor_message_free(message);
+  return NULL;
+}
 }
 
-static void *heartbeat_handler(void *monitor_connection) {
-  atclient *connection = (atclient *)monitor_connection;
-  atlogger_log("Heartbeat_handler", ATLOGGER_LOGGING_LEVEL_INFO, "Starting heartbeat_handler\n");
-  while (true) {
-    sleep(30);
-    atlogger_log("Heartbeat_handler", ATLOGGER_LOGGING_LEVEL_DEBUG, "Sending heartbeat\n");
-    atclient_send_heartbeat(connection, false);
-  };
-}
+static int attalk_send_message(atclient *ctx, const char *recipient_atsign, const char *message,
+                               const size_t messagelen) {
+  int ret = 1;
 
-static int attalk_send_message(atclient *ctx, const atclient_atsign *recipient, char *enc_key_shared_by_me,
-                               const char *message) {
-  int ret = -1;
+  atclient_notify_params params;
+  atclient_notify_params_init(&params);
+
   atclient_atkey atkey;
   atclient_atkey_init(&atkey);
 
-  atclient_atstr atkeystr;
-  atclient_atstr_init(&atkeystr, ATCLIENT_ATKEY_FULL_LEN);
-
   if ((ret = atclient_atkey_create_sharedkey(&atkey, ATKEY_NAME, strlen(ATKEY_NAME), ctx->atsign.atsign,
-                                             strlen(ctx->atsign.atsign), recipient->atsign, strlen(recipient->atsign),
+                                             strlen(ctx->atsign.atsign), recipient_atsign, strlen(recipient_atsign),
                                              ATKEY_NAMESPACE, strlen(ATKEY_NAMESPACE))) != 0) {
-    atclient_atkey_free(&atkey);
-    atclient_atstr_free(&atkeystr);
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to create public key");
-    return ret;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to create atkey: %d\n", ret);
+    goto exit;
   }
 
-  atclient_atkey_metadata_set_ccd(&atkey.metadata, true);
+  atclient_notify_params_create(&params, ATCLIENT_NOTIFY_OPERATION_UPDATE, &atkey, message, true);
 
-  if ((ret = atclient_atkey_to_string(&atkey, atkeystr.str, atkeystr.size, &atkeystr.len)) != 0) {
-    atclient_atkey_free(&atkey);
-    atclient_atstr_free(&atkeystr);
-
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to convert to string");
-    return ret;
+  if ((ret = atclient_notify(ctx, &params, NULL)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to notify: %d\n", ret);
+    goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkeystr.str (%lu): \"%.*s\"\n", atkeystr.len, (int)atkeystr.len,
-               atkeystr.str);
-
-  atclient_notify_params notify_params;
-  atclient_notify_params_init(&notify_params);
-
-  const size_t ivlen = ATCHOPS_IV_BUFFER_SIZE;
-  unsigned char iv[ATCHOPS_IV_BUFFER_SIZE];
-  memset(iv, 0, sizeof(unsigned char) * ivlen);
-
-  const size_t ivbase64size = 64;
-  char ivbase64[ivbase64size];
-  memset(ivbase64, 0, sizeof(char) * ivbase64size);
-  size_t ivbase64len = 0;
-
-  const size_t ciphertextsize = 4096;
-  unsigned char ciphertext[ciphertextsize];
-  memset(ciphertext, 0, sizeof(unsigned char) * ciphertextsize);
-  size_t ciphertextlen = 0;
-
-  const size_t ciphertextbase64size = 4096;
-  char ciphertextbase64[ciphertextbase64size];
-  memset(ciphertextbase64, 0, sizeof(char) * ciphertextbase64size);
-  size_t ciphertextbase64len = 0;
-
-  // generate IV
-  ret = atchops_iv_generate(iv);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_iv_generate: %d\n", ret);
-    return ret;
-  }
-
-  ret = atchops_base64_encode(iv, ATCHOPS_IV_BUFFER_SIZE, ivbase64, ivbase64size, &ivbase64len);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_base64_encode: %d\n", ret);
-    return ret;
-  }
-
-  ret = atclient_atkey_metadata_set_ivnonce(&(atkey.metadata), ivbase64, ivbase64len);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_metadata_set_ivnonce: %d\n", ret);
-    return ret;
-  }
-
-  // encrypt msg
-  const size_t encryptionkeysize = ATCHOPS_AES_256 / 8;
-  unsigned char encryptionkey[encryptionkeysize];
-  memset(encryptionkey, 0, sizeof(unsigned char) * (ATCHOPS_AES_256 / 8));
-  size_t encryptionkeylen = 0;
-  ret = atchops_base64_decode(enc_key_shared_by_me, strlen(enc_key_shared_by_me), encryptionkey, encryptionkeysize,
-                              &encryptionkeylen);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_base64_decode: %d\n", ret);
-    return ret;
-  }
-
-  ret = atchops_aesctr_encrypt(encryptionkey, ATCHOPS_AES_256, iv, (unsigned char *)message, strlen(message),
-                               ciphertext, ciphertextsize, &ciphertextlen);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_aesctr_encrypt: %d\n", ret);
-    return ret;
-  }
-
-  ret = atchops_base64_encode(ciphertext, ciphertextlen, ciphertextbase64, ciphertextbase64size, &ciphertextbase64len);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_base64_encode: %d\n", ret);
-    return ret;
-  }
-
-  notify_params.key = atkey;
-  notify_params.value = ciphertextbase64;
-  notify_params.operation = ATCLIENT_NOTIFY_OPERATION_UPDATE;
-
-  if ((ret = atclient_notify(ctx, &notify_params, NULL)) != 0) {
-    atclient_atkey_free(&atkey);
-    atclient_atstr_free(&atkeystr);
-    atclient_notify_params_free(&notify_params);
-
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to notify");
-    return ret;
-  }
-
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Sent notification");
-  // exit : { return ret; }
+  ret = 0;
+  goto exit;
+exit: { return ret; }
 }
 
-static int attalk_recv_message(atclient_monitor_message *message, char* enc_key_shared_by_other) {
+static void attalk_recv_message(atclient_monitor_message *message) {
+  int ret = 1;
 
-  int ret = -1;
-  char *valueraw = NULL;
-
-  // Convert b64 enc_key to bytes
-  const size_t encryptionkeysize = ATCHOPS_AES_256 / 8;
-  unsigned char encryptionkey[encryptionkeysize];
-  memset(encryptionkey, 0, sizeof(unsigned char) * (ATCHOPS_AES_256 / 8));
-  size_t encryptionkeylen = 0;
-  ret = atchops_base64_decode(enc_key_shared_by_other, strlen(enc_key_shared_by_other), encryptionkey,
-                              encryptionkeysize, &encryptionkeylen);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_base64_decode: %d\n", ret);
-    return ret;
+  switch (message->type) {
+  case ATCLIENT_MONITOR_MESSAGE_TYPE_NONE: {
+    break;
   }
-
-  unsigned char iv[ATCHOPS_IV_BUFFER_SIZE];
-
-  const size_t valuelen = 1024;
-  atclient_atstr value;
-  atclient_atstr_init(&value, valuelen);
-
-  // manage IV
-  // if (atclient_atkey_metadata_is_ivnonce_initialized(&message->notification.key.metadata)) {
-  //   size_t ivolen = 0;
-    // ret = atchops_base64_decode((unsigned char *) message->notification.key.metadata.ivnonce.str,
-    //                             message->notification.key.metadata.ivnonce.len, iv, ATCHOPS_IV_BUFFER_SIZE, &ivolen);
-    // if (ret != 0) {
-    //   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_base64_decode: %d\n", ret);
-    //   return ret;
-    // }
-
-  //   if (ivolen != ATCHOPS_IV_BUFFER_SIZE) {
-  //     ret = 1;
-  //     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ivolen != ivlen (%d != %d)\n", ivolen, ATCHOPS_IV_BUFFER_SIZE);
-  //     return ret;
-  //   }
-  // } else {
-  //   // use legacy IV
-  //   memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_BUFFER_SIZE);
-  // }
-
-  const size_t valuerawsize = strlen(message->notification.value) * 4; // most likely enough space after base64 decode
-  valueraw = malloc(sizeof(char) * valuerawsize);
-  memset(valueraw, 0, sizeof(char) * valuerawsize);
-  size_t valuerawlen = 0;
-
-  ret = atchops_base64_decode((unsigned char *)message->notification.value, strlen(message->notification.value),
-                              (unsigned char *)valueraw, valuerawsize, &valuerawlen);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_base64_decode: %d\n", ret);
-    return ret;
+  case ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE: {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Received message: %s\n", message->data_response);
+    break;
   }
-
-  // decrypt response data
-  ret = atchops_aesctr_decrypt(encryptionkey, ATCHOPS_AES_256, iv, valueraw, valuerawlen, (unsigned char *)value.str,
-                               value.size, &value.len);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_aesctr_decrypt: %d\n", ret);
-    return ret;
+  case ATCLIENT_MONITOR_MESSAGE_TYPE_ERROR_RESPONSE: {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Received error: %s\n", message->error_response);
+    break;
   }
-
-  // atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "%s: %s\n", message->notification.key.sharedby.str, value.str);
+  case ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION: {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Received notification: %s\n", message->notification.decryptedvalue);
+    break;
+  }
+  default: {
+    break;
+  }
+  }
 }

--- a/packages/atclient/include/atclient/constants.h
+++ b/packages/atclient/include/atclient/constants.h
@@ -1,4 +1,3 @@
-
 #ifndef ATCLIENT_CONSTANTS_H
 #define ATCLIENT_CONSTANTS_H
 
@@ -14,4 +13,79 @@
 #define ATCLIENT_DEFAULT_NOTIFIER "SYSTEM"
 
 #define ATCLIENT_MONITOR_BUFFER_LEN 4096 // max chunk size monitor can read at once
+
+#define BLK "\e[0;30m"
+#define RED "\e[0;31m"
+#define GRN "\e[0;32m"
+#define YEL "\e[0;33m"
+#define BLU "\e[0;34m"
+#define MAG "\e[0;35m"
+#define CYN "\e[0;36m"
+#define WHT "\e[0;37m"
+
+//Regular bold text
+#define BBLK "\e[1;30m"
+#define BRED "\e[1;31m"
+#define BGRN "\e[1;32m"
+#define BYEL "\e[1;33m"
+#define BBLU "\e[1;34m"
+#define BMAG "\e[1;35m"
+#define BCYN "\e[1;36m"
+#define BWHT "\e[1;37m"
+
+//Regular underline text
+#define UBLK "\e[4;30m"
+#define URED "\e[4;31m"
+#define UGRN "\e[4;32m"
+#define UYEL "\e[4;33m"
+#define UBLU "\e[4;34m"
+#define UMAG "\e[4;35m"
+#define UCYN "\e[4;36m"
+#define UWHT "\e[4;37m"
+
+//Regular background
+#define BLKB "\e[40m"
+#define REDB "\e[41m"
+#define GRNB "\e[42m"
+#define YELB "\e[43m"
+#define BLUB "\e[44m"
+#define MAGB "\e[45m"
+#define CYNB "\e[46m"
+#define WHTB "\e[47m"
+
+//High intensty background 
+#define BLKHB "\e[0;100m"
+#define REDHB "\e[0;101m"
+#define GRNHB "\e[0;102m"
+#define YELHB "\e[0;103m"
+#define BLUHB "\e[0;104m"
+#define MAGHB "\e[0;105m"
+#define CYNHB "\e[0;106m"
+#define WHTHB "\e[0;107m"
+
+//High intensty text
+#define HBLK "\e[0;90m"
+#define HRED "\e[0;91m"
+#define HGRN "\e[0;92m"
+#define HYEL "\e[0;93m"
+#define HBLU "\e[0;94m"
+#define HMAG "\e[0;95m"
+#define HCYN "\e[0;96m"
+#define HWHT "\e[0;97m"
+
+//Bold high intensity text
+#define BHBLK "\e[1;90m"
+#define BHRED "\e[1;91m"
+#define BHGRN "\e[1;92m"
+#define BHYEL "\e[1;93m"
+#define BHBLU "\e[1;94m"
+#define BHMAG "\e[1;95m"
+#define BHCYN "\e[1;96m"
+#define BHWHT "\e[1;97m"
+
+//Reset
+#define reset "\e[0m"
+#define CRESET "\e[0m"
+#define COLOR_RESET "\e[0m"
+
 #endif

--- a/packages/atclient/include/atclient/notify.h
+++ b/packages/atclient/include/atclient/notify.h
@@ -63,8 +63,8 @@ typedef struct atclient_notify_params {
 } atclient_notify_params;
 
 void atclient_notify_params_init(atclient_notify_params *params);
-void atclient_notify_params_create(atclient_notify_params *params, enum atclient_notify_operation operation,
-                                   atclient_atkey *atkey, char *value, bool shouldencrypt);
+void atclient_notify_params_create(atclient_notify_params *params, const enum atclient_notify_operation operation,
+                                   atclient_atkey *atkey, const char *value, const bool shouldencrypt);
 void atclient_notify_params_free(atclient_notify_params *params);
 
 int atclient_notify(atclient *ctx, atclient_notify_params *params, char *notification_id);

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -213,8 +213,8 @@ int atclient_send_heartbeat(atclient *heartbeat_conn, bool listen_for_ack) {
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sSENT: %s\"%.*s\"\e[0m\n", "\e[1;34m", "\e[0;96m",
-               (int)commandlen - 2, command);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sSENT: %s\"%.*s\"%s\n", BBLU, HCYN, (int)commandlen - 2, command,
+               reset);
 
   if (!listen_for_ack) {
     ret = 0;
@@ -245,8 +245,8 @@ int atclient_send_heartbeat(atclient *heartbeat_conn, bool listen_for_ack) {
     }
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\"\e[0m\n", "\e[1;35m", "\e[0;95m", (int)recvlen,
-               ptr);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, (int)recvlen,
+               ptr, reset);
 
   if (!atclient_stringutils_starts_with((const char *)ptr, recvlen, "data:ok", strlen("data:ok")) &&
       !atclient_stringutils_ends_with((const char *)ptr, recvlen, "data:ok", strlen("data:ok"))) {

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -3,6 +3,7 @@
 #include "atchops/constants.h"
 #include "atclient/atstr.h"
 #include "atclient/cacerts.h"
+#include "atclient/constants.h"
 #include "atlogger/atlogger.h"
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
@@ -215,8 +216,8 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
 
   fix_stdout_buffer(stdoutbuffer.str, stdoutbuffer.len);
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sSENT: %s\"%.*s\"\e[0m\n", "\e[1;34m", "\e[0;96m",
-               (int)stdoutbuffer.len, stdoutbuffer.str);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sSENT: %s\"%.*s\"%s\n", BBLU, HCYN, (int)stdoutbuffer.len,
+               stdoutbuffer.str, reset);
 
   memset(recv, 0, recvsize);
   int found = 0;
@@ -254,8 +255,8 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
   }
   fix_stdout_buffer(stdoutbuffer.str, stdoutbuffer.len);
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\"\e[0m\n", "\e[1;35m", "\e[0;95m",
-               (int)stdoutbuffer.len, stdoutbuffer.str);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG,
+               (int)stdoutbuffer.len, stdoutbuffer.str, reset);
   memset(recv, 0, sizeof(unsigned char) * recvsize); // clear the buffer
   memcpy(recv, stdoutbuffer.str, stdoutbuffer.len);
   goto exit;

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -591,8 +591,7 @@ int atclient_monitor_start(atclient *monitor_conn, const char *regex, const size
     goto exit;
   }
   fix_stdout_buffer(cmd, cmdsize);
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sSENT: %s\"%.*s\"\e[0m\n", "\e[1;34m", "\e[0;95m",
-               (int)strlen(cmd), cmd);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sSENT: %s\"%.*s\"%s\n", BBLK, HCYN, (int)strlen(cmd), cmd, reset);
 
   ret = 0;
   goto exit;
@@ -657,8 +656,8 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
   *message = malloc(sizeof(atclient_monitor_message));
   atclient_monitor_message_init(*message);
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%s:%s\"\e[0m\n", "\e[1;35m", "\e[0;95m", messagetype,
-               messagebody);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, messagetype, messagebody,
+               reset);
 
   if (strcmp(messagetype, "notification") == 0) {
     (*message)->type = ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION;
@@ -685,7 +684,7 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
       atclient_atnotification_set_decryptedvalue(&((*message)->notification), (*message)->notification.value,
                                                  strlen((*message)->notification.value));
       atclient_atnotification_set_decryptedvaluelen(&((*message)->notification),
-                                                     strlen((*message)->notification.value));
+                                                    strlen((*message)->notification.value));
     }
   } else if (strcmp(messagetype, "data") == 0) {
     (*message)->type = ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE;

--- a/packages/atclient/src/notify.c
+++ b/packages/atclient/src/notify.c
@@ -31,7 +31,7 @@ void atclient_notify_params_init(atclient_notify_params *params) {
 }
 
 void atclient_notify_params_create(atclient_notify_params *params, enum atclient_notify_operation operation,
-                                   atclient_atkey *atkey, char *value, bool shouldencrypt) {
+                                   atclient_atkey *atkey, const char *value, bool shouldencrypt) {
   params->operation = operation;
   params->key = *atkey;
   params->value = value;

--- a/packages/atclient/src/notify.c
+++ b/packages/atclient/src/notify.c
@@ -16,6 +16,8 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
 #define TAG "atclient_notify"
 
 void atclient_notify_params_init(atclient_notify_params *params) {
@@ -141,7 +143,12 @@ int atclient_notify(atclient *ctx, atclient_notify_params *params, char *notific
     off += 6 + ttln_len;
   }
 
-  const size_t ciphertextbase64size = strlen(params->value) * 4; // TODO optimize
+  const size_t ciphertextsize = MAX(strlen(params->value) * 2, 128); // TODO optimize
+  unsigned char ciphertext[ciphertextsize];
+  memset(ciphertext, 0, sizeof(unsigned char) * ciphertextsize);
+  size_t ciphertextlen = 0;
+
+  const size_t ciphertextbase64size = MAX(ciphertextsize * 2, 128); // TODO optimize
   unsigned char ciphertextbase64[ciphertextbase64size];
   memset(ciphertextbase64, 0, sizeof(unsigned char) * ciphertextbase64size);
   size_t ciphertextbase64len = 0;
@@ -189,11 +196,6 @@ int atclient_notify(atclient *ctx, atclient_notify_params *params, char *notific
         return res;
       }
     }
-
-    const size_t ciphertextsize = strlen(params->value) * 2; // TODO optimize
-    unsigned char ciphertext[ciphertextsize];
-    memset(ciphertext, 0, sizeof(unsigned char) * ciphertextsize);
-    size_t ciphertextlen = 0;
 
     unsigned char iv[ATCHOPS_IV_BUFFER_SIZE];
     memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_BUFFER_SIZE);


### PR DESCRIPTION
closes #244 

**- What I did**
- Fixed at_talk demo with our implementation of notify/monitor
- Added at_talk back to our CI
- at_talk documentation

Other:
- Fixed notify bug where if the message was too short, not enough memory was allocated for cipher text
- Added colour codes to atclient/constants.h and used those symbolic constants in various places where we use colours in stdout

**- How I did it**
- See changes

**- How to verify it**
- Added at_talk back to our CI

**- Description for the changelog**
feat: at_talk demo
