### PR TITLE
chore: `atclient_atkeysfile` -> `atclient_atkeys_file`

### DIFF
--- a/examples/desktop/pkam_authenticate/src/main.c
+++ b/examples/desktop/pkam_authenticate/src/main.c
@@ -16,8 +16,8 @@ int main(int argc, char **argv) {
 
   atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);
 
-  atclient_atkeysfile atkeys_file;
-  atclient_atkeysfile_init(&atkeys_file);
+  atclient_atkeys_file atkeys_file;
+  atclient_atkeys_file_init(&atkeys_file);
 
   atclient_atkeys atkeys;
   atclient_atkeys_init(&atkeys);
@@ -25,10 +25,10 @@ int main(int argc, char **argv) {
   atclient atclient;
   atclient_init(&atclient);
 
-  if ((ret = atclient_atkeysfile_from_path(&atkeys_file, ATKEYS_FILE_PATH)) != 0) {
+  if ((ret = atclient_atkeys_file_from_path(&atkeys_file, ATKEYS_FILE_PATH)) != 0) {
     goto exit;
   }
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeysfile_read: %d\n", ret);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_file_from_path: %d\n", ret);
 
   if ((ret = atclient_atkeys_populate_from_atkeys_file(&atkeys, &atkeys_file)) != 0) {
     goto exit;
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
   goto exit;
 
 exit: {
-  atclient_atkeysfile_free(&atkeys_file);
+  atclient_atkeys_file_free(&atkeys_file);
   atclient_atkeys_free(&atkeys);
   atclient_free(&atclient);
   return 0;

--- a/packages/atclient/include/atclient/atkeys.h
+++ b/packages/atclient/include/atclient/atkeys.h
@@ -133,13 +133,13 @@ int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys, const char *a
                                           const size_t self_encryption_key_len, const char *enrollment_id_str, const size_t enrollment_id_str_len);
 
 /**
- * @brief populates the struct by decrypting the encrypted RSA keys found in a populated atclient_atkeysfile struct
+ * @brief populates the struct by decrypting the encrypted RSA keys found in a populated atclient_atkeys_file struct
  *
  * @param atkeys The struct to populate, assumed to be NON-NULL and initialized with atclient_atkeys_init
  * @param atkeys_file the struct containing the encrypted RSA keys, typically already read from the *.atKeys file
  * @return int 0 on success, non-zero on failure
  */
-int atclient_atkeys_populate_from_atkeys_file(atclient_atkeys *atkeys, const atclient_atkeysfile *atkeys_file);
+int atclient_atkeys_populate_from_atkeys_file(atclient_atkeys *atkeys, const atclient_atkeys_file *atkeys_file);
 
 /**
  * @brief populates the atkeys struct by reading the *.atKeys file,

--- a/packages/atclient/include/atclient/atkeys_file.h
+++ b/packages/atclient/include/atclient/atkeys_file.h
@@ -21,7 +21,7 @@
 #define ATCLIENT_ATKEYS_FILE_SELF_ENCRYPTION_KEY_STR_INITIALIZED (VALUE_INITIALIZED << 4)
 #define ATCLIENT_ATKEYS_FILE_ENROLLMENT_ID_STR_INITIALIZED (VALUE_INITIALIZED << 5)
 
-typedef struct atclient_atkeysfile {
+typedef struct atclient_atkeys_file {
   char *aes_pkam_public_key_str;     // encrypted with self encryption key. AES decryption with self encryption key will
                                      // reveal base64-encoded RSA key
   char *aes_pkam_private_key_str;    // encrypted with self encryption key. AES decryption with self encryption key will
@@ -34,7 +34,7 @@ typedef struct atclient_atkeysfile {
                                      // 32-byte AES key
   char *enrollment_id_str;
   uint8_t _initialized_fields[1];
-} atclient_atkeysfile;
+} atclient_atkeys_file;
 
 /**
  * @brief Initialize the struct. This function does not allocate the struct, but manages its memory internally. This
@@ -42,46 +42,46 @@ typedef struct atclient_atkeysfile {
  *
  * @param atkeys_file the allocated struct to be initialized.
  */
-void atclient_atkeysfile_init(atclient_atkeysfile *atkeys_file);
+void atclient_atkeys_file_init(atclient_atkeys_file *atkeys_file);
 
 /**
  * @brief Read from a `_key.atKeys` file path.
  *
- * @param atkeys_file the struct to be populated, assumed to be NON-NULL and initialized with atclient_atkeysfile_init
+ * @param atkeys_file the struct to be populated, assumed to be NON-NULL and initialized with atclient_atkeys_file_init
  * @param path  Example "$HOME/.atsign/keys/@alice_key.atKeys"
  * @return int
  */
-int atclient_atkeysfile_from_path(atclient_atkeysfile *atkeys_file, const char *path);
+int atclient_atkeys_file_from_path(atclient_atkeys_file *atkeys_file, const char *path);
 
 /**
  * @brief Read from a string. You would typically read the file first and then call this function to populate your
  * *atkeys_file struct.
  *
- * @param atkeys_file the struct to be populated, assumed to be NON-NULL and initialized with atclient_atkeysfile_init
+ * @param atkeys_file the struct to be populated, assumed to be NON-NULL and initialized with atclient_atkeys_file_init
  * @param file_string the string that is read from the `_key.atKeys` file.
  * @return int
  */
-int atclient_atkeysfile_from_string(atclient_atkeysfile *atkeys_file, const char *file_string);
+int atclient_atkeys_file_from_string(atclient_atkeys_file *atkeys_file, const char *file_string);
 
 /**
  * @brief Free the struct of any memory that was allocated during its lifetime
  *
- * @param atkeys_file the struct to be populated, assumed to be NON-NULL and initialized with atclient_atkeysfile_init
+ * @param atkeys_file the struct to be populated, assumed to be NON-NULL and initialized with atclient_atkeys_file_init
  */
-void atclient_atkeysfile_free(atclient_atkeysfile *atkeys_file);
+void atclient_atkeys_file_free(atclient_atkeys_file *atkeys_file);
 
-bool atclient_atkeysfile_is_aes_pkam_public_key_str_initialized(atclient_atkeysfile *atkeys_file);
-bool atclient_atkeysfile_is_aes_pkam_private_key_str_initialized(atclient_atkeysfile *atkeys_file);
-bool atclient_atkeysfile_is_aes_encrypt_public_key_str_initialized(atclient_atkeysfile *atkeys_file);
-bool atclient_atkeysfile_is_aes_encrypt_private_key_str_initialized(atclient_atkeysfile *atkeys_file);
-bool atclient_atkeysfile_is_self_encryption_key_str_initialized(atclient_atkeysfile *atkeys_file);
-bool atclient_atkeysfile_is_enrollment_id_str_initialized(atclient_atkeysfile *atkeys_file);
+bool atclient_atkeys_file_is_aes_pkam_public_key_str_initialized(atclient_atkeys_file *atkeys_file);
+bool atclient_atkeys_file_is_aes_pkam_private_key_str_initialized(atclient_atkeys_file *atkeys_file);
+bool atclient_atkeys_file_is_aes_encrypt_public_key_str_initialized(atclient_atkeys_file *atkeys_file);
+bool atclient_atkeys_file_is_aes_encrypt_private_key_str_initialized(atclient_atkeys_file *atkeys_file);
+bool atclient_atkeys_file_is_self_encryption_key_str_initialized(atclient_atkeys_file *atkeys_file);
+bool atclient_atkeys_file_is_enrollment_id_str_initialized(atclient_atkeys_file *atkeys_file);
 
-int atclient_atkeysfile_set_aes_pkam_public_key_str(atclient_atkeysfile *atkeys_file, const char *aes_pkam_public_key_str, const size_t aes_pkam_public_key_str_len);
-int atclient_atkeysfile_set_aes_pkam_private_key_str(atclient_atkeysfile *atkeys_file, const char *aes_pkam_private_key_str, const size_t aes_pkam_private_key_str_len);
-int atclient_atkeysfile_set_aes_encrypt_public_key_str(atclient_atkeysfile *atkeys_file, const char *aes_encrypt_public_key_str, const size_t aes_encrypt_public_key_str_len);
-int atclient_atkeysfile_set_aes_encrypt_private_key_str(atclient_atkeysfile *atkeys_file, const char *aes_encrypt_private_key_str, const size_t aes_encrypt_private_key_str_len);
-int atclient_atkeysfile_set_self_encryption_key_str(atclient_atkeysfile *atkeys_file, const char *self_encryption_key_str, const size_t self_encryption_key_str_len);
-int atclient_atkeysfile_set_enrollment_id_str(atclient_atkeysfile *atkeys_file, const char *enrollment_id_str, const size_t enrollment_id_str_len);
+int atclient_atkeys_file_set_aes_pkam_public_key_str(atclient_atkeys_file *atkeys_file, const char *aes_pkam_public_key_str, const size_t aes_pkam_public_key_str_len);
+int atclient_atkeys_file_set_aes_pkam_private_key_str(atclient_atkeys_file *atkeys_file, const char *aes_pkam_private_key_str, const size_t aes_pkam_private_key_str_len);
+int atclient_atkeys_file_set_aes_encrypt_public_key_str(atclient_atkeys_file *atkeys_file, const char *aes_encrypt_public_key_str, const size_t aes_encrypt_public_key_str_len);
+int atclient_atkeys_file_set_aes_encrypt_private_key_str(atclient_atkeys_file *atkeys_file, const char *aes_encrypt_private_key_str, const size_t aes_encrypt_private_key_str_len);
+int atclient_atkeys_file_set_self_encryption_key_str(atclient_atkeys_file *atkeys_file, const char *self_encryption_key_str, const size_t self_encryption_key_str_len);
+int atclient_atkeys_file_set_enrollment_id_str(atclient_atkeys_file *atkeys_file, const char *enrollment_id_str, const size_t enrollment_id_str_len);
 
 #endif

--- a/packages/atclient/src/atkeys.c
+++ b/packages/atclient/src/atkeys.c
@@ -716,7 +716,7 @@ int atclient_atkeys_populate_from_strings(atclient_atkeys *atkeys, const char *a
 exit: { return ret; }
 }
 
-int atclient_atkeys_populate_from_atkeys_file(atclient_atkeys *atkeys, const atclient_atkeysfile *atkeys_file) {
+int atclient_atkeys_populate_from_atkeys_file(atclient_atkeys *atkeys, const atclient_atkeys_file *atkeys_file) {
   int ret = 1;
 
   if (atkeys == NULL) {
@@ -731,7 +731,7 @@ int atclient_atkeys_populate_from_atkeys_file(atclient_atkeys *atkeys, const atc
     goto exit;
   }
 
-  if (atclient_atkeysfile_is_enrollment_id_str_initialized((atclient_atkeysfile *)atkeys_file)) {
+  if (atclient_atkeys_file_is_enrollment_id_str_initialized((atclient_atkeys_file *)atkeys_file)) {
     if ((ret = atclient_atkeys_populate_from_strings(
              atkeys, atkeys_file->aes_pkam_public_key_str, strlen(atkeys_file->aes_pkam_public_key_str),
              atkeys_file->aes_pkam_private_key_str, strlen(atkeys_file->aes_pkam_private_key_str),
@@ -764,12 +764,12 @@ exit: { return ret; }
 int atclient_atkeys_populate_from_path(atclient_atkeys *atkeys, const char *path) {
   int ret = 1;
 
-  atclient_atkeysfile atkeys_file;
-  atclient_atkeysfile_init(&atkeys_file);
+  atclient_atkeys_file atkeys_file;
+  atclient_atkeys_file_init(&atkeys_file);
 
-  if ((ret = atclient_atkeysfile_from_path(&atkeys_file, path)) != 0) {
+  if ((ret = atclient_atkeys_file_from_path(&atkeys_file, path)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_atkeysfile_from_path: %d | failed to read file at path: %s\n", ret, path);
+                 "atclient_atkeys_file_from_path: %d | failed to read file at path: %s\n", ret, path);
     goto exit;
   }
 
@@ -781,7 +781,7 @@ int atclient_atkeys_populate_from_path(atclient_atkeys *atkeys, const char *path
 
   goto exit;
 exit: {
-  atclient_atkeysfile_free(&atkeys_file);
+  atclient_atkeys_file_free(&atkeys_file);
   return ret;
 }
 }
@@ -789,11 +789,11 @@ exit: {
 int atclient_atkeys_populate_from_string(atclient_atkeys *atkeys, const char *file_string) {
   int ret = 1;
 
-  atclient_atkeysfile atkeys_file;
-  atclient_atkeysfile_init(&atkeys_file);
+  atclient_atkeys_file atkeys_file;
+  atclient_atkeys_file_init(&atkeys_file);
 
-  if ((ret = atclient_atkeysfile_from_string(&atkeys_file, file_string)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeysfile_from_string: %d\n", ret);
+  if ((ret = atclient_atkeys_file_from_string(&atkeys_file, file_string)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkeys_file_from_string: %d\n", ret);
     goto exit;
   }
 
@@ -807,7 +807,7 @@ int atclient_atkeys_populate_from_string(atclient_atkeys *atkeys, const char *fi
   goto exit;
 
 exit: {
-  atclient_atkeysfile_free(&atkeys_file);
+  atclient_atkeys_file_free(&atkeys_file);
   return ret;
 }
 }

--- a/packages/atclient/src/atkeys_file.c
+++ b/packages/atclient/src/atkeys_file.c
@@ -12,43 +12,43 @@
 
 #define TAG "atkeys_file"
 
-static bool is_aes_pkam_public_key_str_initialized(atclient_atkeysfile *atkeys_file);
-static bool is_aes_pkam_private_key_str_initialized(atclient_atkeysfile *atkeys_file);
-static bool is_aes_encrypt_public_key_str_initialized(atclient_atkeysfile *atkeys_file);
-static bool is_aes_encrypt_private_key_str_initialized(atclient_atkeysfile *atkeys_file);
-static bool is_self_encryption_key_str_initialized(atclient_atkeysfile *atkeys_file);
-static bool is_enrollment_id_str_initialized(atclient_atkeysfile *atkeys_file);
+static bool is_aes_pkam_public_key_str_initialized(atclient_atkeys_file *atkeys_file);
+static bool is_aes_pkam_private_key_str_initialized(atclient_atkeys_file *atkeys_file);
+static bool is_aes_encrypt_public_key_str_initialized(atclient_atkeys_file *atkeys_file);
+static bool is_aes_encrypt_private_key_str_initialized(atclient_atkeys_file *atkeys_file);
+static bool is_self_encryption_key_str_initialized(atclient_atkeys_file *atkeys_file);
+static bool is_enrollment_id_str_initialized(atclient_atkeys_file *atkeys_file);
 
-static void set_aes_pkam_public_key_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized);
-static void set_aes_pkam_private_key_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized);
-static void set_aes_encrypt_public_key_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized);
-static void set_aes_encrypt_private_key_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized);
-static void set_self_encryption_key_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized);
-static void set_enrollment_id_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized);
+static void set_aes_pkam_public_key_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized);
+static void set_aes_pkam_private_key_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized);
+static void set_aes_encrypt_public_key_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized);
+static void set_aes_encrypt_private_key_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized);
+static void set_self_encryption_key_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized);
+static void set_enrollment_id_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized);
 
-static void unset_aes_pkam_public_key_str(atclient_atkeysfile *atkeys_file);
-static void unset_aes_pkam_private_key_str(atclient_atkeysfile *atkeys_file);
-static void unset_aes_encrypt_public_key_str(atclient_atkeysfile *atkeys_file);
-static void unset_aes_encrypt_private_key_str(atclient_atkeysfile *atkeys_file);
-static void unset_self_encryption_key_str(atclient_atkeysfile *atkeys_file);
-static void unset_enrollment_id_str(atclient_atkeysfile *atkeys_file);
+static void unset_aes_pkam_public_key_str(atclient_atkeys_file *atkeys_file);
+static void unset_aes_pkam_private_key_str(atclient_atkeys_file *atkeys_file);
+static void unset_aes_encrypt_public_key_str(atclient_atkeys_file *atkeys_file);
+static void unset_aes_encrypt_private_key_str(atclient_atkeys_file *atkeys_file);
+static void unset_self_encryption_key_str(atclient_atkeys_file *atkeys_file);
+static void unset_enrollment_id_str(atclient_atkeys_file *atkeys_file);
 
-static int set_aes_pkam_public_key_str(atclient_atkeysfile *atkeys_file, const char *aes_pkam_public_key_str,
+static int set_aes_pkam_public_key_str(atclient_atkeys_file *atkeys_file, const char *aes_pkam_public_key_str,
                                        const size_t aes_pkam_publickey_str_len);
-static int set_aes_pkam_private_key_str(atclient_atkeysfile *atkeys_file, const char *aes_pkam_private_key_str,
+static int set_aes_pkam_private_key_str(atclient_atkeys_file *atkeys_file, const char *aes_pkam_private_key_str,
                                         const size_t aes_pkam_private_key_str_len);
-static int set_aes_encrypt_public_key_str(atclient_atkeysfile *atkeys_file, const char *aes_encrypt_public_key_str,
+static int set_aes_encrypt_public_key_str(atclient_atkeys_file *atkeys_file, const char *aes_encrypt_public_key_str,
                                           const size_t aes_encrypt_public_key_str_len);
-static int set_aes_encrypt_private_key_str(atclient_atkeysfile *atkeys_file, const char *aes_encrypt_private_key_str,
+static int set_aes_encrypt_private_key_str(atclient_atkeys_file *atkeys_file, const char *aes_encrypt_private_key_str,
                                            const size_t aes_encrypt_private_key_str_len);
-static int set_self_encryption_key_str(atclient_atkeysfile *atkeys_file, const char *self_encryption_key_str,
+static int set_self_encryption_key_str(atclient_atkeys_file *atkeys_file, const char *self_encryption_key_str,
                                        const size_t self_encryption_key_str_len);
-static int set_enrollment_id_str(atclient_atkeysfile *atkeys_file, const char *enrollment_id_str,
+static int set_enrollment_id_str(atclient_atkeys_file *atkeys_file, const char *enrollment_id_str,
                                  const size_t enrollment_id_str_len);
 
-void atclient_atkeysfile_init(atclient_atkeysfile *atkeys_file) { memset(atkeys_file, 0, sizeof(atclient_atkeysfile)); }
+void atclient_atkeys_file_init(atclient_atkeys_file *atkeys_file) { memset(atkeys_file, 0, sizeof(atclient_atkeys_file)); }
 
-int atclient_atkeysfile_from_path(atclient_atkeysfile *atkeys_file, const char *path) {
+int atclient_atkeys_file_from_path(atclient_atkeys_file *atkeys_file, const char *path) {
   int ret = 1;
   unsigned char readbuf[FILE_READ_BUFFER_SIZE];
   memset(readbuf, 0, FILE_READ_BUFFER_SIZE);
@@ -66,11 +66,11 @@ int atclient_atkeysfile_from_path(atclient_atkeysfile *atkeys_file, const char *
     return ret;
   }
 
-  ret = atclient_atkeysfile_from_string(atkeys_file, (const char *)readbuf);
+  ret = atclient_atkeys_file_from_string(atkeys_file, (const char *)readbuf);
   return ret;
 }
 
-int atclient_atkeysfile_from_string(atclient_atkeysfile *atkeys_file, const char *file_string) {
+int atclient_atkeys_file_from_string(atclient_atkeys_file *atkeys_file, const char *file_string) {
   int ret = 1;
 
   cJSON *root = cJSON_Parse(file_string);
@@ -152,7 +152,7 @@ exit: {
 }
 }
 
-void atclient_atkeysfile_free(atclient_atkeysfile *atkeys_file) {
+void atclient_atkeys_file_free(atclient_atkeys_file *atkeys_file) {
   unset_aes_pkam_public_key_str(atkeys_file);
   unset_aes_pkam_private_key_str(atkeys_file);
   unset_aes_encrypt_public_key_str(atkeys_file);
@@ -161,31 +161,31 @@ void atclient_atkeysfile_free(atclient_atkeysfile *atkeys_file) {
   unset_enrollment_id_str(atkeys_file);
 }
 
-bool atclient_atkeysfile_is_aes_pkam_public_key_str_initialized(atclient_atkeysfile *atkeys_file) {
+bool atclient_atkeys_file_is_aes_pkam_public_key_str_initialized(atclient_atkeys_file *atkeys_file) {
   return is_aes_pkam_public_key_str_initialized(atkeys_file);
 }
 
-bool atclient_atkeysfile_is_aes_pkam_private_key_str_initialized(atclient_atkeysfile *atkeys_file) {
+bool atclient_atkeys_file_is_aes_pkam_private_key_str_initialized(atclient_atkeys_file *atkeys_file) {
   return is_aes_pkam_private_key_str_initialized(atkeys_file);
 }
 
-bool atclient_atkeysfile_is_aes_encrypt_public_key_str_initialized(atclient_atkeysfile *atkeys_file) {
+bool atclient_atkeys_file_is_aes_encrypt_public_key_str_initialized(atclient_atkeys_file *atkeys_file) {
   return is_aes_encrypt_public_key_str_initialized(atkeys_file);
 }
 
-bool atclient_atkeysfile_is_aes_encrypt_private_key_str_initialized(atclient_atkeysfile *atkeys_file) {
+bool atclient_atkeys_file_is_aes_encrypt_private_key_str_initialized(atclient_atkeys_file *atkeys_file) {
   return is_aes_encrypt_private_key_str_initialized(atkeys_file);
 }
 
-bool atclient_atkeysfile_is_self_encryption_key_str_initialized(atclient_atkeysfile *atkeys_file) {
+bool atclient_atkeys_file_is_self_encryption_key_str_initialized(atclient_atkeys_file *atkeys_file) {
   return is_self_encryption_key_str_initialized(atkeys_file);
 }
 
-bool atclient_atkeysfile_is_enrollment_id_str_initialized(atclient_atkeysfile *atkeys_file) {
+bool atclient_atkeys_file_is_enrollment_id_str_initialized(atclient_atkeys_file *atkeys_file) {
   return is_enrollment_id_str_initialized(atkeys_file);
 }
 
-int atclient_atkeysfile_set_aes_pkam_public_key_str(atclient_atkeysfile *atkeys_file,
+int atclient_atkeys_file_set_aes_pkam_public_key_str(atclient_atkeys_file *atkeys_file,
                                                     const char *aes_pkam_public_key_str,
                                                     const size_t aes_pkam_public_key_str_len) {
   int ret = 1;
@@ -217,7 +217,7 @@ int atclient_atkeysfile_set_aes_pkam_public_key_str(atclient_atkeysfile *atkeys_
 exit: { return ret; }
 }
 
-int atclient_atkeysfile_set_aes_pkam_private_key_str(atclient_atkeysfile *atkeys_file,
+int atclient_atkeys_file_set_aes_pkam_private_key_str(atclient_atkeys_file *atkeys_file,
                                                      const char *aes_pkam_private_key_str,
                                                      const size_t aes_pkam_private_key_str_len) {
   int ret = 1;
@@ -249,7 +249,7 @@ int atclient_atkeysfile_set_aes_pkam_private_key_str(atclient_atkeysfile *atkeys
 exit: { return ret; }
 }
 
-int atclient_atkeysfile_set_aes_encrypt_public_key_str(atclient_atkeysfile *atkeys_file,
+int atclient_atkeys_file_set_aes_encrypt_public_key_str(atclient_atkeys_file *atkeys_file,
                                                        const char *aes_encrypt_public_key_str,
                                                        const size_t aes_encrypt_public_key_str_len) {
   int ret = 1;
@@ -282,7 +282,7 @@ int atclient_atkeysfile_set_aes_encrypt_public_key_str(atclient_atkeysfile *atke
 exit: { return ret; }
 }
 
-int atclient_atkeysfile_set_aes_encrypt_private_key_str(atclient_atkeysfile *atkeys_file,
+int atclient_atkeys_file_set_aes_encrypt_private_key_str(atclient_atkeys_file *atkeys_file,
                                                         const char *aes_encrypt_private_key_str,
                                                         const size_t aes_encrypt_private_key_str_len) {
   int ret = 1;
@@ -315,7 +315,7 @@ int atclient_atkeysfile_set_aes_encrypt_private_key_str(atclient_atkeysfile *atk
 exit: { return ret; }
 }
 
-int atclient_atkeysfile_set_self_encryption_key_str(atclient_atkeysfile *atkeys_file,
+int atclient_atkeys_file_set_self_encryption_key_str(atclient_atkeys_file *atkeys_file,
                                                     const char *self_encryption_key_str,
                                                     const size_t self_encryption_key_str_len) {
   int ret = 1;
@@ -347,7 +347,7 @@ int atclient_atkeysfile_set_self_encryption_key_str(atclient_atkeysfile *atkeys_
 exit: { return ret; }
 }
 
-int atclient_atkeysfile_set_enrollment_id_str(atclient_atkeysfile *atkeys_file, const char *enrollment_id_str,
+int atclient_atkeys_file_set_enrollment_id_str(atclient_atkeys_file *atkeys_file, const char *enrollment_id_str,
                                               const size_t enrollment_id_str_len) {
   int ret = 1;
 
@@ -378,37 +378,37 @@ int atclient_atkeysfile_set_enrollment_id_str(atclient_atkeysfile *atkeys_file, 
 exit: { return ret; }
 }
 
-static bool is_aes_pkam_public_key_str_initialized(atclient_atkeysfile *atkeys_file) {
+static bool is_aes_pkam_public_key_str_initialized(atclient_atkeys_file *atkeys_file) {
   return atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_AES_PKAM_PUBLIC_KEY_STR_INDEX] &
          ATCLIENT_ATKEYS_FILE_AES_PKAM_PUBLIC_KEY_STR_INITIALIZED;
 }
 
-static bool is_aes_pkam_private_key_str_initialized(atclient_atkeysfile *atkeys_file) {
+static bool is_aes_pkam_private_key_str_initialized(atclient_atkeys_file *atkeys_file) {
   return atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_AES_PKAM_PRIVATE_KEY_STR_INDEX] &
          ATCLIENT_ATKEYS_FILE_AES_PKAM_PRIVATE_KEY_STR_INITIALIZED;
 }
 
-static bool is_aes_encrypt_public_key_str_initialized(atclient_atkeysfile *atkeys_file) {
+static bool is_aes_encrypt_public_key_str_initialized(atclient_atkeys_file *atkeys_file) {
   return atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_AES_ENCRYPT_PUBLIC_KEY_STR_INDEX] &
          ATCLIENT_ATKEYS_FILE_AES_ENCRYPT_PUBLIC_KEY_STR_INITIALIZED;
 }
 
-static bool is_aes_encrypt_private_key_str_initialized(atclient_atkeysfile *atkeys_file) {
+static bool is_aes_encrypt_private_key_str_initialized(atclient_atkeys_file *atkeys_file) {
   return atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_AES_ENCRYPT_PRIVATE_KEY_STR_INDEX] &
          ATCLIENT_ATKEYS_FILE_AES_ENCRYPT_PRIVATE_KEY_STR_INITIALIZED;
 }
 
-static bool is_self_encryption_key_str_initialized(atclient_atkeysfile *atkeys_file) {
+static bool is_self_encryption_key_str_initialized(atclient_atkeys_file *atkeys_file) {
   return atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_SELF_ENCRYPTION_KEY_STR_INDEX] &
          ATCLIENT_ATKEYS_FILE_SELF_ENCRYPTION_KEY_STR_INITIALIZED;
 }
 
-static bool is_enrollment_id_str_initialized(atclient_atkeysfile *atkeys_file) {
+static bool is_enrollment_id_str_initialized(atclient_atkeys_file *atkeys_file) {
   return atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_ENROLLMENT_ID_STR_INDEX] &
          ATCLIENT_ATKEYS_FILE_ENROLLMENT_ID_STR_INITIALIZED;
 }
 
-static void set_aes_pkam_public_key_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized) {
+static void set_aes_pkam_public_key_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized) {
   if (initialized) {
     atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_AES_PKAM_PUBLIC_KEY_STR_INDEX] |=
         ATCLIENT_ATKEYS_FILE_AES_PKAM_PUBLIC_KEY_STR_INITIALIZED;
@@ -418,7 +418,7 @@ static void set_aes_pkam_public_key_str_initialized(atclient_atkeysfile *atkeys_
   }
 }
 
-static void set_aes_pkam_private_key_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized) {
+static void set_aes_pkam_private_key_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized) {
   if (initialized) {
     atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_AES_PKAM_PRIVATE_KEY_STR_INDEX] |=
         ATCLIENT_ATKEYS_FILE_AES_PKAM_PRIVATE_KEY_STR_INITIALIZED;
@@ -428,7 +428,7 @@ static void set_aes_pkam_private_key_str_initialized(atclient_atkeysfile *atkeys
   }
 }
 
-static void set_aes_encrypt_public_key_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized) {
+static void set_aes_encrypt_public_key_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized) {
   if (initialized) {
     atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_AES_ENCRYPT_PUBLIC_KEY_STR_INDEX] |=
         ATCLIENT_ATKEYS_FILE_AES_ENCRYPT_PUBLIC_KEY_STR_INITIALIZED;
@@ -438,7 +438,7 @@ static void set_aes_encrypt_public_key_str_initialized(atclient_atkeysfile *atke
   }
 }
 
-static void set_aes_encrypt_private_key_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized) {
+static void set_aes_encrypt_private_key_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized) {
   if (initialized) {
     atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_AES_ENCRYPT_PRIVATE_KEY_STR_INDEX] |=
         ATCLIENT_ATKEYS_FILE_AES_ENCRYPT_PRIVATE_KEY_STR_INITIALIZED;
@@ -448,7 +448,7 @@ static void set_aes_encrypt_private_key_str_initialized(atclient_atkeysfile *atk
   }
 }
 
-static void set_self_encryption_key_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized) {
+static void set_self_encryption_key_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized) {
   if (initialized) {
     atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_SELF_ENCRYPTION_KEY_STR_INDEX] |=
         ATCLIENT_ATKEYS_FILE_SELF_ENCRYPTION_KEY_STR_INITIALIZED;
@@ -458,7 +458,7 @@ static void set_self_encryption_key_str_initialized(atclient_atkeysfile *atkeys_
   }
 }
 
-static void set_enrollment_id_str_initialized(atclient_atkeysfile *atkeys_file, const bool initialized) {
+static void set_enrollment_id_str_initialized(atclient_atkeys_file *atkeys_file, const bool initialized) {
   if (initialized) {
     atkeys_file->_initialized_fields[ATCLIENT_ATKEYS_FILE_ENROLLMENT_ID_STR_INDEX] |=
         ATCLIENT_ATKEYS_FILE_ENROLLMENT_ID_STR_INITIALIZED;
@@ -468,7 +468,7 @@ static void set_enrollment_id_str_initialized(atclient_atkeysfile *atkeys_file, 
   }
 }
 
-static void unset_aes_pkam_public_key_str(atclient_atkeysfile *atkeys_file) {
+static void unset_aes_pkam_public_key_str(atclient_atkeys_file *atkeys_file) {
   if (is_aes_pkam_public_key_str_initialized(atkeys_file)) {
     free(atkeys_file->aes_pkam_public_key_str);
   }
@@ -476,7 +476,7 @@ static void unset_aes_pkam_public_key_str(atclient_atkeysfile *atkeys_file) {
   set_aes_pkam_public_key_str_initialized(atkeys_file, false);
 }
 
-static void unset_aes_pkam_private_key_str(atclient_atkeysfile *atkeys_file) {
+static void unset_aes_pkam_private_key_str(atclient_atkeys_file *atkeys_file) {
   if (is_aes_pkam_private_key_str_initialized(atkeys_file)) {
     free(atkeys_file->aes_pkam_private_key_str);
   }
@@ -484,7 +484,7 @@ static void unset_aes_pkam_private_key_str(atclient_atkeysfile *atkeys_file) {
   set_aes_pkam_private_key_str_initialized(atkeys_file, false);
 }
 
-static void unset_aes_encrypt_public_key_str(atclient_atkeysfile *atkeys_file) {
+static void unset_aes_encrypt_public_key_str(atclient_atkeys_file *atkeys_file) {
   if (is_aes_encrypt_public_key_str_initialized(atkeys_file)) {
     free(atkeys_file->aes_encrypt_public_key_str);
   }
@@ -492,7 +492,7 @@ static void unset_aes_encrypt_public_key_str(atclient_atkeysfile *atkeys_file) {
   set_aes_encrypt_public_key_str_initialized(atkeys_file, false);
 }
 
-static void unset_aes_encrypt_private_key_str(atclient_atkeysfile *atkeys_file) {
+static void unset_aes_encrypt_private_key_str(atclient_atkeys_file *atkeys_file) {
   if (is_aes_encrypt_private_key_str_initialized(atkeys_file)) {
     free(atkeys_file->aes_encrypt_private_key_str);
   }
@@ -500,7 +500,7 @@ static void unset_aes_encrypt_private_key_str(atclient_atkeysfile *atkeys_file) 
   set_aes_encrypt_private_key_str_initialized(atkeys_file, false);
 }
 
-static void unset_self_encryption_key_str(atclient_atkeysfile *atkeys_file) {
+static void unset_self_encryption_key_str(atclient_atkeys_file *atkeys_file) {
   if (is_self_encryption_key_str_initialized(atkeys_file)) {
     free(atkeys_file->self_encryption_key_str);
   }
@@ -508,7 +508,7 @@ static void unset_self_encryption_key_str(atclient_atkeysfile *atkeys_file) {
   set_self_encryption_key_str_initialized(atkeys_file, false);
 }
 
-static void unset_enrollment_id_str(atclient_atkeysfile *atkeys_file) {
+static void unset_enrollment_id_str(atclient_atkeys_file *atkeys_file) {
   if (is_enrollment_id_str_initialized(atkeys_file)) {
     free(atkeys_file->enrollment_id_str);
   }
@@ -516,7 +516,7 @@ static void unset_enrollment_id_str(atclient_atkeysfile *atkeys_file) {
   set_enrollment_id_str_initialized(atkeys_file, false);
 }
 
-static int set_aes_pkam_public_key_str(atclient_atkeysfile *atkeys_file, const char *aes_pkam_public_key_str,
+static int set_aes_pkam_public_key_str(atclient_atkeys_file *atkeys_file, const char *aes_pkam_public_key_str,
                                        const size_t aes_pkam_publickey_str_len) {
   int ret = 1;
 
@@ -540,7 +540,7 @@ static int set_aes_pkam_public_key_str(atclient_atkeysfile *atkeys_file, const c
 exit: { return ret; }
 }
 
-static int set_aes_pkam_private_key_str(atclient_atkeysfile *atkeys_file, const char *aes_pkam_private_key_str,
+static int set_aes_pkam_private_key_str(atclient_atkeys_file *atkeys_file, const char *aes_pkam_private_key_str,
                                         const size_t aes_pkam_private_key_str_len) {
   int ret = 1;
 
@@ -563,7 +563,7 @@ static int set_aes_pkam_private_key_str(atclient_atkeysfile *atkeys_file, const 
   goto exit;
 exit: { return ret; }
 }
-static int set_aes_encrypt_public_key_str(atclient_atkeysfile *atkeys_file, const char *aes_encrypt_public_key_str,
+static int set_aes_encrypt_public_key_str(atclient_atkeys_file *atkeys_file, const char *aes_encrypt_public_key_str,
                                           const size_t aes_encrypt_public_key_str_len) {
   int ret = 1;
 
@@ -589,7 +589,7 @@ static int set_aes_encrypt_public_key_str(atclient_atkeysfile *atkeys_file, cons
 exit: { return ret; }
 }
 
-static int set_aes_encrypt_private_key_str(atclient_atkeysfile *atkeys_file, const char *aes_encrypt_private_key_str,
+static int set_aes_encrypt_private_key_str(atclient_atkeys_file *atkeys_file, const char *aes_encrypt_private_key_str,
                                            const size_t aes_encrypt_private_key_str_len) {
   int ret = 1;
 
@@ -614,7 +614,7 @@ static int set_aes_encrypt_private_key_str(atclient_atkeysfile *atkeys_file, con
 exit: { return ret; }
 }
 
-static int set_self_encryption_key_str(atclient_atkeysfile *atkeys_file, const char *self_encryption_key_str,
+static int set_self_encryption_key_str(atclient_atkeys_file *atkeys_file, const char *self_encryption_key_str,
                                        const size_t self_encryption_key_str_len) {
   int ret = 1;
 
@@ -639,7 +639,7 @@ static int set_self_encryption_key_str(atclient_atkeysfile *atkeys_file, const c
 exit: { return ret; }
 }
 
-static int set_enrollment_id_str(atclient_atkeysfile *atkeys_file, const char *enrollment_id_str,
+static int set_enrollment_id_str(atclient_atkeys_file *atkeys_file, const char *enrollment_id_str,
                                  const size_t enrollment_id_str_len) {
   int ret = 1;
 

--- a/tests/functional_tests/tests/test_atclient_pkam_authenticate.c
+++ b/tests/functional_tests/tests/test_atclient_pkam_authenticate.c
@@ -46,8 +46,8 @@ static int test1_pkam_no_options() {
   const char *tag = "test1_pkam_no_options";
   int ret = 0;
 
-  atclient_atkeysfile atkeys_file;
-  atclient_atkeysfile_init(&atkeys_file);
+  atclient_atkeys_file atkeys_file;
+  atclient_atkeys_file_init(&atkeys_file);
 
   atclient_atkeys atkeys;
   atclient_atkeys_init(&atkeys);
@@ -55,10 +55,10 @@ static int test1_pkam_no_options() {
   atclient atclient;
   atclient_init(&atclient);
 
-  if ((ret = atclient_atkeysfile_from_path(&atkeys_file, atkeyspath)) != 0) {
+  if ((ret = atclient_atkeys_file_from_path(&atkeys_file, atkeyspath)) != 0) {
     return ret;
   }
-  atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeysfile_from_string: %d\n", ret);
+  atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_file_from_string: %d\n", ret);
 
   if ((ret = atclient_atkeys_populate_from_atkeys_file(&atkeys, &atkeys_file)) != 0) {
     return ret;
@@ -79,8 +79,8 @@ static int test2_pkam_with_options() {
   const char *tag = "test2_pkam_with_options";
   int ret = 0;
 
-  atclient_atkeysfile atkeys_file;
-  atclient_atkeysfile_init(&atkeys_file);
+  atclient_atkeys_file atkeys_file;
+  atclient_atkeys_file_init(&atkeys_file);
 
   atclient_atkeys atkeys;
   atclient_atkeys_init(&atkeys);
@@ -88,10 +88,10 @@ static int test2_pkam_with_options() {
   atclient atclient;
   atclient_init(&atclient);
 
-  if ((ret = atclient_atkeysfile_from_path(&atkeys_file, atkeyspath)) != 0) {
+  if ((ret = atclient_atkeys_file_from_path(&atkeys_file, atkeyspath)) != 0) {
     return ret;
   }
-  atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeysfile_from_string: %d\n", ret);
+  atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_file_from_string: %d\n", ret);
 
   if ((ret = atclient_atkeys_populate_from_atkeys_file(&atkeys, &atkeys_file)) != 0) {
     return ret;


### PR DESCRIPTION
**- What I did**
- Renamed `atclient_atkeysfile` -> `atclient_atkeys_file`

**- How to verify it**
- tests pass

**- Description for the changelog**
chore: `atclient_atkeysfile` -> `atclient_atkeys_file`
