### PR TITLE
fix: atclient_create_shared_encryption_key_pair_for_me_and_other memory leaks

### DIFF
--- a/examples/desktop/repl/src/main.c
+++ b/examples/desktop/repl/src/main.c
@@ -102,19 +102,82 @@ int main(int argc, char *argv[]) {
 
   bool loop = true;
   do {
-    printf("Enter command: \n");
+    printf("Enter command: ");
     fgets(buffer, buffersize, stdin);
     bufferlen = strlen(buffer);
-    if (strncmp(buffer, "/exit", strlen("/exit")) == 0) {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Exiting REPL...\n");
-      loop = false;
+
+    if (bufferlen <= 0) {
       continue;
     }
-    ret = atclient_connection_send(&atclient.atserver_connection, (const unsigned char *)buffer, bufferlen, recv,
-                                   recvsize, &recvlen);
-    if (ret != 0) {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d | failed to send command\n", ret);
-      goto exit;
+
+    if (buffer[0] != '/') {
+      ret = atclient_connection_send(&(atclient.atserver_connection), (const unsigned char *)buffer, bufferlen, recv,
+                                     recvsize, &recvlen);
+      if (ret != 0) {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d | failed to send command: %s\n",
+                     ret, buffer);
+      }
+    } else {
+
+      char *command = strtok(buffer, " ");
+      if (command == NULL) {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "No command entered\n");
+        continue;
+      }
+
+      if (strcmp(command, "/exit") == 0) {
+        loop = false;
+        continue;
+      } else if (strcmp(command, "/get") == 0) {
+        char *atkeystr = strtok(NULL, " ");
+        if (atkeystr == NULL) {
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "No atKey entered\n");
+          continue;
+        }
+        atclient_atkey atkey;
+        atclient_atkey_init(&atkey);
+
+        if ((ret = atclient_atkey_from_string(&atkey, atkeystr, strlen(atkeystr)))) {
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_from_string: %d | failed to parse atKey\n",
+                       ret);
+          goto get_end;
+        }
+
+        switch (atkey.atkeytype) {
+        case ATCLIENT_ATKEY_TYPE_UNKNOWN: {
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unknown atKey type\n");
+          goto get_end;
+        }
+        case ATCLIENT_ATKEY_TYPE_PUBLICKEY: {
+          if ((ret = atclient_get_publickey(&atclient, &atkey, recv, recvsize, &recvlen, true)) != 0) {
+            atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_get_publickey: %d | failed to get public key\n",
+                         ret);
+            goto get_end;
+          }
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Value: \"%s\"\n", recv);
+          break;
+        }
+        case ATCLIENT_ATKEY_TYPE_SELFKEY: {
+          if ((ret = atclient_get_selfkey(&atclient, &atkey, recv, recvsize, &recvlen)) != 0) {
+            atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_get_selfkey: %d | failed to get self key\n", ret);
+            goto get_end;
+          }
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Value: \"%s\"\n", recv);
+          break;
+        }
+        case ATCLIENT_ATKEY_TYPE_SHAREDKEY: {
+          if ((ret = atclient_get_sharedkey(&atclient, &atkey, recv, recvsize, &recvlen, NULL, true)) != 0) {
+            atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_get_sharedkey: %d | failed to get shared key\n",
+                         ret);
+            goto get_end;
+          }
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Value: \"%s\"\n", recv);
+          break;
+        }
+        }
+
+      get_end: { atclient_atkey_free(&atkey); }
+      }
     }
     memset(buffer, 0, sizeof(char) * buffersize);
     memset(recv, 0, sizeof(unsigned char) * recvsize);

--- a/examples/desktop/repl/src/main.c
+++ b/examples/desktop/repl/src/main.c
@@ -134,6 +134,7 @@ int main(int argc, char *argv[]) {
           atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "No atKey entered\n");
           continue;
         }
+        atkeystr[strcspn(atkeystr, "\n")] = 0;
         atclient_atkey atkey;
         atclient_atkey_init(&atkey);
 

--- a/packages/atclient/src/encryption_key_helpers.c
+++ b/packages/atclient/src/encryption_key_helpers.c
@@ -282,7 +282,7 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(atclient *atclie
     return ret;
   }
 
-  // 3. encrypt for us (with self encryption key)
+  // 3. encrypt for us (with encrypt public key)
   ret =
       atchops_rsa_encrypt(atclient->atkeys.encryptpublickey, (unsigned char *)sharedenckeybase64, sharedenckeybase64len,
                           sharedenckeyencryptedforus, sharedenckeyencryptedforussize, &sharedenckeyencryptedforuslen);

--- a/packages/atclient/src/encryption_key_helpers.c
+++ b/packages/atclient/src/encryption_key_helpers.c
@@ -5,6 +5,7 @@
 #include "atclient/atkeys.h"
 #include "atclient/stringutils.h"
 #include "atlogger/atlogger.h"
+#include <stdlib.h>
 #include <string.h>
 
 #define TAG "encryption_key_helpers"
@@ -337,13 +338,13 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(atclient *atclie
   const size_t cmdbuffersize1 = strlen("update:shared_key. \r\n") + strlen(sharedwith->without_prefix_str) +
                                 strlen(sharedby->atsign) + 1 + sharedenckeybase64encryptedforuslen;
   cmdbuffer1 = (char *)malloc(sizeof(char) * cmdbuffersize1);
-  memset(cmdbuffer1, 0, sizeof(char) * cmdbuffersize1);
+  snprintf(cmdbuffer1, cmdbuffersize1, "update:shared_key.%s%s %s\r\n", sharedwith->without_prefix_str,
+           sharedby->atsign, sharedenckeybase64encryptedforus);
 
   // 5b. for them (update:shared_key.sharedwith@sharedby <encrypted for them>\r\n)
   const size_t cmdbuffersize2 = strlen("update::shared_key \r\n") + strlen(sharedby->atsign) +
                                 strlen(sharedwith->atsign) + 1 + sharedenckeybase64encryptedforthemlen;
   cmdbuffer2 = (char *)malloc(sizeof(char) * cmdbuffersize2);
-  memset(cmdbuffer2, 0, sizeof(char) * cmdbuffersize2);
   snprintf(cmdbuffer1, cmdbuffersize1, "update:shared_key.%s%s %s\r\n", sharedwith->without_prefix_str,
            sharedby->atsign, sharedenckeybase64encryptedforus);
 

--- a/packages/atclient/src/encryption_key_helpers.c
+++ b/packages/atclient/src/encryption_key_helpers.c
@@ -345,8 +345,8 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(atclient *atclie
   const size_t cmdbuffersize2 = strlen("update::shared_key \r\n") + strlen(sharedby->atsign) +
                                 strlen(sharedwith->atsign) + 1 + sharedenckeybase64encryptedforthemlen;
   cmdbuffer2 = (char *)malloc(sizeof(char) * cmdbuffersize2);
-  snprintf(cmdbuffer1, cmdbuffersize1, "update:shared_key.%s%s %s\r\n", sharedwith->without_prefix_str,
-           sharedby->atsign, sharedenckeybase64encryptedforus);
+  snprintf(cmdbuffer2, cmdbuffersize2, "update:%s:shared_key%s %s\r\n", sharedwith->atsign, sharedby->atsign,
+           sharedenckeybase64encryptedforthem);
 
   // 6. put "encrypted for us" into key store
   ret = atclient_connection_send(&(atclient->atserver_connection), (unsigned char *)cmdbuffer1, cmdbuffersize1 - 1,

--- a/packages/atclient/src/encryption_key_helpers.c
+++ b/packages/atclient/src/encryption_key_helpers.c
@@ -26,8 +26,8 @@ int atclient_get_shared_encryption_key_shared_by_me(atclient *ctx, const atclien
   memset(recv, 0, sizeof(unsigned char) * recvsize);
   size_t recvlen = 0;
 
-  ret = atclient_connection_send(&(ctx->atserver_connection), (unsigned char *)command, commandsize - 1, recv,
-                                 recvsize, &recvlen);
+  ret = atclient_connection_send(&(ctx->atserver_connection), (unsigned char *)command, commandsize - 1, recv, recvsize,
+                                 &recvlen);
   if (ret != 0) {
     return ret;
   }
@@ -262,6 +262,17 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(atclient *atclie
   char publickeybase64[publickeybase64size];
   memset(publickeybase64, 0, sizeof(char) * publickeybase64size);
 
+  const size_t recvsize = 2048;
+  unsigned char recv[recvsize];
+  memset(recv, 0, sizeof(unsigned char) * recvsize);
+  size_t recvlen = 0;
+
+  char *cmdbuffer1 = NULL;
+  char *cmdbuffer2 = NULL;
+
+  atchops_rsakey_publickey publickeystruct;
+  atchops_rsakey_publickey_init(&publickeystruct);
+
   // 2. generate shared encryption key
   ret = atchops_aes_generate_keybase64(sharedenckeybase64, sharedenckeybase64size, &sharedenckeybase64len,
                                        ATCHOPS_AES_256);
@@ -297,8 +308,6 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(atclient *atclie
   }
 
   // create a rsakey public (atchops)
-  atchops_rsakey_publickey publickeystruct;
-  atchops_rsakey_publickey_init(&publickeystruct);
   ret = atchops_rsakey_populate_publickey(&publickeystruct, publickeybase64, strlen(publickeybase64));
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsakey_populate_publickey: %d\n", ret);
@@ -320,39 +329,30 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(atclient *atclie
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                  "failed to base64 encode shared enc key for them | atchops_base64_encode: %d\n", ret);
-    return ret;
+    goto exit;
   }
 
   // 5. prep protocol commands
-
   // 5a. for us (update:shared_key.sharedby@sharedwith <encrypted for us>\r\n)
   const size_t cmdbuffersize1 = strlen("update:shared_key. \r\n") + strlen(sharedwith->without_prefix_str) +
                                 strlen(sharedby->atsign) + 1 + sharedenckeybase64encryptedforuslen;
-  char cmdbuffer1[cmdbuffersize1];
+  cmdbuffer1 = (char *)malloc(sizeof(char) * cmdbuffersize1);
   memset(cmdbuffer1, 0, sizeof(char) * cmdbuffersize1);
-  snprintf(cmdbuffer1, cmdbuffersize1, "update:shared_key.%s%s %s\r\n", sharedwith->without_prefix_str,
-           sharedby->atsign, sharedenckeybase64encryptedforus);
 
   // 5b. for them (update:shared_key.sharedwith@sharedby <encrypted for them>\r\n)
   const size_t cmdbuffersize2 = strlen("update::shared_key \r\n") + strlen(sharedby->atsign) +
                                 strlen(sharedwith->atsign) + 1 + sharedenckeybase64encryptedforthemlen;
-  char cmdbuffer2[cmdbuffersize2];
+  cmdbuffer2 = (char *)malloc(sizeof(char) * cmdbuffersize2);
   memset(cmdbuffer2, 0, sizeof(char) * cmdbuffersize2);
-  snprintf(cmdbuffer2, cmdbuffersize2, "update:%s:shared_key%s %s\r\n", sharedwith->atsign, sharedby->atsign,
-           sharedenckeybase64encryptedforthem);
+  snprintf(cmdbuffer1, cmdbuffersize1, "update:shared_key.%s%s %s\r\n", sharedwith->without_prefix_str,
+           sharedby->atsign, sharedenckeybase64encryptedforus);
 
-  // 5c. receive buffer
-  const size_t recvsize = 2048;
-  unsigned char recv[recvsize];
-  memset(recv, 0, sizeof(unsigned char) * recvsize);
-  size_t recvlen = 0;
-
-  // 5. put "encrypted for us" into key store
+  // 6. put "encrypted for us" into key store
   ret = atclient_connection_send(&(atclient->atserver_connection), (unsigned char *)cmdbuffer1, cmdbuffersize1 - 1,
                                  recv, recvsize, &recvlen);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n", ret);
-    return ret;
+    goto exit;
   }
 
   // check if the key was successfully stored
@@ -360,7 +360,7 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(atclient *atclie
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "recv was \"%.*s\" and did not have prefix \"data:\"\n",
                  (int)recvlen, recv);
-    return ret;
+    goto exit;
   }
 
   memset(recv, 0, sizeof(unsigned char) * recvsize);
@@ -370,7 +370,7 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(atclient *atclie
                                  recv, recvsize, &recvlen);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_connection_send: %d\n", ret);
-    return ret;
+    goto exit;
   }
 
   // check if the key was successfully stored
@@ -378,11 +378,19 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(atclient *atclie
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "recv was \"%.*s\" and did not have prefix \"data:\"\n",
                  (int)recvlen, recv);
-    return ret;
+    goto exit;
   }
 
   // 7. return shared encryption key by me
   memcpy(sharedenckeybyme, sharedenckeybase64, sharedenckeybase64len);
 
-  return 0;
+  ret = 0;
+  goto exit;
+
+exit: {
+  atchops_rsakey_publickey_free(&publickeystruct);
+  free(cmdbuffer1);
+  free(cmdbuffer2);
+  return ret;
+}
 }


### PR DESCRIPTION
**- What I did**
- atchops_rsa_publickey was not freed, so it is now freed
- new `/get` repl feature

**- How to verify it**

**- Description for the changelog**
