### PR TITLE
fix: larger sharedenckeybase64size and null terminate atclient_stringutils_atsign_with_at_symbol

### DIFF
--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -995,7 +995,7 @@ static int decrypt_notification(atclient *atclient, atclient_atnotification *not
   size_t sharedenckeylen = 0;
 
   // temporarily holds the shared encryption key in base64
-  const size_t sharedenckeybase64size = atchops_base64_encoded_size(sharedenckeysize / 8);
+  const size_t sharedenckeybase64size = atchops_base64_encoded_size(sharedenckeysize);
   unsigned char sharedenckeybase64[sharedenckeybase64size];
   memset(sharedenckeybase64, 0, sizeof(unsigned char) * sharedenckeybase64size);
   size_t sharedenckeybase64len = 0;

--- a/packages/atclient/src/stringutils.c
+++ b/packages/atclient/src/stringutils.c
@@ -122,7 +122,7 @@ int atclient_stringutils_atsign_with_at_symbol(const char *original_atsign, cons
       goto exit;
     }
     memcpy(*output_atsign_with_at_symbol, original_atsign, original_atsign_len);
-    (*output_atsign_with_at_symbol)[original_atsign_len] = '\0';                                 // Missing NULL terminator
+    (*output_atsign_with_at_symbol)[original_atsign_len] = '\0';
   } else {
     *output_atsign_with_at_symbol = malloc(sizeof(char) * (original_atsign_len + 2));
     if (*output_atsign_with_at_symbol == NULL) {
@@ -132,7 +132,7 @@ int atclient_stringutils_atsign_with_at_symbol(const char *original_atsign, cons
     memset(*output_atsign_with_at_symbol, 0, sizeof(char) * (original_atsign_len + 2));
     memcpy(*output_atsign_with_at_symbol, "@", 1);
     memcpy(*output_atsign_with_at_symbol + 1, original_atsign, original_atsign_len);
-    (*output_atsign_with_at_symbol)[original_atsign_len + 1] = '\0';                             // Missing NULL terminator
+    (*output_atsign_with_at_symbol)[original_atsign_len + 1] = '\0';
   }
 
   ret = 0;

--- a/packages/atclient/src/stringutils.c
+++ b/packages/atclient/src/stringutils.c
@@ -115,15 +115,25 @@ int atclient_stringutils_atsign_with_at_symbol(const char *original_atsign, cons
     goto exit;
   }
 
-  *output_atsign_with_at_symbol = malloc(sizeof(char) * (original_atsign_len + 2));
-  if (*output_atsign_with_at_symbol == NULL) {
-    ret = -1;
-    goto exit;
+  if (original_atsign[0] == '@') {
+    *output_atsign_with_at_symbol = malloc(sizeof(char) * (original_atsign_len + 1));
+    if (*output_atsign_with_at_symbol == NULL) {
+      ret = -1;
+      goto exit;
+    }
+    memcpy(*output_atsign_with_at_symbol, original_atsign, original_atsign_len);
+    (*output_atsign_with_at_symbol)[original_atsign_len] = '\0';                                 // Missing NULL terminator
+  } else {
+    *output_atsign_with_at_symbol = malloc(sizeof(char) * (original_atsign_len + 2));
+    if (*output_atsign_with_at_symbol == NULL) {
+      ret = -1;
+      goto exit;
+    }
+    memset(*output_atsign_with_at_symbol, 0, sizeof(char) * (original_atsign_len + 2));
+    memcpy(*output_atsign_with_at_symbol, "@", 1);
+    memcpy(*output_atsign_with_at_symbol + 1, original_atsign, original_atsign_len);
+    (*output_atsign_with_at_symbol)[original_atsign_len + 1] = '\0';                             // Missing NULL terminator
   }
-
-  memset(*output_atsign_with_at_symbol, 0, sizeof(char) * (original_atsign_len + 2));
-  memcpy(*output_atsign_with_at_symbol, "@", 1);
-  memcpy(*output_atsign_with_at_symbol + 1, original_atsign, original_atsign_len);
 
   ret = 0;
   goto exit;


### PR DESCRIPTION
**- What I did**
- Removed /8 from base64 encoded size. sharedenckeybase64 buffer size will now be `49` instead of `16`.
- null terminate atclient_stringutils_atsign_with_at_symbol 

**- Description for the changelog**
fix: larger sharedenckeybase64size and null terminate atclient_stringutils_atsign_with_at_symbol
