### PR TITLE
feat: check for ret <= 0 in atclient_monitor_read

### DIFF
--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -245,15 +245,6 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_read failed with exit code: %d\n", ret);
       goto exit;
     }
-    // if (ret == 0) {
-    //   tries++;
-    //   if (tries >= ATCLIENT_CONNECTION_MAX_READ_TRIES) {
-    //     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-    //                  "mbedtls_ssl_read tried to read %d times and found nothing: %d\n", tries, ret);
-    //     ret = 1;
-    //     goto exit;
-    //   }
-    // }
     l = l + ret;
 
     for (int i = l; i >= l - ret && i >= 0; i--) {

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -630,7 +630,7 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
     size_t off = chunksize * chunks;
     for (int i = 0; i < chunksize; i++) {
       ret = mbedtls_ssl_read(&(monitor_conn->atserver_connection.ssl), (unsigned char *)buffer + off + i, 1);
-      if (ret < 0 || buffer[off + i] == '\n') {
+      if (ret <= 0 || buffer[off + i] == '\n') {
         buffer[off + i] = '\0';
         done_reading = true;
         break;
@@ -638,7 +638,7 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
     }
     chunks = chunks + 1;
   }
-  if (ret < 0) {
+  if (ret <= 0) {
     (*message)->type = ATCLIENT_MONITOR_ERROR_READ;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Read nothing from the monitor connection: %d\n", ret);
     goto exit;


### PR DESCRIPTION
**- What I did**
- https://github.com/atsign-foundation/at_c/pull/281 fixed `connection.c`'s `atclient_connection_send`'s issue with `ret == 0` as an error,
- this PR also adds that same error handling in `atclient_monitor_read`.
- this comment is a good explanation of why we should check for the `mbedtls_ssl_read(...) == 0` case.

**- How I did it**

**- How to verify it**
- at_talk works

**- Description for the changelog**
feat: check for ret <= 0 in atclient_monitor_read
