### PR TITLE
fix: atclient_get_publickey mem leak

### DIFF
--- a/packages/atclient/src/atclient_get_publickey.c
+++ b/packages/atclient/src/atclient_get_publickey.c
@@ -124,6 +124,7 @@ int atclient_get_publickey(atclient *atclient, atclient_atkey *atkey, char *valu
   ret = 0;
   goto exit;
 exit: {
+  atclient_atstr_free(&atkeystr);
   if (root != NULL) {
     cJSON_Delete(root);
   }


### PR DESCRIPTION
**- What I did**
- Fixed a memory leak where an atstr was allocated everytime `atclient_get_publickey` was called.
- Now it is freed.
