### PR TITLE
fix: null terminate decrypted value

### DIFF
--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -583,8 +583,12 @@ static int decrypt_notification(atclient *atclient, atclient_atnotification *not
     goto exit;
   }
 
-  const size_t decryptedvaluetempsize = ciphertextlen;
+  const size_t decryptedvaluetempsize = ciphertextlen + 1;
   decryptedvaluetemp = malloc(sizeof(unsigned char) * decryptedvaluetempsize);
+  if(decryptedvaluetemp == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for decrypted value\n");
+    goto exit;
+  }
   memset(decryptedvaluetemp, 0, sizeof(unsigned char) * decryptedvaluetempsize);
   size_t decryptedvaluetemplen = 0;
 


### PR DESCRIPTION
**- What I did**
Ensure one bit is there to null-terminate the decrypted value

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: null terminate decrypted value
