### PR TITLE
fix: memory leaks with atclient_put and atclient_free not freeing connection hooks properly

### DIFF
--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -39,8 +39,17 @@ typedef struct atclient_connection_hooks {
 } atclient_connection_hooks;
 
 typedef struct atclient_connection {
+  atclient_connection_type type;
+
   char host[ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE];
   int port; // example: 64
+
+  // atclient_connection_connect sets this to true and atclient_connection_disconnect sets this to false
+  // this does not mean that the connection is still alive, it just means that the connection was established at least
+  // once, at some  point, check atclient_connection_is_connected for a live status on the connection
+  // _should_be_connected also serves as an internal boolean to check if the following mbedlts contexts have been
+  // initialized and need to be freed at the end
+  bool _should_be_connected;
   mbedtls_net_context net;
   mbedtls_ssl_context ssl;
   mbedtls_ssl_config ssl_config;
@@ -48,13 +57,7 @@ typedef struct atclient_connection {
   mbedtls_entropy_context entropy;
   mbedtls_ctr_drbg_context ctr_drbg;
 
-  atclient_connection_type type;
-
-  // atclient_connection_connect sets this to true and atclient_connection_disconnect sets this to false
-  // this does not mean that the connection is still alive, it just means that the connection was established or taken
-  // down at some point, check atclient_connection_is_connected for a live status on the connection
-  bool should_be_connected;
-
+  bool _is_hooks_enabled;
   atclient_connection_hooks *hooks;
 } atclient_connection;
 

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -443,14 +443,13 @@ void atclient_connection_free(atclient_connection *ctx) {
   if (ctx->_should_be_connected) {
     free_contexts(ctx);
   }
+  if (ctx->hooks != NULL) {
+    free(ctx->hooks);
+  }
   memset(ctx, 0, sizeof(atclient_connection));
   memset(ctx->host, 0, ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE);
   ctx->port = -1;
   ctx->_should_be_connected = false;
-
-  if (ctx->hooks != NULL) {
-    free(ctx->hooks);
-  }
 }
 
 int atclient_connection_get_host_and_port(atclient_atstr *host, int *port, const atclient_atstr url) {

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -46,16 +46,12 @@ static void free_contexts(atclient_connection *ctx) {
 }
 
 void atclient_connection_init(atclient_connection *ctx, atclient_connection_type type) {
-
-  if (ctx == NULL) {
-    return; // how should we handle this error?
-  }
-
   memset(ctx, 0, sizeof(atclient_connection));
   memset(ctx->host, 0, ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE);
   ctx->port = -1;
   ctx->should_be_connected = false;
   ctx->type = type;
+  ctx->hooks = NULL;
 }
 
 int atclient_connection_connect(atclient_connection *ctx, const char *host, const int port) {
@@ -494,7 +490,7 @@ int atclient_connection_hooks_set(atclient_connection *ctx, atclient_connection_
   atclient_connection_hooks *hooks = ctx->hooks;
   if (hooks == NULL) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "Make sure to initialize hooks struct before trying to set a hook\n");
+                 "Make sure to enable hooks struct before trying to set a hook\n");
     return -1;
   }
 
@@ -522,7 +518,7 @@ int atclient_connection_hooks_set(atclient_connection *ctx, atclient_connection_
 void atclient_connection_hooks_set_readonly_src(atclient_connection *ctx, bool readonly_src) {
   if (ctx->hooks == NULL) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "Make sure to initialize hooks struct before trying to set readonly_src\n");
+                 "Make sure to enable hooks struct before trying to set readonly_src\n");
     return;
   }
   ctx->hooks->readonly_src = readonly_src;

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -45,26 +45,35 @@ static void free_contexts(atclient_connection *ctx) {
   mbedtls_ctr_drbg_free(&(ctx->ctr_drbg));
 }
 
+static void free_connection_hooks(atclient_connection *ctx) {
+  if (ctx->hooks != NULL && ctx->_is_hooks_enabled) {
+    free(ctx->hooks);
+    ctx->hooks = NULL;
+    ctx->_is_hooks_enabled = false;
+  }
+}
+
 void atclient_connection_init(atclient_connection *ctx, atclient_connection_type type) {
   memset(ctx, 0, sizeof(atclient_connection));
+  ctx->type = type;
   memset(ctx->host, 0, ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE);
   ctx->port = -1;
-  ctx->should_be_connected = false;
-  ctx->type = type;
+  ctx->_should_be_connected = false;
   ctx->hooks = NULL;
+  ctx->_is_hooks_enabled = false;
 }
 
 int atclient_connection_connect(atclient_connection *ctx, const char *host, const int port) {
   int ret = 1;
 
-  if (ctx->should_be_connected) {
+  if (ctx->_should_be_connected) {
     if((ret = atclient_connection_disconnect(ctx)) != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN, "atclient_connection_disconnect failed with exit code: %d. Continuing connection anyways..\n", ret);
     }
   }
 
   init_contexts(ctx);
-  ctx->should_be_connected = true;
+  ctx->_should_be_connected = true;
 
   const size_t readbufsize = 1024;
   unsigned char readbuf[readbufsize];
@@ -225,9 +234,9 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src_
     src = (unsigned char *)src_r;
   }
 
-  if (!ctx->should_be_connected) {
+  if (!ctx->_should_be_connected) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "ctx->should_be_connected should be true, but is false. You are trying to send messages to a "
+                 "ctx->_should_be_connected should be true, but is false. You are trying to send messages to a "
                  "non-connected connection.\n");
     goto exit;
   }
@@ -373,9 +382,9 @@ exit: {
 int atclient_connection_disconnect(atclient_connection *ctx) {
   int ret = 1;
 
-  if (!ctx->should_be_connected) {
+  if (!ctx->_should_be_connected) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "ctx->should_be_connected should be true, but is false, it was never connected in the first place!\n");
+                 "ctx->_should_be_connected should be true, but is false, it was never connected in the first place!\n");
     goto exit;
   }
 
@@ -384,7 +393,7 @@ int atclient_connection_disconnect(atclient_connection *ctx) {
   } while (ret == MBEDTLS_ERR_SSL_WANT_WRITE || ret == MBEDTLS_ERR_SSL_WANT_READ || ret != 0);
 
   free_contexts(ctx);
-  ctx->should_be_connected = false;
+  ctx->_should_be_connected = false;
 
   ret = 0;
 
@@ -394,8 +403,8 @@ exit: { return ret; }
 
 bool atclient_connection_is_connected(atclient_connection *ctx) {
 
-  if (!ctx->should_be_connected) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_connected should be true, but is false\n");
+  if (!ctx->_should_be_connected) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->_should_be_connected should be true, but is false\n");
     return false;
   }
 
@@ -431,13 +440,13 @@ bool atclient_connection_is_connected(atclient_connection *ctx) {
 }
 
 void atclient_connection_free(atclient_connection *ctx) {
-  if (ctx->should_be_connected) {
+  if (ctx->_should_be_connected) {
     free_contexts(ctx);
   }
   memset(ctx, 0, sizeof(atclient_connection));
   memset(ctx->host, 0, ATCLIENT_CONSTANTS_HOST_BUFFER_SIZE);
   ctx->port = -1;
-  ctx->should_be_connected = false;
+  ctx->_should_be_connected = false;
 
   if (ctx->hooks != NULL) {
     free(ctx->hooks);
@@ -482,13 +491,14 @@ void atclient_connection_enable_hooks(atclient_connection *ctx) {
   ctx->hooks = malloc(sizeof(atclient_connection_hooks));
   memset(ctx->hooks, 0, sizeof(atclient_connection_hooks));
   ctx->hooks->readonly_src = true;
+  ctx->_is_hooks_enabled = true;
 }
 
 // Q. Why is hook a void pointer?
 // A. In case we want to add future hook types which use a different function signature
 int atclient_connection_hooks_set(atclient_connection *ctx, atclient_connection_hook_type type, void *hook) {
   atclient_connection_hooks *hooks = ctx->hooks;
-  if (hooks == NULL) {
+  if (hooks == NULL || !ctx->_is_hooks_enabled) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                  "Make sure to enable hooks struct before trying to set a hook\n");
     return -1;

--- a/tests/functional_tests/tests/test_atclient_connection.c
+++ b/tests/functional_tests/tests/test_atclient_connection.c
@@ -142,8 +142,8 @@ static int test_1_initialize(atclient_connection *conn) {
 
   atclient_connection_init(conn, ATCLIENT_CONNECTION_TYPE_ATDIRECTORY);
 
-  if ((ret = assert_equals(conn->should_be_connected, false)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be false, but is true\n");
+  if ((ret = assert_equals(conn->_should_be_connected, false)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->_should_be_connected should be false, but is true\n");
     goto exit;
   }
 
@@ -166,8 +166,8 @@ static int test_2_connect(atclient_connection *conn) {
     goto exit;
   }
 
-  if ((ret = assert_equals(conn->should_be_connected, true)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "root_conn.should_be_connected should be true, but is false\n");
+  if ((ret = assert_equals(conn->_should_be_connected, true)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "root_conn._should_be_connected should be true, but is false\n");
     goto exit;
   }
 
@@ -234,8 +234,8 @@ static int test_5_disconnect(atclient_connection *conn) {
     goto exit;
   }
 
-  if ((ret = assert_equals(conn->should_be_connected, false)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "root_conn.should_be_connected should be false, but is true\n");
+  if ((ret = assert_equals(conn->_should_be_connected, false)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "root_conn._should_be_connected should be false, but is true\n");
     goto exit;
   }
 
@@ -308,8 +308,8 @@ static int test_8_reconnect(atclient_connection *conn) {
     goto exit;
   }
 
-  if (!conn->should_be_connected) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->should_be_connected should be true, but is false\n");
+  if (!conn->_should_be_connected) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ctx->_should_be_connected should be true, but is false\n");
     ret = 1;
     goto exit;
   }
@@ -345,8 +345,8 @@ static int test_10_free(atclient_connection *conn) {
 
   atclient_connection_free(conn);
 
-  if ((ret = assert_equals(conn->should_be_connected, false)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be false, but is true\n");
+  if ((ret = assert_equals(conn->_should_be_connected, false)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->_should_be_connected should be false, but is true\n");
     goto exit;
   }
 
@@ -363,8 +363,8 @@ static int test_11_initialize(atclient_connection *conn) {
 
   atclient_connection_init(conn, ATCLIENT_CONNECTION_TYPE_ATDIRECTORY);
 
-  if ((ret = assert_equals(conn->should_be_connected, false)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be false, but is true\n");
+  if ((ret = assert_equals(conn->_should_be_connected, false)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->_should_be_connected should be false, but is true\n");
     goto exit;
   }
 
@@ -491,11 +491,11 @@ static int test_17_should_be_connected_should_be_true(atclient_connection *conn)
 
   int ret = 1;
 
-  if ((ret = assert_equals(conn->should_be_connected, true)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->should_be_connected should be true, but is false\n");
+  if ((ret = assert_equals(conn->_should_be_connected, true)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "conn->_should_be_connected should be true, but is false\n");
     goto exit;
   }
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "conn->should_be_connected is true, as expected\n");
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "conn->_should_be_connected is true, as expected\n");
 
   ret = 0;
   goto exit;


### PR DESCRIPTION
**- What I did**
- fix: atclient_atsign_free in atclient_put.c
- fix: atclient_connection_hooks not being freed properly

**- How to verify it**
Used C SSHNPD to conduct a manual test
<img width="1054" alt="image" src="https://github.com/atsign-foundation/at_c/assets/79019866/5400ff9b-a9dd-46cc-b6fb-44dcae5bb7b7">

**- Description for the changelog**
fix: memory leaks with atclient_put and atclient_free not freeing connection hooks properly
