### PR TITLE
fix: network related hooks fixes

### DIFF
--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -248,7 +248,7 @@ void atclient_monitor_set_read_timeout(atclient *monitor_conn, const int timeout
 
 typedef struct atclient_monitor_hooks {
   int (*pre_decrypt_notification)(void);
-  int (*post_decrypt_notification)(void);
+  int (*post_decrypt_notification)(int);
 } atclient_monitor_hooks;
 
 /**

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -1,13 +1,13 @@
 #include "atclient/atclient.h"
-#include "atclient/constants.h"
-#include "atclient/atclient_utils.h"
 #include "atchops/base64.h"
 #include "atchops/rsa.h"
 #include "atclient/atclient.h"
+#include "atclient/atclient_utils.h"
 #include "atclient/atkeys.h"
 #include "atclient/atsign.h"
 #include "atclient/atstr.h"
 #include "atclient/connection.h"
+#include "atclient/constants.h"
 #include "atclient/stringutils.h"
 #include "atlogger/atlogger.h"
 #include <cJSON.h>
@@ -227,12 +227,21 @@ void atclient_set_read_timeout(atclient *ctx, int timeout_ms) {
 static int atclient_start_atserver_connection(atclient *ctx, const char *secondaryhost, const int secondaryport) {
   int ret = 1; // error by default
 
+  // remove hooks to preserve them across resets
+  atclient_connection_hooks *conn_hooks = ctx->atserver_connection.hooks;
+  ctx->atserver_connection.hooks = NULL;
+
+  // clear the atserver connection
   atclient_connection_free(&(ctx->atserver_connection));
   ctx->atserver_connection_started = false;
   memset(&(ctx->atserver_connection), 0, sizeof(atclient_connection));
 
+  // (re) initialize the atserver connection
   atclient_connection_init(&(ctx->atserver_connection), ATCLIENT_CONNECTION_TYPE_ATSERVER);
   ctx->atserver_connection_started = true;
+
+  // add back hooks
+  ctx->atserver_connection.hooks = conn_hooks;
 
   if ((ret = atclient_connection_connect(&(ctx->atserver_connection), secondaryhost, secondaryport)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_connect: %d\n", ret);

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -237,7 +237,9 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src_
   if (try_hooks && ctx->hooks->pre_send != NULL) {
     ctx->hooks->_is_nested_call = true;
     ret = ctx->hooks->pre_send(src, srclen, recv, recvsize, recvlen);
-    ctx->hooks->_is_nested_call = false;
+    if (ctx->hooks != NULL) {
+      ctx->hooks->_is_nested_call = false;
+    }
     if (ret != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "pre_send hook failed with exit code: %d\n", ret);
       goto exit;
@@ -253,7 +255,9 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src_
   if (try_hooks && ctx->hooks->post_send != NULL) {
     ctx->hooks->_is_nested_call = true;
     ret = ctx->hooks->post_send(src, srclen, recv, recvsize, recvlen);
-    ctx->hooks->_is_nested_call = false;
+    if (ctx->hooks != NULL) {
+      ctx->hooks->_is_nested_call = false;
+    }
     if (ret != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "post_send hook failed with exit code: %d\n", ret);
       goto exit;
@@ -285,7 +289,9 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src_
   if (try_hooks && ctx->hooks->pre_recv != NULL) {
     ctx->hooks->_is_nested_call = true;
     ret = ctx->hooks->pre_recv(src, srclen, recv, recvsize, recvlen);
-    ctx->hooks->_is_nested_call = false;
+    if (ctx->hooks != NULL) {
+      ctx->hooks->_is_nested_call = false;
+    }
     if (ret != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "pre_recv hook failed with exit code: %d\n", ret);
       goto exit;
@@ -347,7 +353,9 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src_
   if (try_hooks && ctx->hooks->post_recv != NULL) {
     ctx->hooks->_is_nested_call = true;
     ret = ctx->hooks->post_recv(src, srclen, recv, recvsize, recvlen);
-    ctx->hooks->_is_nested_call = false;
+    if (ctx->hooks != NULL) {
+      ctx->hooks->_is_nested_call = false;
+    }
     if (ret != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "post_recv hook failed with exit code: %d\n", ret);
       goto exit;

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -684,16 +684,21 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
           goto exit;
         }
       }
-      if ((ret = decrypt_notification(atclient, &((*message)->notification))) != 0) {
-        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to decrypt notification\n");
-        goto exit;
-      }
+
+      int decrypt_ret = decrypt_notification(atclient, &((*message)->notification));
+
       if (hooks != NULL && hooks->post_decrypt_notification != NULL) {
-        ret = hooks->post_decrypt_notification();
+        ret = hooks->post_decrypt_notification(decrypt_ret);
         if (ret != 0) {
           atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to call post decrypt notification hook\n");
           goto exit;
         }
+      }
+
+      ret = decrypt_ret;
+      if (ret != 0) {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to decrypt notification\n");
+        goto exit;
       }
     } else {
       atclient_atnotification_set_decryptedvalue(&((*message)->notification),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- connection_send hooks would cause a segfault when the network is down since the hooks would get wiped
  - put guards for that in place.
- similarly, I also had to make sure that hooks are preserved across network connection resets

- the monitor post_decrypt hooks is used to unlock the worker atclient, but it doesn't run if the decrypt notification fails:
  - fixed such that the hook always runs, and the hook provides the return value of the decrypt notification call

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: network related hooks fixes
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
