### PR TITLE
fix: atclient_atkey_from_string

### DIFF
--- a/examples/desktop/repl/src/main.c
+++ b/examples/desktop/repl/src/main.c
@@ -124,6 +124,7 @@ int main(int argc, char *argv[]) {
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "No command entered\n");
         continue;
       }
+      command[strcspn(command, "\n")] = 0;
 
       if (strcmp(command, "/exit") == 0) {
         loop = false;
@@ -178,10 +179,38 @@ int main(int argc, char *argv[]) {
         }
 
       get_end: { atclient_atkey_free(&atkey); }
+      } else if (strcmp(command, "/scan") == 0) {
+        char *regex = NULL;
+        char *saveptr = NULL;
+        regex = strtok_r(NULL, " ", &saveptr);
+        atclient_atkey *arr = NULL;
+        size_t arrlen = 0;
+        if ((ret = atclient_get_atkeys(&atclient, regex, true, 8192, &arr, &arrlen)) != 0) {
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_get_atkeys: %d | failed to get atKeys\n", ret);
+          goto scan_end;
+        }
+        const size_t atkeybufsize = 1024;
+        char atkeybuf[1024];
+        size_t atkey_buf_len;
+        for (size_t i = 0; i < arrlen; i++) {
+          memset(atkeybuf, 0, sizeof(char) * atkeybufsize);
+          atclient_atkey_to_string(&arr[i], atkeybuf, atkeybufsize, &atkey_buf_len);
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atKey[%i]: \'%s\'\n", i, atkeybuf);
+        }
+      scan_end: {
+        for (size_t i = 0; i < arrlen; i++) {
+          atclient_atkey_free(&arr[i]);
+        }
+        free(arr);
+      }
+      } else {
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unknown command: %s\n", command);
       }
     }
+
     memset(buffer, 0, sizeof(char) * buffersize);
     memset(recv, 0, sizeof(unsigned char) * recvsize);
+
   } while (loop);
 
   ret = 0;

--- a/examples/desktop/repl/src/main.c
+++ b/examples/desktop/repl/src/main.c
@@ -203,6 +203,30 @@ int main(int argc, char *argv[]) {
         }
         free(arr);
       }
+      } else if(strcmp(command, "/deleteall") == 0) {
+        atclient_atkey *arr = NULL;
+        size_t arrlen = 0;
+        if((ret = atclient_get_atkeys(&atclient, NULL, true, 8192, &arr, &arrlen)) != 0) {
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_get_atkeys: %d | failed to get atKeys\n", ret);
+          goto deleteall_end;
+        }
+        char buf[4096];
+        size_t bufolen;
+        for(size_t i = 0; i < arrlen; i++) {
+          if((ret = atclient_delete(&atclient, &arr[i])) != 0) {
+            atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_delete: %d | failed to delete atKey\n", ret);
+            continue;
+          }
+          memset(buf, 0, sizeof(char) * 4096);
+          atclient_atkey_to_string(&arr[i], buf, 4096, &bufolen);
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Deleted atKey: %s\n", buf);
+        }
+      deleteall_end: {
+        for (size_t i = 0; i < arrlen; i++) {
+          atclient_atkey_free(&arr[i]);
+        }
+        free(arr);
+      }
       } else {
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unknown command: %s\n", command);
       }

--- a/packages/atclient/src/atclient_get_atkeys.c
+++ b/packages/atclient/src/atclient_get_atkeys.c
@@ -62,6 +62,9 @@ int atclient_get_atkeys(atclient *atclient, const char *regex, const bool showhi
     goto exit;
   }
 
+  // log recevied bytes
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "recv was %lu bytes long\n", recvlen);
+
   // 2. parse response
   if (!atclient_stringutils_starts_with((char *)recv, recvlen, "data:", 5)) {
     ret = 1;

--- a/packages/atclient/src/atkey.c
+++ b/packages/atclient/src/atkey.c
@@ -164,7 +164,7 @@ int atclient_atkey_from_string(atclient_atkey *atkey, const char *atkeystr, cons
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atstr_set_literal failed\n");
       goto exit;
     }
-    char *namespacestr = strtok_r(NULL, ".", &saveptr2);
+    char *namespacestr = strtok_r(NULL, "", &saveptr2);
     if (namespacestr == NULL) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                             "namespacestr is NULL. %s atkey is probably incomplete\n", atkeystr);

--- a/packages/atclient/tests/test_atkey_from_string.c
+++ b/packages/atclient/tests/test_atkey_from_string.c
@@ -1,8 +1,8 @@
 #include "atclient/atkey.h"
 #include "atlogger/atlogger.h"
 #include <stdbool.h>
-#include <string.h>
 #include <stddef.h>
+#include <string.h>
 
 #define TAG "test_atkey_from_string"
 
@@ -15,6 +15,7 @@
 #define TEST_ATKEY_FROM_STRING_1C "public:name.wavi@jeremy"
 // 1D. cached public key with namespace
 #define TEST_ATKEY_FROM_STRING_1D "cached:public:name.wavi@jeremy"
+
 // Test 2: shared keys
 // 2A: non-cached shared key with namespace
 #define TEST_ATKEY_FROM_STRING_2A "@alice:name.wavi@bob"
@@ -24,9 +25,15 @@
 #define TEST_ATKEY_FROM_STRING_2C "@bob:name@alice"
 // 2D: cached shared key with namespace
 #define TEST_ATKEY_FROM_STRING_2D "cached:@bob:name.wavi@alice"
+// 2E: non-cached shared key with compounding namespace
+#define TEST_ATKEY_FROM_STRING_2E "@alice:name.vpsx.sshnp.abcd.efgh@xavierbob123"
+// 2F: cached shared key with compounding namespace
+#define TEST_ATKEY_FROM_STRING_2F "cached:@jeremy:name.vps1.sshnp@xavier"
+
 // Test 3: private hidden keys
 // 3A: private hidden key
 #define TEST_ATKEY_FROM_STRING_3A "_lastnotificationid@alice123_4😘"
+
 // Test 4: self keys
 // 4A: self key with no namespace
 #define TEST_ATKEY_FROM_STRING_4A "name@alice"
@@ -56,25 +63,23 @@ static int test1a() {
 
   if (atkey.metadata.ispublic != 1) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 1, it is %d\n",
-                          atkey.metadata.ispublic);
+                 atkey.metadata.ispublic);
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_PUBLICKEY) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_PUBLICKEY, it is %d\n", atkey.atkeytype);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_PUBLICKEY, it is %d\n",
+                 atkey.atkeytype);
     goto exit;
   }
 
   if (strncmp(atkey.name.str, "publickey", atkey.name.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not publickey, it is \"%s\"\n",
-                          atkey.name.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not publickey, it is \"%s\"\n", atkey.name.str);
     goto exit;
   }
 
   if (strncmp(atkey.sharedby.str, "@bob", atkey.sharedby.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @bob, it is \"%s\"\n",
-                          atkey.sharedby.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @bob, it is \"%s\"\n", atkey.sharedby.str);
     goto exit;
   }
   ret = 0;
@@ -108,42 +113,39 @@ static int test1b() {
 
   if (atkey.metadata.ispublic != 1) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 1, it is %d\n",
-                          atkey.metadata.ispublic);
+                 atkey.metadata.ispublic);
     ret = 1;
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_PUBLICKEY) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_PUBLICKEY, it is %d\n", atkey.atkeytype);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_PUBLICKEY, it is %d\n",
+                 atkey.atkeytype);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.name.str, "publickey", atkey.name.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not publickey, it is \"%s\"\n",
-                          atkey.name.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not publickey, it is \"%s\"\n", atkey.name.str);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n",
-                          atkey.sharedby.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n", atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
   if (atkey.namespacestr.len != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.len is not 0, it is %lu\n",
-                          atkey.namespacestr.len);
+                 atkey.namespacestr.len);
     ret = 1;
     goto exit;
   }
 
   if (atkey.sharedwith.len != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
-                          atkey.sharedwith.len);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n", atkey.sharedwith.len);
     ret = 1;
     goto exit;
   }
@@ -180,14 +182,14 @@ static int test1c() {
 
   if (atkey.metadata.ispublic != 1) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 1, it is %d\n",
-                          atkey.metadata.ispublic);
+                 atkey.metadata.ispublic);
     ret = 1;
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_PUBLICKEY) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_PUBLICKEY, it is %d\n", atkey.atkeytype);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_PUBLICKEY, it is %d\n",
+                 atkey.atkeytype);
     ret = 1;
     goto exit;
   }
@@ -200,21 +202,20 @@ static int test1c() {
 
   if (strncmp(atkey.sharedby.str, "@jeremy", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @jeremy, it is \"%s\"\n",
-                          atkey.sharedby.str);
+                 atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
   if (atkey.sharedwith.len != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
-                          atkey.sharedwith.len);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n", atkey.sharedwith.len);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
-                          atkey.namespacestr.str);
+                 atkey.namespacestr.str);
     ret = 1;
     goto exit;
   }
@@ -250,14 +251,14 @@ static int test1d() {
 
   if (atkey.metadata.ispublic != 1) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 1, it is %d\n",
-                          atkey.metadata.ispublic);
+                 atkey.metadata.ispublic);
     ret = 1;
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_PUBLICKEY) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_PUBLICKEY, it is %d\n", atkey.atkeytype);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_PUBLICKEY, it is %d\n",
+                 atkey.atkeytype);
     ret = 1;
     goto exit;
   }
@@ -270,23 +271,22 @@ static int test1d() {
 
   if (strncmp(atkey.sharedby.str, "@jeremy", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @jeremy, it is \"%s\"\n",
-                          atkey.sharedby.str);
+                 atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
   if (atkey.sharedwith.len != 0 && strlen(atkey.sharedwith.str) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
-                          atkey.sharedwith.len);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n", atkey.sharedwith.len);
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.str is not empty, it is \"%s\"\n",
-                          atkey.sharedwith.str);
+                 atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
-                          atkey.namespacestr.str);
+                 atkey.namespacestr.str);
     ret = 1;
     goto exit;
   }
@@ -323,42 +323,40 @@ static int test2a() {
 
   if (atkey.metadata.ispublic != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 0, it is %d\n",
-                          atkey.metadata.ispublic);
+                 atkey.metadata.ispublic);
     ret = 1;
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_SHAREDKEY) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SHAREDKEY, it is %d\n", atkey.atkeytype);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SHAREDKEY, it is %d\n",
+                 atkey.atkeytype);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.name.str, "name.wavi", atkey.name.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name.wavi, it is \"%s\"\n",
-                          atkey.name.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name.wavi, it is \"%s\"\n", atkey.name.str);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.sharedby.str, "@bob", atkey.sharedby.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @bob, it is \"%s\"\n",
-                          atkey.sharedby.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @bob, it is \"%s\"\n", atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.sharedwith.str, "@alice", atkey.sharedwith.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith is not @alice, it is \"%s\"\n",
-                          atkey.sharedwith.str);
+                 atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
-                          atkey.namespacestr.str);
+                 atkey.namespacestr.str);
     ret = 1;
     goto exit;
   }
@@ -394,14 +392,14 @@ static int test2b() {
 
   if (atkey.metadata.ispublic != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 0, it is %d\n",
-                          atkey.metadata.ispublic);
+                 atkey.metadata.ispublic);
     ret = 1;
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_SHAREDKEY) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SHAREDKEY, it is %d\n", atkey.atkeytype);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SHAREDKEY, it is %d\n",
+                 atkey.atkeytype);
     ret = 1;
     goto exit;
   }
@@ -413,22 +411,21 @@ static int test2b() {
   }
 
   if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n",
-                          atkey.sharedby.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n", atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.sharedwith.str, "@bob", atkey.sharedwith.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith is not @bob, it is \"%s\"\n",
-                          atkey.sharedwith.str);
+                 atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
   if (atkey.namespacestr.len != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.len is not 0, it is %lu\n",
-                          atkey.namespacestr.len);
+                 atkey.namespacestr.len);
     ret = 1;
     goto exit;
   }
@@ -461,14 +458,14 @@ static int test2c() {
 
   if (atkey.metadata.ispublic != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 0, it is %d\n",
-                          atkey.metadata.ispublic);
+                 atkey.metadata.ispublic);
     ret = 1;
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_SHAREDKEY) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SHAREDKEY, it is %d\n", atkey.atkeytype);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SHAREDKEY, it is %d\n",
+                 atkey.atkeytype);
     ret = 1;
     goto exit;
   }
@@ -480,22 +477,21 @@ static int test2c() {
   }
 
   if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n",
-                          atkey.sharedby.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n", atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.sharedwith.str, "@bob", atkey.sharedwith.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith is not @bob, it is \"%s\"\n",
-                          atkey.sharedwith.str);
+                 atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
   if (atkey.namespacestr.len != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.len is not 0, it is %lu\n",
-                          atkey.namespacestr.len);
+                 atkey.namespacestr.len);
     ret = 1;
     goto exit;
   }
@@ -531,14 +527,14 @@ static int test2d() {
 
   if (atkey.metadata.ispublic != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 0, it is %d\n",
-                          atkey.metadata.ispublic);
+                 atkey.metadata.ispublic);
     ret = 1;
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_SHAREDKEY) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SHAREDKEY, it is %d\n", atkey.atkeytype);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SHAREDKEY, it is %d\n",
+                 atkey.atkeytype);
     ret = 1;
     goto exit;
   }
@@ -550,22 +546,21 @@ static int test2d() {
   }
 
   if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n",
-                          atkey.sharedby.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n", atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.sharedwith.str, "@bob", atkey.sharedwith.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith is not @bob, it is \"%s\"\n",
-                          atkey.sharedwith.str);
+                 atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
-                          atkey.namespacestr.str);
+                 atkey.namespacestr.str);
     ret = 1;
     goto exit;
   }
@@ -576,6 +571,104 @@ exit: {
   atclient_atkey_free(&atkey);
   return ret;
 }
+}
+
+static int test2e() {
+  int ret = 1;
+
+  atclient_atkey atkey;
+  atclient_atkey_init(&atkey);
+
+  if ((ret = atclient_atkey_from_string(&atkey, TEST_ATKEY_FROM_STRING_2E, strlen(TEST_ATKEY_FROM_STRING_2E))) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_from_string failed: %d\n", ret);
+    goto exit;
+  }
+
+  // @alice:name.vpsx.sshnp.abcd.efgh@xavierbob123
+  if(strcmp(atkey.sharedby.str, "@xavierbob123") != 0) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @jeremy, it is %s\n", atkey.sharedby.str);
+    goto exit;
+  }
+
+  if(strcmp(atkey.sharedwith.str, "@alice") != 0) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith is not @jeremy, it is %s\n", atkey.sharedwith.str);
+    goto exit;
+  }
+
+  if(strcmp(atkey.name.str, "name") != 0) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is %s\n", atkey.name.str);
+    goto exit;
+  }
+
+  if(strcmp(atkey.namespacestr.str, "vpsx.sshnp.abcd.efgh") != 0) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not vps1.sshnp, it is %s\n", atkey.namespacestr.str);
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: {
+  atclient_atkey_free(&atkey);
+  return ret;
+}
+}
+
+static int test2f() {
+  int ret = 1;
+
+  atclient_atkey atkey;
+  atclient_atkey_init(&atkey);
+
+  if ((ret = atclient_atkey_from_string(&atkey, TEST_ATKEY_FROM_STRING_2F, strlen(TEST_ATKEY_FROM_STRING_2F))) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_from_string failed: %d\n", ret);
+    goto exit;
+  }
+
+  // cached:@jeremy:name.vps1.sshnp@xavier
+
+  if(!atclient_atkey_metadata_is_iscached_initialized(&atkey.metadata)) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.iscached is not initialized when it should be\n");
+    goto exit;
+  }
+
+  if(atkey.metadata.iscached != true) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.iscached is false when it should be true\n");
+    goto exit;
+  }
+
+  if(strcmp(atkey.sharedby.str, "@xavier") != 0) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @jeremy, it is %s\n", atkey.sharedby.str);
+    goto exit;
+  }
+
+  if(strcmp(atkey.sharedwith.str, "@jeremy") != 0) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith is not @jeremy, it is %s\n", atkey.sharedwith.str);
+    goto exit;
+  }
+
+  if(strcmp(atkey.name.str, "name") != 0) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is %s\n", atkey.name.str);
+    goto exit;
+  }
+
+  if(strcmp(atkey.namespacestr.str, "vps1.sshnp") != 0) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not vps1.sshnp, it is %s\n", atkey.namespacestr.str);
+    goto exit;
+  }
+
+  ret = 0;
+  goto exit;
+exit: { return ret; }
 }
 
 static int test3a() {
@@ -601,42 +694,41 @@ static int test3a() {
 
   if (atkey.metadata.ispublic != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 0, it is %d\n",
-                          atkey.metadata.ispublic);
+                 atkey.metadata.ispublic);
     ret = 1;
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_SELFKEY) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_PRIVATEHIDDENKEY, it is %d\n", atkey.atkeytype);
+                 "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_PRIVATEHIDDENKEY, it is %d\n", atkey.atkeytype);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.name.str, "_lastnotificationid", atkey.name.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not _lastnotificationid, it is \"%s\"\n",
-                          atkey.name.str);
+                 atkey.name.str);
     ret = 1;
     goto exit;
   }
 
   if (strncmp(atkey.sharedby.str, "@alice123_4😘", atkey.sharedby.len) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice123_4😘, it is \"%s\"\n",
-                          atkey.sharedby.str);
+                 atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
   if (atkey.sharedwith.len != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
-                          atkey.sharedwith.len);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n", atkey.sharedwith.len);
     ret = 1;
     goto exit;
   }
 
   if (atkey.namespacestr.len != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.len is not 0, it is %lu\n",
-                          atkey.namespacestr.len);
+                 atkey.namespacestr.len);
     ret = 1;
     goto exit;
   }
@@ -673,14 +765,14 @@ static int test4a() {
 
   if (atkey.metadata.ispublic != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 0, it is %d\n",
-                          atkey.metadata.ispublic);
+                 atkey.metadata.ispublic);
     ret = 1;
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_SELFKEY) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SELFKEY, it is %d\n", atkey.atkeytype);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SELFKEY, it is %d\n",
+                 atkey.atkeytype);
     ret = 1;
     goto exit;
   }
@@ -692,26 +784,24 @@ static int test4a() {
   }
 
   if (strncmp(atkey.sharedby.str, "@alice", atkey.sharedby.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n",
-                          atkey.sharedby.str);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @alice, it is \"%s\"\n", atkey.sharedby.str);
     ret = 1;
     goto exit;
   }
 
   if (atkey.sharedwith.len != 0 && strlen(atkey.sharedwith.str) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
-                          atkey.sharedwith.len);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n", atkey.sharedwith.len);
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.str is not empty, it is \"%s\"\n",
-                          atkey.sharedwith.str);
+                 atkey.sharedwith.str);
     ret = 1;
     goto exit;
   }
 
   if (atkey.namespacestr.len != 0 && strlen(atkey.namespacestr.str) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.len is not 0, it is %lu\n",
-                          atkey.namespacestr.len);
+                 atkey.namespacestr.len);
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr.str is not empty, it is \"%s\"\n",
-                          atkey.namespacestr.str);
+                 atkey.namespacestr.str);
     ret = 1;
     goto exit;
   }
@@ -740,51 +830,50 @@ static int test4b() {
   }
 
   if (atkey.metadata.iscached != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.iscached is not 0\n");
     ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.iscached is not 0\n");
     goto exit;
   }
 
   if (atkey.metadata.ispublic != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 0, it is %d\n",
-                          atkey.metadata.ispublic);
     ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ispublic is not 0, it is %d\n",
+                 atkey.metadata.ispublic);
     goto exit;
   }
 
   if (atkey.atkeytype != ATCLIENT_ATKEY_TYPE_SELFKEY) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                          "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SELFKEY, it is %d\n", atkey.atkeytype);
     ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.atkeytype is not ATCLIENT_ATKEY_TYPE_SELFKEY, it is %d\n",
+                 atkey.atkeytype);
     goto exit;
   }
 
   if (strncmp(atkey.name.str, "name", atkey.name.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is \"%s\"\n", atkey.name.str);
     ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.name is not name, it is \"%s\"\n", atkey.name.str);
     goto exit;
   }
 
   if (strncmp(atkey.sharedby.str, "@jeremy_0", atkey.sharedby.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @jeremy_0, it is \"%s\"\n",
-                          atkey.sharedby.str);
     ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedby is not @jeremy_0, it is \"%s\"\n",
+                 atkey.sharedby.str);
     goto exit;
   }
 
   if (atkey.sharedwith.len != 0 && strlen(atkey.sharedwith.str) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n",
-                          atkey.sharedwith.len);
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.str is not empty, it is \"%s\"\n",
-                          atkey.sharedwith.str);
     ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.len is not 0, it is %lu\n", atkey.sharedwith.len);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.sharedwith.str is not empty, it is \"%s\"\n",
+                 atkey.sharedwith.str);
     goto exit;
   }
 
   if (strncmp(atkey.namespacestr.str, "wavi", atkey.namespacestr.len) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
-                          atkey.namespacestr.str);
     ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespacestr is not wavi, it is \"%s\"\n",
+                 atkey.namespacestr.str);
     goto exit;
   }
 
@@ -802,84 +891,72 @@ int main() {
   atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
 
   // test 1a. cached public key (cached:public:publickey@bob)
-  ret = test1a();
-  if (ret != 0) {
+  if ((ret = test1a()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test1a failed\n");
-    ret = 1;
     goto exit;
   }
 
   // test 1b. non-cached public key (public:publickey@alice)
-  ret = test1b();
-  if (ret != 0) {
+  if ((ret = test1b()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test1b failed\n");
-    ret = 1;
     goto exit;
   }
 
   // test 1c
-  ret = test1c();
-  if (ret != 0) {
+  if ((ret = test1c()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test1c failed\n");
-    ret = 1;
     goto exit;
   }
 
   // test 1d
-  ret = test1d();
-  if (ret != 0) {
+  if ((ret = test1d()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test1d failed\n");
-    ret = 1;
     goto exit;
   }
 
   // test 2a. non-cached sharedkey with namespace (@alice:name.wavi@bob)
-  ret = test2a();
-  if (ret != 0) {
+  if ((ret = test2a()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test2a failed\n");
-    ret = 1;
     goto exit;
   }
 
-  ret = test2b();
-  if (ret != 0) {
+  if ((ret = test2b()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test2b failed\n");
-    ret = 1;
     goto exit;
   }
 
-  ret = test2c();
-  if (ret != 0) {
+  if ((ret = test2c()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test2c failed\n");
-    ret = 1;
     goto exit;
   }
 
-  ret = test2d();
-  if (ret != 0) {
+  if ((ret = test2d()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test2d failed\n");
-    ret = 1;
     goto exit;
   }
 
-  ret = test3a();
-  if (ret != 0) {
+  if ((ret = test2e()) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test2e failed\n");
+    goto exit;
+  }
+
+  if ((ret = test2f()) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test2f failed\n");
+    goto exit;
+  }
+
+  if ((ret = test3a()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test3a failed\n");
-    ret = 1;
     goto exit;
   }
 
-  ret = test4a();
-  if (ret != 0) {
+  if ((ret = test4a()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test4a failed\n");
-    ret = 1;
     goto exit;
   }
 
-  ret = test4b();
-  if (ret != 0) {
+  if ((ret = test4b()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test4b failed\n");
-    ret = 1;
     goto exit;
   }
 


### PR DESCRIPTION
closes #327 

**- What I did**
- fixed compounding namespacing in `atclient_atkey_from_string`
- added 2 unit tests for namespacing in `test_atclient_atkey_from_string`
- 2 new REPL features: /scan and /deleteall

**- How to verify it**
- 2 new unit tests pass

**- Description for the changelog**
fix: atclient_atkey_from_string
