### PR TITLE
fix: skip logging prefix if tag is null

### DIFF
--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -112,15 +112,12 @@ void atlogger_log(const char *tag, const enum atlogger_logging_level level, cons
     return;
   }
 
-  atlogger_get_prefix(level, prefix, PREFIX_BUFFER_LEN);
-
   va_list args;
   va_start(args, format);
-  printf("%.*s", (int)strlen(prefix), prefix);
   if (tag != NULL) {
-    printf(" %s", tag);
+    atlogger_get_prefix(level, prefix, PREFIX_BUFFER_LEN);
+    printf("%.*s %s | ", (int)strlen(prefix), prefix, tag);
   }
-  printf(" | ");
   vprintf(format, args);
   va_end(args);
 }

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -116,8 +116,8 @@ void atlogger_log(const char *tag, const enum atlogger_logging_level level, cons
   va_start(args, format);
   if (tag != NULL) {
     atlogger_get_prefix(level, prefix, PREFIX_BUFFER_LEN);
-    printf("%.*s", (int)strlen(prefix), prefix);
-    printf("%.*s| ", (int)strlen(tag), tag);
+    printf("%.*s ", (int)strlen(prefix), prefix);
+    printf("%.*s | ", (int)strlen(tag), tag);
   }
   vprintf(format, args);
   va_end(args);

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -116,7 +116,8 @@ void atlogger_log(const char *tag, const enum atlogger_logging_level level, cons
   va_start(args, format);
   if (tag != NULL) {
     atlogger_get_prefix(level, prefix, PREFIX_BUFFER_LEN);
-    printf("%.*s %s | ", (int)strlen(prefix), prefix, tag);
+    printf("%.*s", (int)strlen(prefix), prefix);
+    printf("%.*s| ", (int)strlen(tag), tag);
   }
   vprintf(format, args);
   va_end(args);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes https://github.com/atsign-foundation/at_c/issues/236

**- What I did**
- skip printing prefix when atlogger_log() is called with NULL tag
- when tag is NULL:
- - previously -> "[INFO] datetime |  | log statement"
- - now -> "log statement"`

**- How I did it**
- moved the atlogger_get_prefix() call inside an if-statement that validates that tag is not null

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: skip logging prefix if tag is null