### PR TITLE
build(deps): Bump MbedTLS to 3.6.1

### DIFF
--- a/cmake/find_mbedtls.cmake
+++ b/cmake/find_mbedtls.cmake
@@ -8,9 +8,9 @@ message(STATUS "[MbedTLS] fetching package...")
 include(FetchContent)
 fetchcontent_declare(
   MbedTLS
-  URL https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/v3.5.1.zip
+  URL https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.1/mbedtls-3.6.1.tar.bz2
   URL_HASH
-    SHA256=959a492721ba036afc21f04d1836d874f93ac124cf47cf62c9bcd3a753e49bdb # hash for v3.5.1 .zip release source code
+    SHA256=fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3 # hash for v3.6.1 .tar.bz2 release source code
   # FIND_PACKAGE_ARGS QUIET CONFIG
 )
 fetchcontent_makeavailable(MbedTLS)


### PR DESCRIPTION
We presently can't build C sshnpd for musl on arm64. Here's the note in the build workflow:

```txt
## 20240806: arm64 failing due to Mbed TLS error:
## /sshnpd/sshnpd/build/_deps/mbedtls-src/library/aesce.c:87:10:
## fatal error: 'asm/hwcap.h' file not found
#          - platform: linux/arm64
#            output-name: sshnpd-linux-arm64-musl
```

**- What I did**

Updated the cmake file to get the release tarball for v3.6.1

NB we're no longer just grabbing the zip of the git source, as that [fails due to missing submodules](https://github.com/Mbed-TLS/mbedtls/issues/8993)

**- How I did it**

Tested using my fork of this repo

**- How to verify it**

CI here and further testing once taken up for C sshnpd

**- Description for the changelog**

build(deps): Bump MbedTLS to 3.6.1
