### PR TITLE
chore: remove debug logs from `atclient_put_self_key.c` and fix monitor.c warning

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           mkdir tarball
           mkdir at_c-${{ github.ref_name }}
-          cp -R packages/* at_c-${{ github.ref_name }}
+          cp -R . at_c-${{ github.ref_name }}
           tar -cvzf tarball/at_c-${{ github.ref_name }}.tar.gz at_c-${{ github.ref_name }}
       - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:

--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           mkdir tarball
           mkdir at_c-${{ github.ref_name }}
-          cp -R . at_c-${{ github.ref_name }}
+          cp -R packages/* at_c-${{ github.ref_name }}
           tar -cvzf tarball/at_c-${{ github.ref_name }}.tar.gz at_c-${{ github.ref_name }}
       - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:

--- a/packages/atclient/src/atclient_put_self_key.c
+++ b/packages/atclient/src/atclient_put_self_key.c
@@ -106,17 +106,6 @@ int atclient_put_self_key(atclient *ctx, atclient_atkey *atkey, const char *valu
     goto exit;
   }
 
-  // log value_encrypted
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "value_encrypted: ");
-  for (size_t i = 0; i < value_encrypted_len; i++) {
-    printf("%02x ", value_encrypted[i]);
-  }
-  printf("\n");
-
-  // log value_encrypted_len
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "value_encrypted_len: %zu\n", value_encrypted_len);
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "value_encrypted_size: %zu\n", value_encrypted_size);
-
   size_t value_encrypted_base64_len = 0;
   memset(value_encrypted_base64, 0, sizeof(char) * value_encrypted_base64_size);
   if ((ret = atchops_base64_encode(value_encrypted, value_encrypted_len, (unsigned char *) value_encrypted_base64,

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -245,10 +245,11 @@ bool atclient_monitor_is_connected(atclient *monitor_conn) {
 static int parse_message(const char *original, char **message_type, char **message_body) {
   int ret = -1;
 
+  char *original_copy = strdup(original);
   char *temp = NULL;
   char *saveptr;
 
-  temp = strtok_r(original, ":", &saveptr);
+  temp = strtok_r(original_copy, ":", &saveptr);
   if (temp == NULL) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to parse message type\n");
     goto exit;
@@ -291,7 +292,10 @@ static int parse_message(const char *original, char **message_type, char **messa
 
   ret = 0;
   goto exit;
-exit: { return ret; }
+exit: {
+  free(original_copy);
+  return ret;
+}
 }
 
 // populates *notification given a notification "*messagebody" which has been received from atServer


### PR DESCRIPTION
**- What I did**
- Removed probably unwanted debug logs
- Fixed warning with `const char *original`

**- Description for the changelog**
chore: remove debug logs from `atclient_put_self_key.c` and fixed warning with `const char *original`
