### PR TITLE
refactor: monitor (BREAKING CHANGES)

### DIFF
--- a/examples/desktop/at_talk/src/main.c
+++ b/examples/desktop/at_talk/src/main.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[]) {
   atclient_init(&atclient1);
 
   atclient monitor; // free later
-  atclient_init(&monitor);
+  atclient_monitor_init(&monitor);
 
   pthread_t tid;
 

--- a/examples/desktop/at_talk/src/main.c
+++ b/examples/desktop/at_talk/src/main.c
@@ -260,8 +260,9 @@ static void *monitor_handler(void *xargs) {
       }
       tries = 1;
     }
-    case ATCLIENT_MONITOR_ERROR_READ:
-    case ATCLIENT_MONITOR_ERROR_PARSE: {
+    case ATCLIENT_MONITOR_EMPTY_READ:
+    case ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION:
+    case ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION: {
       if (tries >= MAX_RETRIES) {
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG,
                      "Failed to read a message for 5 consecutive reads, checking if connection is alive...\n", ret);

--- a/examples/desktop/at_talk/src/main.c
+++ b/examples/desktop/at_talk/src/main.c
@@ -239,21 +239,23 @@ static void *monitor_handler(void *xargs) {
   int tries = 1;
 
   while (true) {
-    atclient_monitor_message *message = NULL;
+    atclient_monitor_message message;
+    atclient_monitor_message_init(&message);
+
     pthread_mutex_lock(&monitor_mutex);
     pthread_mutex_lock(&client_mutex);
     ret = atclient_monitor_read(monitor, ctx, &message, NULL);
     pthread_mutex_unlock(&monitor_mutex);
     pthread_mutex_unlock(&client_mutex);
 
-    switch (message->type) {
+    switch (message.type) {
     case ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION: {
-      if (strcmp(message->notification.id, "-1") == 0) {
+      if (strcmp(message.notification.id, "-1") == 0) {
         // We received a stats notification. Ignore it.
         break;
       }
-      if (atclient_atnotification_decryptedvalue_is_initialized(&(message->notification))) {
-        const atclient_atnotification *notification = &(message->notification);
+      if (atclient_atnotification_decryptedvalue_is_initialized(&(message.notification))) {
+        const atclient_atnotification *notification = &(message.notification);
         printf("\n%s%s%s: %s\n", HGRN, notification->from, reset, notification->decryptedvalue);
         printf("%s%s%s: ", HBLU, from_atsign, reset);
         fflush(stdout);
@@ -288,11 +290,11 @@ static void *monitor_handler(void *xargs) {
       break;
     }
     default: {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Received message type: %d\n", message->type);
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Received message type: %d\n", message.type);
     }
     }
 
-    atclient_monitor_message_free(message);
+    atclient_monitor_message_free(&message);
     usleep(100);
   }
   goto exit;

--- a/examples/desktop/at_talk/src/main.c
+++ b/examples/desktop/at_talk/src/main.c
@@ -262,7 +262,7 @@ static void *monitor_handler(void *xargs) {
       }
       tries = 1;
     }
-    case ATCLIENT_MONITOR_EMPTY_READ:
+    case ATCLIENT_MONITOR_ERROR_READ:
     case ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION:
     case ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION: {
       if (tries >= MAX_RETRIES) {

--- a/examples/desktop/events/monitor.c
+++ b/examples/desktop/events/monitor.c
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
   atclient monitor_conn;
   atclient_monitor_init(&monitor_conn);
 
-  atclient_monitor_message *message = NULL;
+  atclient_monitor_message message;
 
   if ((ret = get_atsign_input(argc, argv, &atsign)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to get atsign input (Example: \'./monitor -a @bob\')\n");
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
       continue;
     }
 
-    switch (message->type) {
+    switch (message.type) {
     case ATCLIENT_MONITOR_MESSAGE_TYPE_NONE: {
       // atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_MESSAGE_TYPE_NONE\n");
       break;
@@ -88,15 +88,15 @@ int main(int argc, char *argv[]) {
     case ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION: {
       // atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION\n");
       // atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message Body: %s\n", message->notification.value);
-      if (strcmp(message->notification.id, "-1") == 0) {
+      if (strcmp(message.notification.id, "-1") == 0) {
         // ignore stats notification
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Received stats notification, ignoring it.\n");
         break;
       }
-      if (atclient_atnotification_decryptedvalue_is_initialized(&message->notification)) {
+      if (atclient_atnotification_decryptedvalue_is_initialized(&message.notification)) {
         // atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message id: %s\n", message->notification.id);
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "decryptedvalue: \"%s\"\n",
-                     message->notification.decryptedvalue);
+                     message.notification.decryptedvalue);
       }
       break;
     }
@@ -114,7 +114,7 @@ int main(int argc, char *argv[]) {
     case ATCLIENT_MONITOR_EMPTY_READ:
     case ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION:
     case ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION: {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: %d\n", message->type);
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: %d\n", message.type);
       break;
     }
     }
@@ -127,7 +127,7 @@ exit: {
   atclient_atkeys_free(&atkeys);
   free(atsign);
   atclient_monitor_free(&monitor_conn);
-  atclient_monitor_message_free(message);
+  atclient_monitor_message_free(&message);
   return ret;
 }
 }

--- a/examples/desktop/events/monitor.c
+++ b/examples/desktop/events/monitor.c
@@ -111,7 +111,7 @@ int main(int argc, char *argv[]) {
       // Body: %s\n", message->error_response);
       break;
     }
-    case ATCLIENT_MONITOR_EMPTY_READ:
+    case ATCLIENT_MONITOR_ERROR_READ:
     case ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION:
     case ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION: {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: %d\n", message.type);

--- a/examples/desktop/events/monitor.c
+++ b/examples/desktop/events/monitor.c
@@ -111,6 +111,12 @@ int main(int argc, char *argv[]) {
       // Body: %s\n", message->error_response);
       break;
     }
+    case ATCLIENT_MONITOR_EMPTY_READ:
+    case ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION:
+    case ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION: {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: %d\n", message->type);
+      break;
+    }
     }
     // sleep(3);
   }

--- a/examples/desktop/events/resilient_monitor.c
+++ b/examples/desktop/events/resilient_monitor.c
@@ -117,17 +117,17 @@ int main(int argc, char *argv[]) {
       break;
     }
     case ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION: {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_PARSE\n");
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION\n");
       tries++;
       break;
     }
     case ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION: {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_DECRYPT\n");
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION\n");
       tries++;
       break;
     }
     case ATCLIENT_MONITOR_ERROR_READ: {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_EMPTY_READ\n");
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_READ with error code %d\n", message->error_read.error_code);
       tries++;
       break;
     }

--- a/examples/desktop/events/resilient_monitor.c
+++ b/examples/desktop/events/resilient_monitor.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
       break;
     }
     case ATCLIENT_MONITOR_EMPTY_READ: {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_READ\n");
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_EMPTY_READ\n");
       tries++;
       break;
     }

--- a/examples/desktop/events/resilient_monitor.c
+++ b/examples/desktop/events/resilient_monitor.c
@@ -116,11 +116,17 @@ int main(int argc, char *argv[]) {
       // Body: %s\n", message->error_response);
       break;
     }
-    case ATCLIENT_MONITOR_ERROR_PARSE: {
+    case ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION: {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_PARSE\n");
+      tries++;
       break;
     }
-    case ATCLIENT_MONITOR_ERROR_READ: {
+    case ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION: {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_DECRYPT\n");
+      tries++;
+      break;
+    }
+    case ATCLIENT_MONITOR_EMPTY_READ: {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_ERROR_READ\n");
       tries++;
       break;

--- a/examples/desktop/events/resilient_monitor.c
+++ b/examples/desktop/events/resilient_monitor.c
@@ -126,7 +126,7 @@ int main(int argc, char *argv[]) {
       tries++;
       break;
     }
-    case ATCLIENT_MONITOR_EMPTY_READ: {
+    case ATCLIENT_MONITOR_ERROR_READ: {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Message type: ATCLIENT_MONITOR_EMPTY_READ\n");
       tries++;
       break;

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -167,8 +167,10 @@ enum atclient_monitor_message_type {
   ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION,
   ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE,
   ATCLIENT_MONITOR_MESSAGE_TYPE_ERROR_RESPONSE,
-  ATCLIENT_MONITOR_ERROR_READ, // usually a socket error
-  ATCLIENT_MONITOR_ERROR_PARSE,
+  ATCLIENT_MONITOR_EMPTY_READ, // nothing was read from the socket, could be a socket error, disconnection, or simply
+                               // that nothing was read
+  ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION,
+  ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION,
 };
 
 /**

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -180,7 +180,9 @@ enum atclient_monitor_message_type {
 
 // Represents error information when `ATCLIENT_MONITOR_ERROR_READ` is the message type given by atclient_monitor_read
 typedef struct atclient_monitor_message_error_read {
-  int error_code;
+  int error_code; // if 0, then the connection should be disposed of immediately, as it is of no use anymore,
+                  // if MBEDTLS_ERR_SSL_TIMEOUT, then a read timeout occurred,
+                  // else if < 0, then an error occurred when reading from the SSL connection.
 } atclient_monitor_message_error_read;
 
 /**

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -272,7 +272,7 @@ int atclient_monitor_start(atclient *monitor_conn, const char *regex, const size
 /**
  * @brief Read a notification from the monitor connection into message
  * @param monitor_conn the atclient context for the monitor connection. it is assumed that this is intialized and pkam
- * authenticated.
+ * authenticated. See atclient_monitor_init and atclient_monitor_pkam_authenticate
  * @param atclient the atclient context for the atclient connection, it is advised that this connection an entirely
  * separate connection from the monitor_conn to avoid colliding messages when reading. it is assumed that this is
  * initialized and pkam authenticated.

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -285,7 +285,7 @@ int atclient_monitor_start(atclient *monitor_conn, const char *regex, const size
  * @note Message may be a notification, a data response, or an error response, check the type field to determine which
  * data field to use
  */
-int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_monitor_message **message,
+int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_monitor_message *message,
                           atclient_monitor_hooks *hooks);
 
 /**

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -166,17 +166,22 @@ enum atclient_monitor_message_type {
   // the following 4 enums help indicate what type of message was received from the monitor connection and which field
   // of the union to access
   ATCLIENT_MONITOR_MESSAGE_TYPE_NONE,
-  ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION,
-  ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE,
-  ATCLIENT_MONITOR_MESSAGE_TYPE_ERROR_RESPONSE,
+  ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION,   // indicates caller to access `notification` from the union
+  ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE,  // indicates caller to access `data_response` from the union
+  ATCLIENT_MONITOR_MESSAGE_TYPE_ERROR_RESPONSE, // indicates caller to access `error_response` from the union
 
   // the following 3 enums help indicate what type of error occurred when reading from the monitor connection, you will
   // expect one of these enums along with a non-zero return value from atclient_monitor_read
-  ATCLIENT_MONITOR_EMPTY_READ, // nothing was read from the socket, could be a socket error, disconnection, or simply
-                               // that nothing was read
+  ATCLIENT_MONITOR_ERROR_READ, // could be a read timeout or some other error, indicates the caller to access
+                               // `error_read` from the union
   ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION,
   ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION,
 };
+
+// Represents error information when `ATCLIENT_MONITOR_ERROR_READ` is the message type given by atclient_monitor_read
+typedef struct atclient_monitor_message_error_read {
+  int error_code;
+} atclient_monitor_message_error_read;
 
 /**
  * @brief Represents a message received from the monitor connection
@@ -191,6 +196,7 @@ typedef struct atclient_monitor_message {
     atclient_atnotification notification; // when is_notification is true
     char *data_response;                  // message of the data response (e.g. "ok", when "data:ok" is received)
     char *error_response;                 // message of the error_response
+    atclient_monitor_message_error_read error_read;
   };
 } atclient_monitor_message;
 

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -276,8 +276,10 @@ int atclient_monitor_start(atclient *monitor_conn, const char *regex, const size
  * @param atclient the atclient context for the atclient connection, it is advised that this connection an entirely
  * separate connection from the monitor_conn to avoid colliding messages when reading. it is assumed that this is
  * initialized and pkam authenticated.
- * @param message pass in a double pointer to the message, it will be allocated and filled in by this function. The
- * caller is responsible for freeing the message, using atclient_monitor_message_free
+ * @param message A pointer to the initialized atclient_monitor_message. It is up to
+ * the caller to allocate memory to this struct, call atclient_monitor_message_init before passing to this function,
+ * then call atclient_monitor_free use. This function populates the message struct with the notification, data response,
+ * or error response read from the monitor connection.
  * @return 0 on success, non-zero on error
  *
  * @note Message may be a notification, a data response, or an error response, check the type field to determine which

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -163,10 +163,15 @@ void atclient_atnotification_set_decryptedvaluelen(atclient_atnotification *noti
  *
  */
 enum atclient_monitor_message_type {
+  // the following 4 enums help indicate what type of message was received from the monitor connection and which field
+  // of the union to access
   ATCLIENT_MONITOR_MESSAGE_TYPE_NONE,
   ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION,
   ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE,
   ATCLIENT_MONITOR_MESSAGE_TYPE_ERROR_RESPONSE,
+
+  // the following 3 enums help indicate what type of error occurred when reading from the monitor connection, you will
+  // expect one of these enums along with a non-zero return value from atclient_monitor_read
   ATCLIENT_MONITOR_EMPTY_READ, // nothing was read from the socket, could be a socket error, disconnection, or simply
                                // that nothing was read
   ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION,

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -540,8 +540,8 @@ void atclient_monitor_message_free(atclient_monitor_message *message) {
   }
 }
 
-void atclient_monitor_init(atclient *monitor_conn) { memset(monitor_conn, 0, sizeof(atclient)); }
-void atclient_monitor_free(atclient *monitor_conn) { return; }
+void atclient_monitor_init(atclient *monitor_conn) { atclient_init(monitor_conn); }
+void atclient_monitor_free(atclient *monitor_conn) { atclient_free(monitor_conn); }
 
 int atclient_monitor_pkam_authenticate(atclient *monitor_conn, const char *atserver_host, const int atserver_port,
                                        const atclient_atkeys *atkeys, const char *atsign) {
@@ -667,7 +667,8 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
     atclient_atnotification_init(&((*message)->notification));
     if ((ret = parse_notification(&((*message)->notification), messagebody)) != 0) {
       (*message)->type = ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION;
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to parse notification with messagebody: \"%s\"\n", messagebody);
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to parse notification with messagebody: \"%s\"\n",
+                   messagebody);
       goto exit;
     }
     if (atclient_atnotification_isEncrypted_is_initialized(&((*message)->notification)) &&

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -610,16 +610,18 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
                           atclient_monitor_hooks *hooks) {
   int ret = -1;
 
-  const size_t chunksize = ATCLIENT_MONITOR_BUFFER_LEN;
+  char *buffertemp = NULL;
+  char *buffer = NULL;
 
   size_t chunks = 0;
-  char *buffer = malloc(sizeof(char) * chunksize);
+  const size_t chunksize = ATCLIENT_MONITOR_BUFFER_LEN;
+  
+  buffer = malloc(sizeof(char) * chunksize);
   if(buffer == NULL) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for buffer\n");
     goto exit;
   }
   memset(buffer, 0, sizeof(char) * chunksize);
-  char *buffertemp = NULL;
 
   bool done_reading = false;
   while (!done_reading) {

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -642,8 +642,9 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
     }
     chunks = chunks + 1;
   }
-  if (ret <= 0) {
-    message->type = ATCLIENT_MONITOR_EMPTY_READ;
+  if(ret <= 0) { // you should reconnect...
+    message->type = ATCLIENT_MONITOR_ERROR_READ;
+    message->error_read.error_code = ret;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Read nothing from the monitor connection: %d\n", ret);
     goto exit;
   }

--- a/tests/functional_tests/tests/test_atclient_monitor.c
+++ b/tests/functional_tests/tests/test_atclient_monitor.c
@@ -194,7 +194,8 @@ exit: {
 static int monitor_for_notification(atclient *monitor_conn, atclient *atclient2) {
   int ret = 1;
 
-  atclient_monitor_message *message = NULL;
+  atclient_monitor_message message;
+  atclient_monitor_message_init(&message);
 
   const int max_tries = 10;
   int tries = 1;
@@ -206,30 +207,23 @@ static int monitor_for_notification(atclient *monitor_conn, atclient *atclient2)
       continue;
     }
 
-    if (message == NULL) {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO,
-                   "monitor message is NULL, when it is expected to be populated :(\n");
-      tries++;
-      continue;
-    }
-
-    if (!atclient_atnotification_decryptedvalue_is_initialized(&(message->notification))) {
+    if (!atclient_atnotification_decryptedvalue_is_initialized(&(message.notification))) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Decrypted value is not initialized\n");
       tries++;
       continue;
     }
 
-    if (!atclient_atnotification_decryptedvaluelen_is_initialized(&(message->notification))) {
+    if (!atclient_atnotification_decryptedvaluelen_is_initialized(&(message.notification))) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Decrypted value length is not initialized\n");
       tries++;
       continue;
     }
 
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Decrypted Value (%lu): %s\n",
-                 (int)message->notification.decryptedvaluelen, message->notification.decryptedvalue);
+                 (int)message.notification.decryptedvaluelen, message.notification.decryptedvalue);
 
     // compare the decrypted value with the expected value
-    if (strcmp(message->notification.decryptedvalue, ATKEY_VALUE) != 0) {
+    if (strcmp(message.notification.decryptedvalue, ATKEY_VALUE) != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Decrypted value does not match expected value\n");
       tries++;
       continue;
@@ -248,7 +242,7 @@ static int monitor_for_notification(atclient *monitor_conn, atclient *atclient2)
   ret = 1;
   goto exit;
 exit: {
-  atclient_monitor_message_free(message);
+  atclient_monitor_message_free(&message);
   return ret;
 }
 }

--- a/tests/functional_tests/tests/test_atclient_monitor.c
+++ b/tests/functional_tests/tests/test_atclient_monitor.c
@@ -51,7 +51,7 @@ int main() {
   atclient_atkeys_init(&atkeys_sharedby);
 
   atclient monitor_conn;
-  atclient_init(&monitor_conn);
+  atclient_monitor_init(&monitor_conn);
 
   atclient atclient2;
   atclient_init(&atclient2);


### PR DESCRIPTION
closes #282 

**- What I did**
- New `ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION` enum
- New `atclient_monitor_message_error_read` struct
- Refactored at_talk to have this new change
- Implemented `atclient_monitor_init` and `atclient_monitor_free`
- Changed atclient_monitor_message from a double pointer to a single pointer in `atclient_monitor_read`

**- Description for the changelog**
feat: new monitor message enums (breaking change)
