### PR TITLE
feat: atlogger timestamps

### DIFF
--- a/packages/atclient/src/atkeysfile.c
+++ b/packages/atclient/src/atkeysfile.c
@@ -41,6 +41,7 @@ int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path) 
   }
 
   const size_t bytesread = fread(readbuf.str, 1, FILE_READ_BUFFER_SIZE, file);
+  fclose(file);
   if (bytesread == 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "fread failed\n");
     ret = 1;
@@ -87,40 +88,40 @@ int atclient_atkeysfile_read(atclient_atkeysfile *atkeysfile, const char *path) 
   ret = atclient_atstr_set(&(atkeysfile->aespkampublickeystr), aespkampublickey->valuestring,
                            strlen(aespkampublickey->valuestring));
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atclient_atstr_set: %d | failed to set aespkampublickeystr\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkampublickeystr\n",
+                 ret);
     goto exit;
   }
 
   ret = atclient_atstr_set(&(atkeysfile->aespkamprivatekeystr), aespkamprivatekey->valuestring,
                            strlen(aespkamprivatekey->valuestring));
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atclient_atstr_set: %d | failed to set aespkamprivatekeystr\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkamprivatekeystr\n",
+                 ret);
     goto exit;
   }
 
   ret = atclient_atstr_set(&(atkeysfile->aesencryptprivatekeystr), aesencryptprivatekey->valuestring,
                            strlen(aesencryptprivatekey->valuestring));
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atclient_atstr_set: %d | failed to set aesencryptprivatekeystr\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptprivatekeystr\n",
+                 ret);
     goto exit;
   }
 
   ret = atclient_atstr_set(&(atkeysfile->aesencryptpublickeystr), aesencryptpublickey->valuestring,
                            strlen(aesencryptpublickey->valuestring));
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atclient_atstr_set: %d | failed to set aesencryptpublickeystr\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptpublickeystr\n",
+                 ret);
     goto exit;
   }
 
   ret = atclient_atstr_set(&(atkeysfile->selfencryptionkeystr), selfencryptionkey->valuestring,
                            strlen(selfencryptionkey->valuestring));
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n",
+                 ret);
     goto exit;
   }
 
@@ -130,7 +131,6 @@ exit: {
   if (root != NULL) {
     cJSON_Delete(root);
   }
-  fclose(file);
   atclient_atstr_free(&readbuf);
   return ret;
 }
@@ -163,43 +163,42 @@ int atclient_atkeysfile_write(const atclient_atkeysfile *atkeysfile, const char 
   cJSON_AddStringToObject(root, "aesEncryptPublicKey", aesencryptpublickey.str);
   cJSON_AddStringToObject(root, "selfEncryptionKey", selfencryptionkey.str);
 
-  ret =
-      atclient_atstr_set(&aespkampublickey, atkeysfile->aespkampublickeystr.str, atkeysfile->aespkampublickeystr.len);
+  ret = atclient_atstr_set(&aespkampublickey, atkeysfile->aespkampublickeystr.str, atkeysfile->aespkampublickeystr.len);
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atclient_atstr_set: %d | failed to set aespkampublickeystr\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkampublickeystr\n",
+                 ret);
     goto exit;
   }
 
   ret = atclient_atstr_set(&aespkamprivatekey, atkeysfile->aespkamprivatekeystr.str,
                            atkeysfile->aespkamprivatekeystr.len);
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atclient_atstr_set: %d | failed to set aespkamprivatekeystr\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aespkamprivatekeystr\n",
+                 ret);
     goto exit;
   }
 
   ret = atclient_atstr_set(&aesencryptprivatekey, atkeysfile->aesencryptprivatekeystr.str,
                            atkeysfile->aesencryptprivatekeystr.len);
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atclient_atstr_set: %d | failed to set aesencryptprivatekeystr\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptprivatekeystr\n",
+                 ret);
     goto exit;
   }
 
   ret = atclient_atstr_set(&aesencryptpublickey, atkeysfile->aesencryptpublickeystr.str,
                            atkeysfile->aesencryptpublickeystr.len);
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atclient_atstr_set: %d | failed to set aesencryptpublickeystr\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set aesencryptpublickeystr\n",
+                 ret);
     goto exit;
   }
 
   ret = atclient_atstr_set(&selfencryptionkey, atkeysfile->selfencryptionkeystr.str,
                            atkeysfile->selfencryptionkeystr.len);
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set: %d | failed to set selfencryptionkeystr\n",
+                 ret);
     goto exit;
   }
 

--- a/packages/atlogger/include/atlogger/atlogger.h
+++ b/packages/atlogger/include/atlogger/atlogger.h
@@ -12,8 +12,12 @@ enum atlogger_logging_level {
   ATLOGGER_LOGGING_LEVEL_DEBUG = 100, // everything, very verbose
 };
 
+// opts
+#define ATLOGGER_ENABLE_TIMESTAMPS 1
+
 enum atlogger_logging_level atlogger_get_logging_level();
 void atlogger_set_logging_level(const enum atlogger_logging_level level);
+void atlogger_set_opts(int opts);
 void atlogger_log(const char *tag, const enum atlogger_logging_level level, const char *format, ...);
 void atlogger_fix_stdout_buffer(char *str, const size_t strlen);
 

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -82,8 +82,9 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
       off += strlen(prefix + off);
     }
 
+    off -= 3;
     snprintf(prefix + off, PREFIX_BUFFER_LEN - off, " |");
-    off += 3;
+    off += 2;
     prefix[off] = '\0';
   }
 }

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -69,7 +69,7 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
     int res = clock_gettime(CLOCK_REALTIME, &timespec);
 
     if (res == 0) {
-      res = strftime(prefix + off, PREFIX_BUFFER_LEN - off, " | %F %T",
+      res = strftime(prefix + off, PREFIX_BUFFER_LEN - off, "%F %T",
                      gmtime(&timespec.tv_sec)); // format accurate to the second
       if (res != 0) {
         off += res;
@@ -82,7 +82,7 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
       off += strlen(prefix + off);
     }
 
-    snprintf(prefix + off, PREFIX_BUFFER_LEN - off, " | ");
+    snprintf(prefix + off, PREFIX_BUFFER_LEN - off, " |");
     off += 3;
     prefix[off] = '\0';
   }
@@ -116,7 +116,7 @@ void atlogger_log(const char *tag, const enum atlogger_logging_level level, cons
   va_start(args, format);
   printf(" %.*s", (int)strlen(prefix), prefix);
   if (tag != NULL) {
-    printf("\t%s", tag);
+    printf(" %s", tag);
   }
   printf(" | ");
   vprintf(format, args);

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -68,7 +68,7 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
   if (ctx->opts & ATLOGGER_ENABLE_TIMESTAMPS) {
     int res = clock_gettime(CLOCK_REALTIME, &timespec); // posix-1.2008 way
     if (res == 0) {
-      snprintf(prefix + off, PREFIX_BUFFER_LEN - off, "%ld", timespec.tv_sec * 1000000 + timespec.tv_nsec);
+      snprintf(prefix + off, PREFIX_BUFFER_LEN - off, " %ld", timespec.tv_sec * 1000000 + timespec.tv_nsec);
       // TODO: adjust off if any other things need to be added to the prefix
     }
   }

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -69,7 +69,7 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
     int res = clock_gettime(CLOCK_REALTIME, &timespec);
 
     if (res == 0) {
-      res = strftime(prefix + off, PREFIX_BUFFER_LEN - off, "%F %T",
+      res = strftime(prefix + off, PREFIX_BUFFER_LEN - off, " | %F %T",
                      gmtime(&timespec.tv_sec)); // format accurate to the second
       if (res != 0) {
         off += res;
@@ -79,9 +79,10 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
 
     if (res == 0) {
       snprintf(prefix + off, PREFIX_BUFFER_LEN - off, ".%ld", timespec.tv_nsec);
-      // TODO: future modifications to the prefix require calculation of the new offset
-      // off += ?
+      off += strlen(prefix + off);
     }
+
+    snprintf(prefix + off, PREFIX_BUFFER_LEN - off, " | ");
   }
 }
 

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -1,10 +1,11 @@
 
 #include "atlogger/atlogger.h"
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stddef.h>
+#include <time.h>
 
 #define PREFIX_BUFFER_LEN 64
 #define INFO_PREFIX "\e[0;32m[INFO]\e[0m"
@@ -13,36 +14,12 @@
 #define DEBUG_PREFIX "\e[0;34m[DEBG]\e[0m"
 
 static char *prefix;
+static struct timespec timespec;
 
 typedef struct atlogger_ctx {
   enum atlogger_logging_level level;
+  int opts;
 } atlogger_ctx;
-
-static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char *prefix,
-                                size_t prefixlen) {
-  memset(prefix, 0, prefixlen);
-  switch (logging_level) {
-  case ATLOGGER_LOGGING_LEVEL_INFO: {
-    memcpy(prefix, INFO_PREFIX, strlen(INFO_PREFIX));
-    break;
-  }
-  case ATLOGGER_LOGGING_LEVEL_WARN: {
-    memcpy(prefix, WARN_PREFIX, strlen(WARN_PREFIX));
-    break;
-  }
-  case ATLOGGER_LOGGING_LEVEL_ERROR: {
-    memcpy(prefix, ERROR_PREFIX, strlen(ERROR_PREFIX));
-    break;
-  }
-  case ATLOGGER_LOGGING_LEVEL_DEBUG: {
-    memcpy(prefix, DEBUG_PREFIX, strlen(DEBUG_PREFIX));
-    break;
-  }
-  default: {
-    break;
-  }
-  }
-}
 
 static atlogger_ctx *atlogger_get_instance() {
   static atlogger_ctx *ctx;
@@ -53,7 +30,48 @@ static atlogger_ctx *atlogger_get_instance() {
     memset(prefix, 0, sizeof(char) * PREFIX_BUFFER_LEN);
   }
 
+  ctx->opts = ATLOGGER_ENABLE_TIMESTAMPS;
   return ctx;
+}
+
+static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char *prefix, size_t prefixlen) {
+  memset(prefix, 0, prefixlen);
+  int off = 0;
+
+  switch (logging_level) {
+  case ATLOGGER_LOGGING_LEVEL_INFO: {
+    off = strlen(INFO_PREFIX);
+    memcpy(prefix, INFO_PREFIX, off);
+    break;
+  }
+  case ATLOGGER_LOGGING_LEVEL_WARN: {
+    off = strlen(WARN_PREFIX);
+    memcpy(prefix, WARN_PREFIX, off);
+    break;
+  }
+  case ATLOGGER_LOGGING_LEVEL_ERROR: {
+    off = strlen(ERROR_PREFIX);
+    memcpy(prefix, ERROR_PREFIX, off);
+    break;
+  }
+  case ATLOGGER_LOGGING_LEVEL_DEBUG: {
+    off = strlen(DEBUG_PREFIX);
+    memcpy(prefix, DEBUG_PREFIX, off);
+    break;
+  }
+  default: {
+    break;
+  }
+  }
+
+  atlogger_ctx *ctx = atlogger_get_instance();
+  if (ctx->opts & ATLOGGER_ENABLE_TIMESTAMPS) {
+    int res = clock_gettime(CLOCK_REALTIME, &timespec); // posix-1.2008 way
+    if (res == 0) {
+      snprintf(prefix + off, PREFIX_BUFFER_LEN - off, "%ld", timespec.tv_sec * 1000000 + timespec.tv_nsec);
+      // TODO: adjust off if any other things need to be added to the prefix
+    }
+  }
 }
 
 enum atlogger_logging_level atlogger_get_logging_level() {
@@ -64,6 +82,11 @@ enum atlogger_logging_level atlogger_get_logging_level() {
 void atlogger_set_logging_level(const enum atlogger_logging_level level) {
   atlogger_ctx *ctx = atlogger_get_instance();
   ctx->level = level;
+}
+
+void atlogger_set_opts(int opts) {
+  atlogger_ctx *ctx = atlogger_get_instance();
+  ctx->opts = opts;
 }
 
 void atlogger_log(const char *tag, const enum atlogger_logging_level level, const char *format, ...) {

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -66,10 +66,18 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
 
   atlogger_ctx *ctx = atlogger_get_instance();
   if (ctx->opts & ATLOGGER_ENABLE_TIMESTAMPS) {
-    int res = clock_gettime(CLOCK_REALTIME, &timespec); // posix-1.2008 way
+    int res = clock_gettime(CLOCK_REALTIME, &timespec);
+
     if (res == 0) {
-      snprintf(prefix + off, PREFIX_BUFFER_LEN - off, " %ld", timespec.tv_sec * 1000000 + timespec.tv_nsec);
-      // TODO: adjust off if any other things need to be added to the prefix
+      res = strftime(prefix + off, PREFIX_BUFFER_LEN - off, "%F %T",
+                     gmtime(&timespec.tv_sec)); // format accurate to the second
+      off += res;
+    }
+
+    if (res == 0) {
+      snprintf(prefix + off, PREFIX_BUFFER_LEN - off, ".%ld", timespec.tv_nsec);
+      // TODO: future modifications to the prefix require calculation of the new offset
+      // off += ?
     }
   }
 }

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -69,7 +69,7 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
     int res = clock_gettime(CLOCK_REALTIME, &timespec);
 
     if (res == 0) {
-      res = strftime(prefix + off, PREFIX_BUFFER_LEN - off, "%F %T",
+      res = strftime(prefix + off, PREFIX_BUFFER_LEN - off, " %F %T",
                      gmtime(&timespec.tv_sec)); // format accurate to the second
       if (res != 0) {
         off += res;

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -71,7 +71,10 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
     if (res == 0) {
       res = strftime(prefix + off, PREFIX_BUFFER_LEN - off, "%F %T",
                      gmtime(&timespec.tv_sec)); // format accurate to the second
-      off += res;
+      if (res != 0) {
+        off += res;
+        res = 0;
+      }
     }
 
     if (res == 0) {

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -83,6 +83,8 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
     }
 
     snprintf(prefix + off, PREFIX_BUFFER_LEN - off, " | ");
+    off += 3;
+    prefix[off] = '\0';
   }
 }
 

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -114,7 +114,7 @@ void atlogger_log(const char *tag, const enum atlogger_logging_level level, cons
 
   va_list args;
   va_start(args, format);
-  printf(" %.*s", (int)strlen(prefix), prefix);
+  printf("%.*s", (int)strlen(prefix), prefix);
   if (tag != NULL) {
     printf(" %s", tag);
   }

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -78,7 +78,7 @@ static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char 
     }
 
     if (res == 0) {
-      snprintf(prefix + off, PREFIX_BUFFER_LEN - off, ".%ld", timespec.tv_nsec);
+      snprintf(prefix + off, PREFIX_BUFFER_LEN - off, ".%09lu", timespec.tv_nsec);
       off += strlen(prefix + off);
     }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added an internal opts bitmask to the atlogger
  - Added a bit for logging timestamps; defaults to on
- Added unix timestamps to the prefix, accurate to nanoseconds (on some platforms this will be rounded to ms)

**- How I did it**

**- How to verify it**

![CleanShot 2024-05-31 at 18 25 15@2x](https://github.com/atsign-foundation/at_c/assets/33691921/8484b8b1-77bf-4e3b-836a-d24b3acb246c)

**- Description for the changelog**
feat: atlogger timestamps
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
