### PR TITLE
build: Release workflow for C SDK tarball

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -1,0 +1,82 @@
+name: C_Release_Automation
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions: # added using https://github.com/step-security/secure-repo
+  contents: read
+
+jobs:
+  source_tarball:
+    name: Generate source tarball
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Create tarball
+        run: |
+          mkdir tarball
+          mkdir at_c-${{ github.ref_name }}
+          cp -R packages/* at_c-${{ github.ref_name }
+          tar -cvzf tarball/at_c-${{ github.ref_name }}.tar.gz at_c-${{ github.ref_name }}
+      - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        with:
+          name: csshnpd-src-${{github.ref_name}}-${{github.run_number}}-${{github.run_attempt}}
+          path: ./tarball/at_c-${{ github.ref_name }}.tar.gz
+
+  github-release:
+    name: >-
+      Upload artifacts and generate checksums for provenance
+    needs: [source_tarball]
+    runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    permissions:
+      contents: write # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write # IMPORTANT: mandatory for sigstore
+      attestations: write
+    steps:
+      - name: Download all the tarballs
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          path: tarballs/
+## 20240807: Need a different approach to SBOMs for C SDK
+#    - name: Generate SBOMs
+#      run: |
+#        syft scan file:./packages/dart/sshnoports/pubspec.lock \
+#          -o 'spdx-json=tarballs/dart_sshnoports_sbom.spdx.json' \
+#          -o 'cyclonedx-json=tarballs/dart_sshnoports_sbom.cyclonedx.json'
+      - name: Move packages for signing
+        run: |
+          cd tarballs
+          mv */*.tar.gz .
+          rm -Rf -- */
+      - name: Generate SHA256 checksums
+        working-directory: tarballs
+        run: sha256sum * > checksums.txt
+      - name: Upload artifacts to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload '${{ github.ref_name }}' tarballs/** --repo '${{
+          github.repository }}'
+      - id: hash
+        name: Pass artifact hashes for SLSA provenance
+        working-directory: tarballs
+        run: |
+          echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+      - uses: actions/attest-build-provenance@210c1913531870065f03ce1f9440dd87bc0938cd # v1.4.0
+        with:
+          subject-path: "tarballs/**"
+
+  provenance:
+    needs: [github-release]
+    permissions:
+      actions: read # Needed for detection of GitHub Actions environment.
+      id-token: write # Needed for provenance signing and ID
+      contents: write # Needed for release uploads
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0 # 5a775b367a56d5bd118a224a811bba288150a563
+    with:
+      base64-subjects: "${{ needs.github-release.outputs.hashes }}"
+      upload-assets: true


### PR DESCRIPTION
Release workflow as discussed in arch call 20240806

**- What I did**

Created workflow that builds source tarball then generates SLSA attestation

**- How I did it**

Based on c_release workflow in noports

**- How to verify it**

Create a (pre)release after merging using a `v` tag

**- Description for the changelog**

build: Release workflow for C SDK tarball
