### PR TITLE
feat: connection resilience

### DIFF
--- a/examples/desktop/at_talk/src/main.c
+++ b/examples/desktop/at_talk/src/main.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
   atclient_atkeys_init(&atkeys1);
 
   atclient_connection root_conn;
-  atclient_connection_init(&root_conn);
+  atclient_connection_init(&root_conn, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
 
   atclient atclient1;
   atclient_init(&atclient1);

--- a/examples/desktop/crud/delete.c
+++ b/examples/desktop/crud/delete.c
@@ -28,7 +28,7 @@ int main() {
   atclient_atkeys atkeys;
 
   atclient_init(&atclient);
-  atclient_connection_init(&root_conn);
+  atclient_connection_init(&root_conn, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
   atclient_atsign_init(&atsign, ATSIGN);
   atclient_atkey_init(&atkey);
   atclient_atkeys_init(&atkeys);

--- a/examples/desktop/crud/get_publickey.c
+++ b/examples/desktop/crud/get_publickey.c
@@ -38,7 +38,7 @@ int main() {
   atclient_init(&atclient);
 
   atclient_connection root_connection;
-  atclient_connection_init(&root_connection);
+  atclient_connection_init(&root_connection, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
   atclient_connection_connect(&root_connection, ROOT_HOST, ROOT_PORT);
 
   atclient_atsign atsign;

--- a/examples/desktop/crud/get_selfkey.c
+++ b/examples/desktop/crud/get_selfkey.c
@@ -34,7 +34,7 @@ int main() {
   size_t valueolen = 0;
 
   atclient_connection root_conn;
-  atclient_connection_init(&root_conn);
+  atclient_connection_init(&root_conn, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
   atclient_connection_connect(&root_conn, ROOT_HOST, ROOT_PORT);
 
   atclient atclient;

--- a/examples/desktop/crud/get_sharedkey.c
+++ b/examples/desktop/crud/get_sharedkey.c
@@ -44,7 +44,7 @@ int main() {
   atclient_atstr_init(&value, valuelen);
 
   atclient_connection root_conn;
-  atclient_connection_init(&root_conn);
+  atclient_connection_init(&root_conn, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
   atclient_connection_connect(&root_conn, "root.atsign.org", 64);
 
   atclient atclient;

--- a/examples/desktop/crud/put_publickey.c
+++ b/examples/desktop/crud/put_publickey.c
@@ -34,7 +34,7 @@ int main() {
   atclient_init(&atclient);
 
   atclient_connection root_connection;
-  atclient_connection_init(&root_connection);
+  atclient_connection_init(&root_connection, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
   atclient_connection_connect(&root_connection, "root.atsign.org", 64);
 
   atclient_atsign atsign;

--- a/examples/desktop/crud/put_selfkey.c
+++ b/examples/desktop/crud/put_selfkey.c
@@ -34,7 +34,7 @@ int main() {
   atclient_init(&atclient);
 
   atclient_connection root_connection;
-  atclient_connection_init(&root_connection);
+  atclient_connection_init(&root_connection, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
   atclient_connection_connect(&root_connection, "root.atsign.org", 64);
 
   atclient_atsign atsign;

--- a/examples/desktop/crud/put_sharedkey.c
+++ b/examples/desktop/crud/put_sharedkey.c
@@ -40,7 +40,7 @@ int main()
     atclient_init(&atclient);
 
     atclient_connection root_connection;
-    atclient_connection_init(&root_connection);
+    atclient_connection_init(&root_connection, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
     atclient_connection_connect(&root_connection, ROOT_HOST, ROOT_PORT);
 
     atclient_atsign atsign;

--- a/examples/desktop/events/CMakeLists.txt
+++ b/examples/desktop/events/CMakeLists.txt
@@ -4,7 +4,7 @@ project(sample_cmake_project)
 
 find_package(atsdk REQUIRED CONFIG)
 
-set(examples notify monitor)
+set(examples notify monitor resilient_monitor)
 
 foreach(example ${examples})
   add_executable(${example} ${CMAKE_CURRENT_LIST_DIR}/${example}.c)

--- a/examples/desktop/events/notify.c
+++ b/examples/desktop/events/notify.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
   atclient_init(&atclient);
 
   atclient_connection root_connection;
-  atclient_connection_init(&root_connection);
+  atclient_connection_init(&root_connection, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
 
   atclient_atkey atkey;
   atclient_atkey_init(&atkey);

--- a/examples/desktop/events/resilient_monitor.c
+++ b/examples/desktop/events/resilient_monitor.c
@@ -95,6 +95,7 @@ int main(int argc, char *argv[]) {
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "decryptedvalue: \"%s\"\n",
                      message->notification.decryptedvalue);
       }
+      tries = 1;
       break;
     }
     case ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE: {

--- a/examples/desktop/events/resilient_monitor.c
+++ b/examples/desktop/events/resilient_monitor.c
@@ -70,6 +70,8 @@ int main(int argc, char *argv[]) {
     goto exit;
   }
 
+  atclient_monitor_set_read_timeout(&monitor_conn, 3*1000); // monitor read will wait at most 3 seconds for a message. As soon bytes are read, it will return. If no bytes are read, it will return after 3 seconds.
+
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Starting main monitor loop...\n");
   size_t tries = 1;
   size_t max_tries = 10;

--- a/examples/desktop/events/resilient_monitor.c
+++ b/examples/desktop/events/resilient_monitor.c
@@ -38,8 +38,6 @@ int main(int argc, char *argv[]) {
   atclient monitor_conn;
   atclient_monitor_init(&monitor_conn);
 
-  pthread_t tid;
-
   atclient_monitor_message *message = NULL;
 
   if ((ret = get_atsign_input(argc, argv, &atsign)) != 0) {
@@ -57,7 +55,7 @@ int main(int argc, char *argv[]) {
     goto exit;
   }
 
-  if((ret = atclient_pkam_authenticate(&atclient2, &root_connection, &atkeys, atsign)) != 0) {
+  if ((ret = atclient_pkam_authenticate(&atclient2, &root_connection, &atkeys, atsign)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to authenticate with PKAM\n");
     goto exit;
   }
@@ -73,13 +71,11 @@ int main(int argc, char *argv[]) {
   }
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Starting main monitor loop...\n");
+  size_t tries = 1;
+  size_t max_tries = 10;
   while (true) {
 
     ret = atclient_monitor_read(&monitor_conn, &atclient2, &message);
-    if (ret != 0) {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read monitor message: %d\n", ret);
-      continue;
-    }
 
     switch (message->type) {
     case ATCLIENT_MONITOR_MESSAGE_TYPE_NONE: {
@@ -89,8 +85,7 @@ int main(int argc, char *argv[]) {
     case ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION: {
       // atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION\n");
       // atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message Body: %s\n", message->notification.value);
-      if(strcmp(message->notification.id, "-1")== 0)
-      {
+      if (strcmp(message->notification.id, "-1") == 0) {
         // ignore stats notification
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Received stats notification, ignoring it.\n");
         break;
@@ -113,16 +108,36 @@ int main(int argc, char *argv[]) {
       // Body: %s\n", message->error_response);
       break;
     }
+    case ATCLIENT_MONITOR_ERROR_PARSE: {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_PARSE\n");
+      break;
+    }
+    case ATCLIENT_MONITOR_ERROR_READ: {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_READ\n");
+      tries++;
+      break;
+    }
     }
     // sleep(3);
+
+    if(tries >= max_tries) {
+      if(!atclient_monitor_is_connected(&monitor_conn)) {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "We are not connected :( attempting reconnection\n");
+        if((ret = atclient_monitor_pkam_authenticate(&monitor_conn, &root_connection, &atkeys, atsign)) != 0)
+        {
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to authenticate monitor with PKAM\n");
+          goto exit;
+        }
+      } else {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "We are connected ! :)\n");
+      }
+      tries = 1;
+    }
   }
 
   ret = 0;
   goto exit;
 exit: {
-  if (pthread_cancel(tid) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to cancel heartbeat_handler\n");
-  }
   atclient_atkeys_free(&atkeys);
   atclient_connection_free(&root_connection);
   atclient_monitor_free(&monitor_conn);

--- a/examples/desktop/pkam_authenticate/src/main.c
+++ b/examples/desktop/pkam_authenticate/src/main.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
   atclient_init(&atclient);
   
   atclient_connection root_conn;
-  atclient_connection_init(&root_conn);
+  atclient_connection_init(&root_conn, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
   atclient_connection_connect(&root_conn, "root.atsign.org", 64);
 
   atclient_atsign atsign;

--- a/examples/desktop/repl/src/main.c
+++ b/examples/desktop/repl/src/main.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[]) {
   size_t recvlen = 0;
 
   atclient_connection root_conn;
-  atclient_connection_init(&root_conn);
+  atclient_connection_init(&root_conn, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
 
   atclient atclient;
   atclient_init(&atclient);

--- a/packages/atclient/include/atclient/atclient.h
+++ b/packages/atclient/include/atclient/atclient.h
@@ -29,6 +29,14 @@ typedef struct atclient {
 void atclient_init(atclient *ctx);
 
 /**
+ * @brief Frees memory allocated by atclient's _init function. The caller of _init is responsible for calling this once
+ * it is done with the atclient context.
+ *
+ * @param ctx the atclient context to free
+ */
+void atclient_free(atclient *ctx);
+
+/**
  * @brief initialize the atclient's secondary connection to the specified host and port
  *
  * @param ctx initialized atclient context
@@ -176,11 +184,14 @@ int atclient_delete(atclient *atclient, const atclient_atkey *atkey);
 int atclient_send_heartbeat(atclient *heartbeat_conn);
 
 /**
- * @brief Frees memory allocated by atclient's _init function. The caller of _init is responsible for calling this once
- * it is done with the atclient context.
+ * @brief For any atclient SSL operations (such as the crud operations like put,get,delete or event operations like
+ * notify), the timeout will be set to this value. Once an operation is ran (mbedtls_ssl_read), it will wait at most
+ * `timeout_ms` before returning. If any bytes are read, it will return immediately. If no bytes are read, it will
+ * return after `timeout_ms` milliseconds.
  *
- * @param ctx the atclient context to free
+ * @param ctx the pkam_authenticated atclient context
+ * @param timeout_ms the timeout in milliseconds
  */
-void atclient_free(atclient *ctx);
+void atclient_set_timeout(atclient *ctx, int timeout_ms);
 
 #endif

--- a/packages/atclient/include/atclient/atclient.h
+++ b/packages/atclient/include/atclient/atclient.h
@@ -51,12 +51,13 @@ int atclient_start_secondary_connection(atclient *ctx, const char *secondaryhost
  * the pkam private key and atclient context is connected to the root server
  *
  * @param ctx initialized atclient context
- * @param root_conn initialized root connection
+ * @param host host of the secondary server (aka atServer)
+ * @param port port of the secondary server (aka atServer)
  * @param atkeys populated atkeys, especially with the pkam private key
  * @param atsign the atsign the atkeys belong to
  * @return int 0 on success
  */
-int atclient_pkam_authenticate(atclient *ctx, atclient_connection *root_conn, const atclient_atkeys *atkeys,
+int atclient_pkam_authenticate(atclient *ctx, const char *host, const int port,  const atclient_atkeys *atkeys,
                                const char *atsign);
 
 /**

--- a/packages/atclient/include/atclient/atclient.h
+++ b/packages/atclient/include/atclient/atclient.h
@@ -192,6 +192,6 @@ int atclient_send_heartbeat(atclient *heartbeat_conn);
  * @param ctx the pkam_authenticated atclient context
  * @param timeout_ms the timeout in milliseconds
  */
-void atclient_set_timeout(atclient *ctx, int timeout_ms);
+void atclient_set_read_timeout(atclient *ctx, int timeout_ms);
 
 #endif

--- a/packages/atclient/include/atclient/atclient.h
+++ b/packages/atclient/include/atclient/atclient.h
@@ -51,13 +51,12 @@ int atclient_start_secondary_connection(atclient *ctx, const char *secondaryhost
  * the pkam private key and atclient context is connected to the root server
  *
  * @param ctx initialized atclient context
- * @param host host of the secondary server (aka atServer)
- * @param port port of the secondary server (aka atServer)
+ * @param root_conn initialized root connection
  * @param atkeys populated atkeys, especially with the pkam private key
  * @param atsign the atsign the atkeys belong to
  * @return int 0 on success
  */
-int atclient_pkam_authenticate(atclient *ctx, const char *host, const int port,  const atclient_atkeys *atkeys,
+int atclient_pkam_authenticate(atclient *ctx, atclient_connection *root_conn, const atclient_atkeys *atkeys,
                                const char *atsign);
 
 /**

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -10,9 +10,14 @@
 #include <stddef.h>
 
 #define ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE 128 // the size of the buffer for the host name
-//
+
+// represents the type of connection
+typedef enum atclient_connection_type {
+  ATCLIENT_CONNECTION_TYPE_DIRECTORY, // uses '\n' to check if it is connected
+  ATCLIENT_CONNECTION_TYPE_ATSERVER // uses 'noop:0\r\n' to check if it is connected
+} atclient_connection_type;
+
 typedef struct atclient_connection {
-  // char *host; // assume null terminated, example: "root.atsign.org"
   char host[ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE];
   int port; // example: 64
   mbedtls_net_context net;
@@ -22,18 +27,23 @@ typedef struct atclient_connection {
   mbedtls_entropy_context entropy;
   mbedtls_ctr_drbg_context ctr_drbg;
 
-  bool should_be_connected;
+  atclient_connection_type type;
+
   // atclient_connection_connect sets this to true and atclient_connection_disconnect sets this to false
   // this does not mean that the connection is still alive, it just means that the connection was established or taken
   // down at some point, check atclient_connection_is_connected for a live status on the connection
+  bool should_be_connected;
 } atclient_connection;
 
 /**
  * @brief initialize the context for a connection. this function should be called before use of any other function
  *
  * @param ctx the context to initialize
+ * @param type the type of connection to initialize,
+ * if it is ATCLIENT_CONNECTION_TYPE_ROOT, then '\\n' will be used to check if it is connected.
+ * if it is ATCLIENT_CONNECTION_TYPE_ATSERVER, then 'noop:0\r\n' will be used to check if it is connected
  */
-void atclient_connection_init(atclient_connection *ctx);
+void atclient_connection_init(atclient_connection *ctx, atclient_connection_type type);
 
 /**
  * @brief after initializing a connection context, connect to a host and port

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -22,10 +22,10 @@ typedef struct atclient_connection {
   mbedtls_entropy_context entropy;
   mbedtls_ctr_drbg_context ctr_drbg;
 
-  bool should_be_initialized; // true, if atclient_connection_init was called, is false when atclient_connection_free is
-                              // called. This is used to prevent double free.
-  bool should_be_connected;   // true, if atclient_connection_connect was called, is false, if
-                              // atclient_connection_disconnect is called. This is used to prevent double free.
+  bool should_be_connected;
+  // atclient_connection_connect sets this to true and atclient_connection_disconnect sets this to false
+  // this does not mean that the connection is still alive, it just means that the connection was established or taken
+  // down at some point, check atclient_connection_is_connected for a live status on the connection
 } atclient_connection;
 
 /**

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -83,9 +83,9 @@ int atclient_connection_disconnect(atclient_connection *ctx);
  * @brief checks if the connection is connected
  *
  * @param ctx the connection to check
- * @return int 1 if connected, 0 if not connected, negative on error
+ * @return true if the connection is connected, otherwise false if it is not connected or an error occurred
  */
-int atclient_connection_is_connected(atclient_connection *ctx);
+bool atclient_connection_is_connected(atclient_connection *ctx);
 
 /**
  * @brief free memory allocated by the init function

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -6,6 +6,7 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/net_sockets.h>
 #include <mbedtls/ssl.h>
+#include <stdbool.h>
 #include <stddef.h>
 
 #define ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE 128 // the size of the buffer for the host name
@@ -20,6 +21,11 @@ typedef struct atclient_connection {
   mbedtls_x509_crt cacert;
   mbedtls_entropy_context entropy;
   mbedtls_ctr_drbg_context ctr_drbg;
+
+  bool should_be_initialized; // true, if atclient_connection_init was called, is false when atclient_connection_free is
+                              // called. This is used to prevent double free.
+  bool should_be_connected;   // true, if atclient_connection_connect was called, is false, if
+                              // atclient_connection_disconnect is called. This is used to prevent double free.
 } atclient_connection;
 
 /**

--- a/packages/atclient/include/atclient/constants.h
+++ b/packages/atclient/include/atclient/constants.h
@@ -12,7 +12,8 @@
 
 #define ATCLIENT_DEFAULT_NOTIFIER "SYSTEM"
 
-#define ATCLIENT_CONSTANTS_READ_TIMEOUT 3*1000 // 3 seconds
+#define ATCLIENT_CLIENT_READ_TIMEOUT_MS 3*1000 // 3 seconds
+#define ATCLIENT_MONITOR_READ_TIMEOUT_MS 100 // 0.1 seconds
 
 #define ATCLIENT_MONITOR_BUFFER_LEN 4096 // max chunk size monitor can read at once
 

--- a/packages/atclient/include/atclient/constants.h
+++ b/packages/atclient/include/atclient/constants.h
@@ -12,6 +12,8 @@
 
 #define ATCLIENT_DEFAULT_NOTIFIER "SYSTEM"
 
+#define ATCLIENT_CONSTANTS_READ_TIMEOUT 3*1000 // 3 seconds
+
 #define ATCLIENT_MONITOR_BUFFER_LEN 4096 // max chunk size monitor can read at once
 
 #define BLK "\e[0;30m"

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -168,7 +168,7 @@ enum atclient_monitor_message_type {
   ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE,
   ATCLIENT_MONITOR_MESSAGE_TYPE_ERROR_RESPONSE,
   ATCLIENT_MONITOR_ERROR_READ, // usually a socket error
-  ATCLIENT_MONITOR_ERROR_PARSE, 
+  ATCLIENT_MONITOR_ERROR_PARSE,
 };
 
 /**
@@ -238,7 +238,7 @@ int atclient_monitor_pkam_authenticate(atclient *monitor_conn, atclient_connecti
 
 /**
  * @brief Set how long `atclient_monitor_read` should wait for a message before timing out
- * 
+ *
  * @param monitor_conn the pkam authenticated monitor connection
  * @param timeoutms the timeout in milliseconds
  */
@@ -269,5 +269,15 @@ int atclient_monitor_start(atclient *monitor_conn, const char *regex, const size
  * data field to use
  */
 int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_monitor_message **message);
+
+/**
+ * @brief Check if the monitor connection is still established (client is listening for notifications, and the server
+ * still has potential to send notifications to you)
+ *
+ * @param monitor_conn the monitor connection to check
+ * @return 1 if connected, 0 if not connected, negative on error, you can deduce that 0 and negative basically mean the
+ * same thing (we are not connected :( )
+ */
+int atclient_monitor_is_connected(atclient *monitor_conn);
 
 #endif

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -275,9 +275,8 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
  * still has potential to send notifications to you)
  *
  * @param monitor_conn the monitor connection to check
- * @return 1 if connected, 0 if not connected, negative on error, you can deduce that 0 and negative basically mean the
- * same thing (we are not connected :( )
+ * @return true if connected, false if not connected or an error happened
  */
-int atclient_monitor_is_connected(atclient *monitor_conn);
+bool atclient_monitor_is_connected(atclient *monitor_conn);
 
 #endif

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -166,7 +166,9 @@ enum atclient_monitor_message_type {
   ATCLIENT_MONITOR_MESSAGE_TYPE_NONE,
   ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION,
   ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE,
-  ATCLIENT_MONITOR_MESSAGE_TYPE_ERROR_RESPONSE
+  ATCLIENT_MONITOR_MESSAGE_TYPE_ERROR_RESPONSE,
+  ATCLIENT_MONITOR_ERROR_READ, // usually a socket error
+  ATCLIENT_MONITOR_ERROR_PARSE, 
 };
 
 /**
@@ -233,6 +235,14 @@ void atclient_monitor_free(atclient *monitor_conn);
  */
 int atclient_monitor_pkam_authenticate(atclient *monitor_conn, atclient_connection *root_conn,
                                        const atclient_atkeys *atkeys, const char *atsign);
+
+/**
+ * @brief Set how long `atclient_monitor_read` should wait for a message before timing out
+ * 
+ * @param monitor_conn the pkam authenticated monitor connection
+ * @param timeoutms the timeout in milliseconds
+ */
+void atclient_monitor_set_read_timeout(atclient *monitor_conn, const int timeoutms);
 
 /**
  * @brief Onboards the monitor_connection and starts the monitoring connection.

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -25,6 +25,16 @@ void atclient_init(atclient *ctx) {
   ctx->async_read = false;
 }
 
+void atclient_free(atclient *ctx) { 
+  // TODO: add initialized fields to free
+
+  // TODO: free secondary_connection if it's been started (called atclient_start_secondary_connection)
+  atclient_connection_free(&(ctx->secondary_connection));
+
+  // TODO: free atsign if it's been initialized (called atclient_atsign_init)
+  // TODO: free atkeys if it's been initialized (called atclient_atkeys_init)
+}
+
 int atclient_start_secondary_connection(atclient *ctx, const char *secondaryhost, const int secondaryport) {
   int ret = 1; // error by default
 
@@ -196,8 +206,6 @@ exit: {
 }
 }
 
-void atclient_free(atclient *ctx) { atclient_connection_free(&(ctx->secondary_connection)); }
-
 int atclient_send_heartbeat(atclient *heartbeat_conn) {
   int ret = -1;
 
@@ -239,4 +247,8 @@ exit: {
   }
   return ret;
 }
+}
+
+void atclient_set_timeout(atclient *ctx, int timeout_ms) {
+  mbedtls_ssl_conf_read_timeout(&(ctx->secondary_connection.ssl_config), timeout_ms);
 }

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -28,7 +28,7 @@ void atclient_init(atclient *ctx) {
 int atclient_start_secondary_connection(atclient *ctx, const char *secondaryhost, const int secondaryport) {
   int ret = 1; // error by default
 
-  atclient_connection_init(&(ctx->secondary_connection));
+  atclient_connection_init(&(ctx->secondary_connection), ATCLIENT_CONNECTION_TYPE_ATSERVER);
 
   ret = atclient_connection_connect(&(ctx->secondary_connection), secondaryhost, secondaryport);
   if (ret != 0) {

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -249,6 +249,6 @@ exit: {
 }
 }
 
-void atclient_set_timeout(atclient *ctx, int timeout_ms) {
+void atclient_set_read_timeout(atclient *ctx, int timeout_ms) {
   mbedtls_ssl_conf_read_timeout(&(ctx->secondary_connection.ssl_config), timeout_ms);
 }

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -51,7 +51,7 @@ int atclient_start_secondary_connection(atclient *ctx, const char *secondaryhost
 exit: { return ret; }
 }
 
-int atclient_pkam_authenticate(atclient *ctx, atclient_connection *root_conn, const atclient_atkeys *atkeys,
+int atclient_pkam_authenticate(atclient *ctx, const char *host, const int port, const atclient_atkeys *atkeys,
                                const char *atsign) {
   int ret = 1; // error by default
 

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -51,7 +51,7 @@ int atclient_start_secondary_connection(atclient *ctx, const char *secondaryhost
 exit: { return ret; }
 }
 
-int atclient_pkam_authenticate(atclient *ctx, const char *host, const int port, const atclient_atkeys *atkeys,
+int atclient_pkam_authenticate(atclient *ctx, atclient_connection *root_conn, const atclient_atkeys *atkeys,
                                const char *atsign) {
   int ret = 1; // error by default
 

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -29,6 +29,11 @@ static void my_debug(void *ctx, int level, const char *file, int line, const cha
 }
 
 void atclient_connection_init(atclient_connection *ctx) {
+
+  if(ctx == NULL) {
+    return; // how should we handle this error?
+  }
+
   memset(ctx, 0, sizeof(atclient_connection));
   memset(ctx->host, 0, ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE);
   ctx->port = -1;
@@ -39,6 +44,9 @@ void atclient_connection_init(atclient_connection *ctx) {
   mbedtls_x509_crt_init(&(ctx->cacert));
   mbedtls_entropy_init(&(ctx->entropy));
   mbedtls_ctr_drbg_init(&(ctx->ctr_drbg));
+
+  ctx->should_be_initialized = true;
+  ctx->should_be_connected = false;
 }
 
 int atclient_connection_connect(atclient_connection *ctx, const char *host, const int port) {
@@ -47,11 +55,28 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
   atclient_atstr readbuf;
   atclient_atstr_init(&readbuf, 1024);
 
+  /*
+   * 1. Set the ctx->host and ctx->port
+   */
   memcpy(ctx->host, host, strlen(host)); // assume null terminated, example: "root.atsign.org"
   ctx->port = port;        // example: 64
 
   char portstr[6];
   sprintf(portstr, "%d", ctx->port);
+
+
+  /*
+   * 2. Parse CA certs
+   */
+  ret = mbedtls_x509_crt_parse(&(ctx->cacert), (unsigned char *)cas_pem, cas_pem_len);
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_x509_crt_parse failed with exit code: %d\n", ret);
+    goto exit;
+  }
+
+  /*
+   * 3. Seed the random number generator
+   */
 
   ret = mbedtls_ctr_drbg_seed(&(ctx->ctr_drbg), mbedtls_entropy_func, &(ctx->entropy),
                               (unsigned char *)ATCHOPS_RNG_PERSONALIZATION, strlen(ATCHOPS_RNG_PERSONALIZATION));
@@ -60,18 +85,18 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
     goto exit;
   }
 
-  ret = mbedtls_x509_crt_parse(&(ctx->cacert), (unsigned char *)cas_pem, cas_pem_len);
-  if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_x509_crt_parse failed with exit code: %d\n", ret);
-    goto exit;
-  }
-
+  /*
+   * 4. Start the socket connection
+   */
   ret = mbedtls_net_connect(&(ctx->net), host, portstr, MBEDTLS_NET_PROTO_TCP);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_net_connect failed with exit code: %d\n", ret);
     goto exit;
   }
 
+  /*
+   * 5. Prepare the SSL connection
+   */
   ret = mbedtls_ssl_config_defaults(&(ctx->ssl_config), MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
                                     MBEDTLS_SSL_PRESET_DEFAULT);
   if (ret != 0) {
@@ -79,8 +104,8 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
     goto exit;
   }
 
-  mbedtls_ssl_conf_ca_chain(&(ctx->ssl_config), &(ctx->cacert), NULL);
   mbedtls_ssl_conf_authmode(&(ctx->ssl_config), MBEDTLS_SSL_VERIFY_REQUIRED);
+  mbedtls_ssl_conf_ca_chain(&(ctx->ssl_config), &(ctx->cacert), NULL);
   mbedtls_ssl_conf_rng(&(ctx->ssl_config), mbedtls_ctr_drbg_random, &(ctx->ctr_drbg));
   mbedtls_ssl_conf_dbg(&(ctx->ssl_config), my_debug, stdout);
 
@@ -98,12 +123,18 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
 
   mbedtls_ssl_set_bio(&(ctx->ssl), &(ctx->net), mbedtls_net_send, mbedtls_net_recv, mbedtls_net_recv_timeout);
 
+  /*
+   * 6. Perform the SSL handshake
+   */
   ret = mbedtls_ssl_handshake(&(ctx->ssl));
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_handshake failed with exit code: %d\n", ret);
     goto exit;
   }
 
+  /*
+   * 7. Verify the server certificate
+   */
   ret = mbedtls_ssl_get_verify_result(&(ctx->ssl));
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_get_verify_result failed with exit code: %d\n", ret);
@@ -140,10 +171,17 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
     ret = 0; // a positive exit code is not an error
   }
 
+  ctx->should_be_connected = true;
+
   goto exit;
 
 exit: {
   atclient_atstr_free(&readbuf);
+  if(ret != 0) {
+    // undo what we set
+    memset(ctx->host, 0, ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE);
+    ctx->port = -1;
+  }
   return ret;
 }
 }
@@ -220,7 +258,7 @@ int atclient_connection_disconnect(atclient_connection *ctx) {
 
 int atclient_connection_is_connected(atclient_connection *ctx) {
   int ret = 0; // false by default
-  const char *cmd = "\r\n";
+  const char *cmd = "\n";
   const size_t cmdlen = strlen(cmd);
   const size_t recvsize = 128;
   unsigned char recv[recvsize];
@@ -244,12 +282,25 @@ exit: { return ret; }
 }
 
 void atclient_connection_free(atclient_connection *ctx) {
+  if(!ctx->should_be_initialized) {
+    return;
+  }
+  if(ctx->should_be_connected) {
+    if((atclient_connection_disconnect(ctx)) != 0) {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_disconnect failed\n");
+    }
+  }
   mbedtls_net_free(&(ctx->net));
   mbedtls_ssl_free(&(ctx->ssl));
   mbedtls_ssl_config_free(&(ctx->ssl_config));
   mbedtls_x509_crt_free(&(ctx->cacert));
   mbedtls_entropy_free(&(ctx->entropy));
   mbedtls_ctr_drbg_free(&(ctx->ctr_drbg));
+  memset(ctx, 0, sizeof(atclient_connection));
+  memset(ctx->host, 0, ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE);
+  ctx->port = -1;
+  ctx->should_be_initialized = false;
+  ctx->should_be_connected = false;
 }
 
 int atclient_connection_get_host_and_port(atclient_atstr *host, int *port, const atclient_atstr url) {

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -208,7 +208,8 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
   }
 
   ret = mbedtls_ssl_write(&(ctx->ssl), src, srclen);
-  if (ret < 0) {
+  if (ret <= 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_write failed with exit code: %d\n", ret);
     goto exit;
   }
 
@@ -216,7 +217,6 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     unsigned char srccopy[srclen];
     memcpy(srccopy, src, srclen);
     atlogger_fix_stdout_buffer((char *) srccopy, srclen);
-
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sSENT: %s\"%.*s\"%s\n", BBLU, HCYN, strlen((char *) srccopy), srccopy,
                  reset);
   }
@@ -249,7 +249,8 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
 
   } while (ret == MBEDTLS_ERR_SSL_WANT_READ || !found);
 
-  if (ret < 0) {
+  if (ret <= 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_read failed with exit code: %d\n", ret);
     goto exit;
   }
 
@@ -310,7 +311,7 @@ int atclient_connection_is_connected(atclient_connection *ctx) {
   ret = atclient_connection_send(ctx, (unsigned char *)command, commandlen, recv,
                                  recvsize, &recvlen);
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to send \n to connection: %d\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to send \'\\n\' to connection: %d\n", ret);
     ret = -1;
     goto exit;
   }

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -296,12 +296,11 @@ int atclient_connection_disconnect(atclient_connection *ctx) {
 exit: { return ret; }
 }
 
-int atclient_connection_is_connected(atclient_connection *ctx) {
-  int ret = -1;
+bool atclient_connection_is_connected(atclient_connection *ctx) {
 
   if (!ctx->should_be_connected) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_connected should be true, but is false\n");
-    return ret;
+    return false;
   }
 
   char *command = "\n";
@@ -312,9 +311,9 @@ int atclient_connection_is_connected(atclient_connection *ctx) {
   } else {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                  "ctx->type is not ATCLIENT_CONNECTION_TYPE_ATSERVER or ATCLIENT_CONNECTION_TYPE_ROOT\n");
-    return ret;
+    return false;
   }
-  
+
   const size_t commandlen = strlen(command);
 
   const size_t recvsize = 64;
@@ -322,23 +321,18 @@ int atclient_connection_is_connected(atclient_connection *ctx) {
   memset(recv, 0, sizeof(unsigned char) * recvsize);
   size_t recvlen;
 
-  ret = atclient_connection_send(ctx, (unsigned char *)command, commandlen, recv, recvsize, &recvlen);
+  int ret = atclient_connection_send(ctx, (unsigned char *)command, commandlen, recv, recvsize, &recvlen);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to send \'\\n\' to connection: %d\n", ret);
-    ret = -1;
-    goto exit;
+    return false;
   }
 
   if (recvlen <= 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "recvlen is <= 0, connection did not respond to \'\\n\'\n");
-    ret = 0;
-    goto exit;
+    return false;
   }
 
-  ret = 1;
-  goto exit;
-
-exit: { return ret; }
+  return true;
 }
 
 void atclient_connection_free(atclient_connection *ctx) {

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -120,7 +120,7 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
   mbedtls_ssl_conf_authmode(&(ctx->ssl_config), MBEDTLS_SSL_VERIFY_REQUIRED);
   mbedtls_ssl_conf_rng(&(ctx->ssl_config), mbedtls_ctr_drbg_random, &(ctx->ctr_drbg));
   mbedtls_ssl_conf_dbg(&(ctx->ssl_config), my_debug, stdout);
-  mbedtls_ssl_conf_read_timeout(&(ctx->ssl_config), ATCLIENT_CONSTANTS_READ_TIMEOUT); // recv will timeout after X seconds
+  mbedtls_ssl_conf_read_timeout(&(ctx->ssl_config), ATCLIENT_CLIENT_READ_TIMEOUT_MS); // recv will timeout after X seconds
 
   ret = mbedtls_ssl_setup(&(ctx->ssl), &(ctx->ssl_config));
   if (ret != 0) {

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -47,7 +47,7 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
   atclient_atstr readbuf;
   atclient_atstr_init(&readbuf, 1024);
 
-  strcpy(ctx->host, host); // assume null terminated, example: "root.atsign.org"
+  memcpy(ctx->host, host, strlen(host)); // assume null terminated, example: "root.atsign.org"
   ctx->port = port;        // example: 64
 
   char portstr[6];

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -208,7 +208,7 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
   int ret = 1;
 
   if (!ctx->should_be_connected) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_connected should be true, but is false\n");
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_connected should be true, but is false. You are trying to send messages to a non-connected connection.\n");
     goto exit;
   }
 

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -231,6 +231,8 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     goto exit;
   }
 
+  memset(recv, 0, sizeof(unsigned char) * recvsize);
+
   bool found = false;
   size_t l = 0;
   do {
@@ -259,13 +261,14 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     goto exit;
   }
 
+  // atlogger_fix_stdout_buffer((char *)recv, *recvlen);
   recv[*recvlen] = '\0'; // null terminate the string
 
   if (atlogger_get_logging_level() >= ATLOGGER_LOGGING_LEVEL_DEBUG) {
     unsigned char recvcopy[*recvlen];
     memcpy(recvcopy, recv, *recvlen);
     atlogger_fix_stdout_buffer((char *)recvcopy, *recvlen);
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, strlen(recvcopy), recvcopy,
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, *recvlen, recvcopy,
                  reset);
   }
 
@@ -318,7 +321,6 @@ bool atclient_connection_is_connected(atclient_connection *ctx) {
 
   const size_t recvsize = 64;
   unsigned char recv[recvsize];
-  memset(recv, 0, sizeof(unsigned char) * recvsize);
   size_t recvlen;
 
   int ret = atclient_connection_send(ctx, (unsigned char *)command, commandlen, recv, recvsize, &recvlen);

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -104,8 +104,8 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
     goto exit;
   }
 
-  mbedtls_ssl_conf_authmode(&(ctx->ssl_config), MBEDTLS_SSL_VERIFY_REQUIRED);
   mbedtls_ssl_conf_ca_chain(&(ctx->ssl_config), &(ctx->cacert), NULL);
+  mbedtls_ssl_conf_authmode(&(ctx->ssl_config), MBEDTLS_SSL_VERIFY_REQUIRED);
   mbedtls_ssl_conf_rng(&(ctx->ssl_config), mbedtls_ctr_drbg_random, &(ctx->ctr_drbg));
   mbedtls_ssl_conf_dbg(&(ctx->ssl_config), my_debug, stdout);
 
@@ -167,12 +167,12 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
   }
 
   // now we are guaranteed a blank canvas
-  if (ret > 0) {
-    ret = 0; // a positive exit code is not an error
-  }
 
   ctx->should_be_connected = true;
 
+  if (ret > 0) {
+    ret = 0; // a positive exit code is not an error
+  }
   goto exit;
 
 exit: {
@@ -252,7 +252,6 @@ int atclient_connection_disconnect(atclient_connection *ctx) {
   } while (ret == MBEDTLS_ERR_SSL_WANT_WRITE);
   ret = 0;
 
-  atclient_connection_free(ctx);
   return ret;
 }
 

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -553,9 +553,16 @@ int atclient_monitor_pkam_authenticate(atclient *monitor_conn, atclient_connecti
     goto exit;
   }
 
+  atclient_monitor_set_read_timeout(monitor_conn, ATCLIENT_MONITOR_READ_TIMEOUT_MS);
+
   ret = 0;
   goto exit;
 exit: { return ret; }
+}
+
+void atclient_monitor_set_read_timeout(atclient *monitor_conn, const int timeoutms)
+{
+  mbedtls_ssl_conf_read_timeout(&(monitor_conn->secondary_connection.ssl_config), timeoutms);
 }
 
 int atclient_monitor_start(atclient *monitor_conn, const char *regex, const size_t regexlen) {
@@ -612,6 +619,9 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
   memset(buffer, 0, sizeof(char) * chunksize);
   char *buffertemp = NULL;
 
+  *message = malloc(sizeof(atclient_monitor_message));
+  atclient_monitor_message_init(*message);
+
   bool done_reading = false;
   while (!done_reading) {
     if (chunks > 0) {
@@ -632,6 +642,8 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
     chunks = chunks + 1;
   }
   if (ret < 0) {
+    (*message)->type = ATCLIENT_MONITOR_ERROR_READ;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Read nothing from the monitor connection: %d\n", ret);
     goto exit;
   }
 
@@ -644,12 +656,10 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
   char *messagebody = NULL;
   ret = parse_message(buffer, &messagetype, &messagebody);
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to find message type and message body from: %s\n", buffer);
+    (*message)->type = ATCLIENT_MONITOR_ERROR_PARSE;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Failed to find message type and message body from: %s\n", buffer);
     goto exit;
   }
-
-  *message = malloc(sizeof(atclient_monitor_message));
-  atclient_monitor_message_init(*message);
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, messagetype, messagebody,
                reset);

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -714,6 +714,10 @@ exit: {
 }
 }
 
+int atclient_monitor_is_connected(atclient *monitor_conn) {
+  return atclient_connection_is_connected(&monitor_conn->secondary_connection);
+}
+
 // given a string notification (*original is assumed to JSON parsable), we can deduce the message_type (e.g. data,
 // error, notification) and return the message body which is everything after the prefix (data:, error:, notification:).
 // This function will modify *message_type and *message_body to point to the respective values in *original.

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -714,7 +714,7 @@ exit: {
 }
 }
 
-int atclient_monitor_is_connected(atclient *monitor_conn) {
+bool atclient_monitor_is_connected(atclient *monitor_conn) {
   return atclient_connection_is_connected(&monitor_conn->secondary_connection);
 }
 

--- a/tests/functional_tests/lib/src/helpers.c
+++ b/tests/functional_tests/lib/src/helpers.c
@@ -41,7 +41,7 @@ int functional_tests_pkam_auth(atclient *atclient, atclient_atkeys *atkeys, cons
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "functional_tests_pkam_auth Begin\n");
 
   atclient_connection root_connection;
-  atclient_connection_init(&root_connection);
+  atclient_connection_init(&root_connection, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
 
   if ((ret = atclient_connection_connect(&root_connection, ROOT_HOST, ROOT_PORT)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_connect: %d\n", ret);

--- a/tests/functional_tests/tests/test_atclient_connection.c
+++ b/tests/functional_tests/tests/test_atclient_connection.c
@@ -1,128 +1,343 @@
 #include <atclient/connection.h>
 #include <atlogger/atlogger.h>
 #include <functional_tests/helpers.h>
+#include <string.h>
 
 #define TAG "test_atclient_connection"
 
-#define ROOT_HOST "root.atsign.org" 
+#define ROOT_HOST "root.atsign.org"
 #define ROOT_PORT 64
+
+static int assert_equals(bool actual, bool expected);
 
 static int test_1_initialize(atclient_connection *conn);
 static int test_2_connect(atclient_connection *conn);
-static int test_3_is_connected(atclient_connection *conn);
+static int test_3_is_connected_should_be_true(atclient_connection *conn);
 static int test_4_send(atclient_connection *conn);
 static int test_5_disconnect(atclient_connection *conn);
-static int test_6_send(atclient_connection *conn); // should fail, a failuer to send will return 0
-static int test_7_free(atclient_connection *conn);
+static int test_6_is_connected_should_be_false(atclient_connection *conn);
+static int test_7_send_should_fail(atclient_connection *conn); // should fail, a failuer to send will return 0
+static int test_8_reconnect(atclient_connection *conn);
+static int test_9_is_connected_should_be_true(atclient_connection *conn);
+static int test_10_free(atclient_connection *conn);
 
-int main(int argc, char *argv[])
-{
-    int ret = 1;
+// simulating a server that is not responding back
+static int test_11_initialize(atclient_connection *conn);
 
-    atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);
+int main(int argc, char *argv[]) {
+  int ret = 1;
 
-    atclient_connection root_conn;
+  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);
 
-    if ((ret = test_1_initialize(&root_conn)) != 0)
-    {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_1_initialize: %d\n", ret);
-        goto exit;
-    }
+  atclient_connection root_conn;
 
-    if((ret = test_2_connect(&root_conn)) != 0)
-    {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_2_connect: %d\n", ret);
-        goto exit;
-    }
-
-    if((ret = test_3_is_connected(&root_conn)) != 0)
-    {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_3_is_connected: %d\n", ret);
-        goto exit;
-    }
-
-    ret = 0;
+  if ((ret = test_1_initialize(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_1_initialize: %d\n", ret);
     goto exit;
-exit: {
-    return ret;
-}
-}
+  }
 
-static int test_1_initialize(atclient_connection *conn)
-{
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_1_initialize Begin\n");
-
-    int ret = 1;
-
-    atclient_connection_init(conn);
-
-    if(!conn->should_be_initialized)
-    {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_initialized should be true, but is false\n");
-        ret = 1;
-        goto exit;
-    }
-
-    if(conn->should_be_connected)
-    {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_connected should be false, but is true.\n");
-        ret = 1;
-        goto exit;
-    }
-
-    ret = 0;
+  if ((ret = test_2_connect(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_2_connect: %d\n", ret);
     goto exit;
-exit: {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_1_initialize End: %d\n", ret);
-    return ret;
-}
-}
+  }
 
-static int test_2_connect(atclient_connection *conn)
-{
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_2_connect Begin\n");
-
-    int ret = 1;
-
-    ret = atclient_connection_connect(conn, ROOT_HOST, ROOT_PORT);
-    if (ret != 0)
-    {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
-        goto exit;
-    }
-
-    if(!conn->should_be_connected)
-    {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_connected should be true, but is false\n");
-        ret = 1;
-        goto exit;
-    }
-
-    ret = 0;
+  if ((ret = test_3_is_connected_should_be_true(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_3_is_connected: %d\n", ret);
     goto exit;
-exit: {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_2_connect End: %d\n", ret);
-    return ret;
-}
-}
+  }
 
-static int test_3_is_connected(atclient_connection *conn)
-{
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_3_is_connected Begin\n");
-
-    int ret = 1;
-
-    ret = atclient_connection_is_connected(conn);
-    if (ret != 1)
-    {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
-        goto exit;
-    }
-
-    ret = 0;
+  if ((ret = test_4_send(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_4_send: %d\n", ret);
     goto exit;
+  }
+
+  if ((ret = test_5_disconnect(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_5_disconnect: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_6_is_connected_should_be_false(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_6_is_connected_should_be_false: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_7_send_should_fail(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_7_send_should_fail: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_8_reconnect(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_7_reconnect: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_9_is_connected_should_be_true(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_8_is_connected: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_10_free(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_9_free: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_11_initialize(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_11_initialize: %d\n", ret);
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: { return ret; }
+}
+
+static int assert_equals(bool actual, bool expected) {
+  if (actual != expected) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Expected %d, but got %d\n", expected, actual);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_1_initialize(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_1_initialize Begin\n");
+
+  int ret = 1;
+
+  atclient_connection_init(conn);
+
+  if((ret = assert_equals(conn->should_be_connected, false)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be false, but is true\n");
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
 exit: {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_3_is_connected End: %d\n", ret);
-    return ret;
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_1_initialize End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_2_connect(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_2_connect Begin\n");
+
+  int ret = 1;
+
+  ret = atclient_connection_connect(conn, ROOT_HOST, ROOT_PORT);
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = assert_equals(conn->should_be_connected, true)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "root_conn.should_be_connected should be true, but is false\n");
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_2_connect End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_3_is_connected_should_be_true(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_3_is_connected Begin\n");
+
+  int ret = 1;
+
+  ret = atclient_connection_is_connected(conn);
+  if (ret != 1) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_3_is_connected End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_4_send(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_4_send Begin\n");
+
+  int ret = 1;
+
+  const unsigned char *send_data = (const unsigned char *)"12alpaca\r\n";
+  const size_t send_data_len = strlen((const char *)send_data);
+
+  const size_t recvsize = 1024;
+  unsigned char recv[1024];
+  size_t recvlen = 0;
+
+  ret = atclient_connection_send(conn, send_data, send_data_len, recv, recvsize, &recvlen);
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to send: %d\n", ret);
+    goto exit;
+  }
+
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Received: %s\n", recv);
+
+  ret = 0;
+  goto exit;
+exit: { return ret; }
+}
+
+static int test_5_disconnect(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_5_disconnect Begin\n");
+
+  int ret = 1;
+
+  ret = atclient_connection_disconnect(conn);
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to disconnect: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = assert_equals(conn->should_be_connected, false)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "root_conn.should_be_connected should be false, but is true\n");
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_5_disconnect End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_6_is_connected_should_be_false(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_6_is_connected_should_be_false Begin\n");
+
+  int ret;
+
+  ret = atclient_connection_is_connected(conn);
+  if (ret == 1) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "atclient_connection_is_connected returned true when it should have been false: %d\n", ret);
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_6_is_connected_should_be_false End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_7_send_should_fail(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_7_send_should_fail\n");
+
+  int ret = 1;
+
+  const unsigned char *send_data = (const unsigned char *)"12alpaca\r\n";
+  const size_t send_data_len = strlen((const char *)send_data);
+
+  const size_t recvsize = 1024;
+  unsigned char recv[recvsize];
+  size_t recvlen = 0;
+
+  ret = atclient_connection_send(conn, send_data, send_data_len, recv, recvsize, &recvlen);
+  if (ret == 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "Successfully sent \"%s\" when it should have resulted in a failure: %d\n", ret);
+    ret = 1;
+    goto exit;
+  }
+
+  atlogger_fix_stdout_buffer(recv, recvlen);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO,
+               "Successfully failed at sending message to a disconnected connection.\n", send_data);
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_7_send_should_fail End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_8_reconnect(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_8_reconnect Begin\n");
+
+  int ret = 1;
+
+  ret = atclient_connection_connect(conn, ROOT_HOST, ROOT_PORT);
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to reconnect: %d\n", ret);
+    goto exit;
+  }
+
+  if (!conn->should_be_connected) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_connected should be true, but is false\n");
+    ret = 1;
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_8_reconnect End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_9_is_connected_should_be_true(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_9_is_connected_should_be_true Begin\n");
+
+  int ret = 1;
+
+  ret = atclient_connection_is_connected(conn);
+  if (ret != 1) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: { return ret; }
+}
+
+static int test_10_free(atclient_connection *conn) {
+  int ret = 1;
+
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_10_free Begin\n");
+
+  atclient_connection_free(conn);
+
+  if ((ret = assert_equals(conn->should_be_connected, false)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be false, but is true\n");
+    goto exit;
+  }
+
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_10_free End\n");
+  return ret;
+}
+}
+
+static int test_11_initialize(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_11_initialize Begin\n");
+
+  int ret = 1;
+
+  atclient_connection_init(conn);
+
+  if((ret = assert_equals(conn->should_be_connected, false)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be false, but is true\n");
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_11_initialize End: %d\n", ret);
+  return ret;
 }
 }

--- a/tests/functional_tests/tests/test_atclient_connection.c
+++ b/tests/functional_tests/tests/test_atclient_connection.c
@@ -23,6 +23,12 @@ static int test_10_free(atclient_connection *conn);
 
 // simulating a server that is not responding back
 static int test_11_initialize(atclient_connection *conn);
+static int test_12_connect(atclient_connection *conn);
+static int test_13_is_connected_should_be_true(atclient_connection *conn);
+static int test_14_simulate_server_not_responding(atclient_connection *conn);
+static int test_15_send_should_fail(atclient_connection *conn);
+static int test_16_is_connected_should_be_false(atclient_connection *conn);
+static int test_17_should_be_connected_should_be_true(atclient_connection *conn);
 
 int main(int argc, char *argv[]) {
   int ret = 1;
@@ -86,6 +92,36 @@ int main(int argc, char *argv[]) {
     goto exit;
   }
 
+  if ((ret = test_12_connect(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_12_connect: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_13_is_connected_should_be_true(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_13_is_connected: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_14_simulate_server_not_responding(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_14_simulate_server_not_responding: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_15_send_should_fail(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_15_send_should_fail: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_16_is_connected_should_be_false(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_16_is_connected_should_be_false: %d\n", ret);
+    goto exit;
+  }
+
+  if ((ret = test_17_should_be_connected_should_be_true(&root_conn)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_17_should_be_connected_should_be_true: %d\n", ret);
+    goto exit;
+  }
+
   ret = 0;
   goto exit;
 exit: { return ret; }
@@ -106,7 +142,7 @@ static int test_1_initialize(atclient_connection *conn) {
 
   atclient_connection_init(conn);
 
-  if((ret = assert_equals(conn->should_be_connected, false)) != 0) {
+  if ((ret = assert_equals(conn->should_be_connected, false)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be false, but is true\n");
     goto exit;
   }
@@ -251,9 +287,8 @@ static int test_7_send_should_fail(atclient_connection *conn) {
     goto exit;
   }
 
-  atlogger_fix_stdout_buffer(recv, recvlen);
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO,
-               "Successfully failed at sending message to a disconnected connection.\n", send_data);
+               "Successfully failed at sending message to a disconnected connection\n");
 
   ret = 0;
   goto exit;
@@ -329,7 +364,7 @@ static int test_11_initialize(atclient_connection *conn) {
 
   atclient_connection_init(conn);
 
-  if((ret = assert_equals(conn->should_be_connected, false)) != 0) {
+  if ((ret = assert_equals(conn->should_be_connected, false)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be false, but is true\n");
     goto exit;
   }
@@ -338,6 +373,136 @@ static int test_11_initialize(atclient_connection *conn) {
   goto exit;
 exit: {
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_11_initialize End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_12_connect(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_12_connect Begin\n");
+
+  int ret = 1;
+
+  ret = atclient_connection_connect(conn, ROOT_HOST, ROOT_PORT);
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_12_connect End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_13_is_connected_should_be_true(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_13_is_connected Begin\n");
+
+  int ret = 1;
+
+  ret = atclient_connection_is_connected(conn);
+  if (ret != 1) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_13_is_connected End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_14_simulate_server_not_responding(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_14_simulate_server_not_responding Begin\n");
+
+  int ret = 1;
+
+  // simulate server not responding
+  ret = mbedtls_ssl_close_notify(&conn->ssl);
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to close notify: %d\n", ret);
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_14_simulate_server_not_responding End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_15_send_should_fail(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_15_send_should_fail\n");
+
+  int ret = 1;
+
+  const unsigned char *send_data = (const unsigned char *)"12alpaca\r\n";
+  const size_t send_data_len = strlen((const char *)send_data);
+
+  const size_t recvsize = 1024;
+  unsigned char recv[recvsize];
+  memset(recv, 0, recvsize);
+  size_t recvlen = 0;
+
+  ret = atclient_connection_send(conn, send_data, send_data_len, recv, recvsize, &recvlen);
+  if (ret == 0) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "Successfully sent message, when it should have been a failure. ret: %d\n", ret);
+    goto exit;
+  }
+
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Successfully failed at sending message to a disconnected connection: %d\n", ret);
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_15_send_should_fail End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_16_is_connected_should_be_false(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_16_is_connected_should_be_false Begin\n");
+
+  int ret;
+
+  ret = atclient_connection_is_connected(conn);
+  if (ret == 1) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "atclient_connection_is_connected returned true when it should have been false: %d\n", ret);
+    goto exit;
+  }
+
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Connection is not connected, as expected: %d\n", ret);
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_16_is_connected_should_be_false End: %d\n", ret);
+  return ret;
+}
+}
+
+static int test_17_should_be_connected_should_be_true(atclient_connection *conn) {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_17_should_be_connected_should_be_true Begin\n");
+
+  int ret = 1;
+
+  if ((ret = assert_equals(conn->should_be_connected, true)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be true, but is false\n");
+    goto exit;
+  }
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "conn->should_be_connected is true, as expected\n");
+
+  ret = 0;
+  goto exit;
+exit: {
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_17_should_be_connected_should_be_true End: %d\n", ret);
   return ret;
 }
 }

--- a/tests/functional_tests/tests/test_atclient_connection.c
+++ b/tests/functional_tests/tests/test_atclient_connection.c
@@ -184,9 +184,9 @@ static int test_3_is_connected_should_be_true(atclient_connection *conn) {
 
   int ret = 1;
 
-  ret = atclient_connection_is_connected(conn);
-  if (ret != 1) {
+  if (!atclient_connection_is_connected(conn)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
+    ret = 1;
     goto exit;
   }
 
@@ -250,10 +250,9 @@ exit: {
 static int test_6_is_connected_should_be_false(atclient_connection *conn) {
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_6_is_connected_should_be_false Begin\n");
 
-  int ret;
+  int ret= 1; 
 
-  ret = atclient_connection_is_connected(conn);
-  if (ret == 1) {
+  if (atclient_connection_is_connected(conn)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                  "atclient_connection_is_connected returned true when it should have been false: %d\n", ret);
     goto exit;
@@ -328,9 +327,9 @@ static int test_9_is_connected_should_be_true(atclient_connection *conn) {
 
   int ret = 1;
 
-  ret = atclient_connection_is_connected(conn);
-  if (ret != 1) {
+  if (!atclient_connection_is_connected(conn)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
+    ret = 1;
     goto exit;
   }
 
@@ -401,8 +400,7 @@ static int test_13_is_connected_should_be_true(atclient_connection *conn) {
 
   int ret = 1;
 
-  ret = atclient_connection_is_connected(conn);
-  if (ret != 1) {
+  if (!atclient_connection_is_connected(conn)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
     goto exit;
   }
@@ -469,12 +467,12 @@ exit: {
 static int test_16_is_connected_should_be_false(atclient_connection *conn) {
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_16_is_connected_should_be_false Begin\n");
 
-  int ret;
+  int ret = 1;
 
-  ret = atclient_connection_is_connected(conn);
-  if (ret == 1) {
+  if (atclient_connection_is_connected(conn)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                  "atclient_connection_is_connected returned true when it should have been false: %d\n", ret);
+    ret = 1;
     goto exit;
   }
 

--- a/tests/functional_tests/tests/test_atclient_connection.c
+++ b/tests/functional_tests/tests/test_atclient_connection.c
@@ -1,0 +1,128 @@
+#include <atclient/connection.h>
+#include <atlogger/atlogger.h>
+#include <functional_tests/helpers.h>
+
+#define TAG "test_atclient_connection"
+
+#define ROOT_HOST "root.atsign.org" 
+#define ROOT_PORT 64
+
+static int test_1_initialize(atclient_connection *conn);
+static int test_2_connect(atclient_connection *conn);
+static int test_3_is_connected(atclient_connection *conn);
+static int test_4_send(atclient_connection *conn);
+static int test_5_disconnect(atclient_connection *conn);
+static int test_6_send(atclient_connection *conn); // should fail, a failuer to send will return 0
+static int test_7_free(atclient_connection *conn);
+
+int main(int argc, char *argv[])
+{
+    int ret = 1;
+
+    atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);
+
+    atclient_connection root_conn;
+
+    if ((ret = test_1_initialize(&root_conn)) != 0)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_1_initialize: %d\n", ret);
+        goto exit;
+    }
+
+    if((ret = test_2_connect(&root_conn)) != 0)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_2_connect: %d\n", ret);
+        goto exit;
+    }
+
+    if((ret = test_3_is_connected(&root_conn)) != 0)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_3_is_connected: %d\n", ret);
+        goto exit;
+    }
+
+    ret = 0;
+    goto exit;
+exit: {
+    return ret;
+}
+}
+
+static int test_1_initialize(atclient_connection *conn)
+{
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_1_initialize Begin\n");
+
+    int ret = 1;
+
+    atclient_connection_init(conn);
+
+    if(!conn->should_be_initialized)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_initialized should be true, but is false\n");
+        ret = 1;
+        goto exit;
+    }
+
+    if(conn->should_be_connected)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_connected should be false, but is true.\n");
+        ret = 1;
+        goto exit;
+    }
+
+    ret = 0;
+    goto exit;
+exit: {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_1_initialize End: %d\n", ret);
+    return ret;
+}
+}
+
+static int test_2_connect(atclient_connection *conn)
+{
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_2_connect Begin\n");
+
+    int ret = 1;
+
+    ret = atclient_connection_connect(conn, ROOT_HOST, ROOT_PORT);
+    if (ret != 0)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
+        goto exit;
+    }
+
+    if(!conn->should_be_connected)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_connected should be true, but is false\n");
+        ret = 1;
+        goto exit;
+    }
+
+    ret = 0;
+    goto exit;
+exit: {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_2_connect End: %d\n", ret);
+    return ret;
+}
+}
+
+static int test_3_is_connected(atclient_connection *conn)
+{
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_3_is_connected Begin\n");
+
+    int ret = 1;
+
+    ret = atclient_connection_is_connected(conn);
+    if (ret != 1)
+    {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
+        goto exit;
+    }
+
+    ret = 0;
+    goto exit;
+exit: {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_3_is_connected End: %d\n", ret);
+    return ret;
+}
+}

--- a/tests/functional_tests/tests/test_atclient_connection.c
+++ b/tests/functional_tests/tests/test_atclient_connection.c
@@ -140,7 +140,7 @@ static int test_1_initialize(atclient_connection *conn) {
 
   int ret = 1;
 
-  atclient_connection_init(conn);
+  atclient_connection_init(conn, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
 
   if ((ret = assert_equals(conn->should_be_connected, false)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be false, but is true\n");
@@ -362,7 +362,7 @@ static int test_11_initialize(atclient_connection *conn) {
 
   int ret = 1;
 
-  atclient_connection_init(conn);
+  atclient_connection_init(conn, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
 
   if ((ret = assert_equals(conn->should_be_connected, false)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be false, but is true\n");

--- a/tests/functional_tests/tests/test_atclient_monitor.c
+++ b/tests/functional_tests/tests/test_atclient_monitor.c
@@ -112,7 +112,7 @@ static int monitor_pkam_auth(atclient *monitor_conn, const atclient_atkeys *atke
   int ret = 1;
 
   atclient_connection root_conn;
-  atclient_connection_init(&root_conn);
+  atclient_connection_init(&root_conn, ATCLIENT_CONNECTION_TYPE_DIRECTORY);
 
   if ((ret = atclient_connection_connect(&root_conn, ROOT_HOST, ROOT_PORT)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_connect: %d\n", ret);

--- a/tests/functional_tests/tools/run_ctest.sh
+++ b/tests/functional_tests/tools/run_ctest.sh
@@ -10,4 +10,4 @@ cd "$SCRIPT_DIRECTORY/.."
 # 2. Run tests
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build
-ctest --test-dir build -VV --timeout 300
+ctest --test-dir build -VV --timeout 60


### PR DESCRIPTION
**- What I did**
- Changed function signature to `atclient_connection_init(atclient_connection *ctx, atclient_connection_type type);`
- NEW enum atclient_connection_type: `ATCLIENT_CONNECTION_TYPE_DIRECTORY` or `ATCLIENT_CONNECTION_TYPE_ATSERVER`. This enum is used to use either `\n` or `noop:0\r\n` to check if a connection is alive
- NEW `resilient_monitor.c` example (desktop/events/)
- NEW `atclient_set_read_timeout` in `atclient.h` - this function sets the `mbedtls_ssl_read` timeout in milliseconds. It will wait `timeout_ms` milliseconds waiting for bytes to be read. The moment one byte is read, the timeout will reset and will read the bytes from the socket. If  `timeout_ms` time has passed, and no data has yet been read, then `mbedtls_ssl_read` will return.
- `atclient_connection->should_be_connected` boolean determines if a connection *should* be connected. A connection *should* be connected if `atclient_connection_connect` was called and *should not* be connected if `atclient_connection_disconnect` was called.
- NEW `atclient_connection_is_connected` uses `\n` or `noop` to check if a connection is connected (if it receives something back).

Other
- Fixed `atclient_connection_free` seg faults
- CTest functional tests will timeout after 60 seconds (if it doesn't pass within 60 seconds it will fail).

New tests
- `test_atclient_connection.c` -> in summary, this test checks that `send` fails and passes when it should and `is_connected` fails and passes when it should. Also checks if `init` and `connect` work as expected.

**- How I did it**
- With hands

**- How to verify it**
- New tests
- Existing tests pass

**- Description for the changelog**
feat: connection resilience capabilities
