### PR TITLE
build(deps): Group Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
We presently get multiple separate PRs for changes to GitHub Actions. 

**- What I did**

Added a group

**- How I did it**

Copied from at_client_sdk

**- How to verify it**

Future PRs

**- Description for the changelog**

build(deps): Group Dependabot PRs