### PR TITLE
chore: DEBG instead of INFO for SENT and RECV logs

### DIFF
--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -222,7 +222,7 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     unsigned char srccopy[srclen];
     memcpy(srccopy, src, srclen);
     atlogger_fix_stdout_buffer((char *)srccopy, srclen);
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sSENT: %s\"%.*s\"%s\n", BBLU, HCYN, strlen((char *)srccopy),
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sSENT: %s\"%.*s\"%s\n", BBLU, HCYN, strlen((char *)srccopy),
                  srccopy, reset);
   }
 

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -599,7 +599,7 @@ int atclient_monitor_start(atclient *monitor_conn, const char *regex, const size
     goto exit;
   }
   atlogger_fix_stdout_buffer(cmd, cmdsize);
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sSENT: %s\"%.*s\"%s\n", BBLK, HCYN, (int)strlen(cmd), cmd, reset);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sSENT: %s\"%.*s\"%s\n", BBLK, HCYN, (int)strlen(cmd), cmd, reset);
 
   ret = 0;
   goto exit;
@@ -661,7 +661,7 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, messagetype, messagebody,
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, messagetype, messagebody,
                reset);
 
   if (strcmp(messagetype, "notification") == 0) {


### PR DESCRIPTION
closes #280 

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: DEBG instead of INFO for SENT and RECV logs
