### PR TITLE
fix: atlogger memory leak

### DIFF
--- a/packages/atlogger/include/atlogger/atlogger.h
+++ b/packages/atlogger/include/atlogger/atlogger.h
@@ -20,5 +20,5 @@ void atlogger_set_logging_level(const enum atlogger_logging_level level);
 void atlogger_set_opts(int opts);
 void atlogger_log(const char *tag, const enum atlogger_logging_level level, const char *format, ...);
 void atlogger_fix_stdout_buffer(char *str, const size_t strlen);
-
+void atlogger_free(void);
 #endif

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -21,13 +21,21 @@ typedef struct atlogger_ctx {
   int opts;
 } atlogger_ctx;
 
-static atlogger_ctx *atlogger_get_instance() {
-  static atlogger_ctx *ctx;
+static atlogger_ctx *ctx;
+static void atlogger_init() {
+  ctx = (atlogger_ctx *)malloc(sizeof(atlogger_ctx));
+  prefix = (char *)malloc(sizeof(char) * PREFIX_BUFFER_LEN);
+  memset(prefix, 0, sizeof(char) * PREFIX_BUFFER_LEN);
+}
 
+void atlogger_free() {
+  free(prefix);
+  free(ctx);
+}
+
+static atlogger_ctx *atlogger_get_instance() {
   if (ctx == NULL) {
-    ctx = (atlogger_ctx *)malloc(sizeof(atlogger_ctx));
-    prefix = (char *)malloc(sizeof(char) * PREFIX_BUFFER_LEN);
-    memset(prefix, 0, sizeof(char) * PREFIX_BUFFER_LEN);
+    atlogger_init();
   }
 
   ctx->opts = ATLOGGER_ENABLE_TIMESTAMPS;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Added a function for freeing memory created by the atlogger singleton
- It isn't mandatory that you use this method, since the amount allocated will never change and 99% of the time you will want to free this memory, it is right as the program exits. But for the sake of having a way to free every single piece of memory properly, we need this function.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: atlogger memory leak
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
