### PR TITLE
fix: start buffer index from correct position

### DIFF
--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -136,7 +136,7 @@ void atlogger_fix_stdout_buffer(char *str, const size_t strlen) {
   int carriagereturnindex = -1;
   int newlineindex = -1;
 
-  for (int i = strlen; i >= 0; i--) {
+  for (int i = strlen - 1; i >= 0; i--) {
     if (str[i] == '\r' && carriagereturnindex == -1) {
       carriagereturnindex = i;
     }
@@ -152,7 +152,7 @@ void atlogger_fix_stdout_buffer(char *str, const size_t strlen) {
     str[strlen - 1] = '\0';
   }
 
-  for (int i = strlen; i >= 0; i--) {
+  for (int i = strlen - 1; i >= 0; i--) {
     if (str[i] == '\n' && newlineindex == -1) {
       newlineindex = i;
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Subtracted 1 from starting index to start within buffer bounds

Note: this was the really noisy error we saw in the valgrind logs, they are looking much more readable after this change.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: start buffer index from correct position
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
