### PR TITLE
feat: atchops_rsa_generate 

### DIFF
--- a/packages/atchops/include/atchops/rsa_key.h
+++ b/packages/atchops/include/atchops/rsa_key.h
@@ -46,6 +46,14 @@ int atchops_rsa_key_public_key_clone(const atchops_rsa_key_public_key *src, atch
 int atchops_rsa_key_private_key_clone(const atchops_rsa_key_private_key *src, atchops_rsa_key_private_key *dst);
 
 /**
+ * @brief Generate a new RSA 2048 key pair (public and private)
+ * 
+ * @param public_key the public key struct to populate, assumed to be allocated and initialized. initialized via atchops_rsa_key_public_key_init
+ * @param private_key the private key struct to populate, assumed to be allocated and initialized. initialized via atchops_rsa_key_private_key_init
+ */
+int atchops_rsa_key_generate(atchops_rsa_key_public_key *public_key, atchops_rsa_key_private_key *private_key);
+
+/**
  * @brief Populate a public key struct from a base64 string
  *
  * @param public_key_struct the public key struct to populate

--- a/packages/atchops/src/rsa.c
+++ b/packages/atchops/src/rsa.c
@@ -407,9 +407,3 @@ exit: {
   return ret;
 }
 }
-
-int atchops_rsa_generate(atchops_rsa_key_public_key *public_key, atchops_rsa_key_private_key *private_key,
-                         const unsigned int key_size) {
-  // TODO maybe also introduce `enum atchops_rsa_key_size` ?
-  return 1; // TODO: implement
-}

--- a/packages/atchops/src/rsa_key.c
+++ b/packages/atchops/src/rsa_key.c
@@ -251,20 +251,19 @@ int atchops_rsa_key_generate(atchops_rsa_key_public_key *public_key, atchops_rsa
     goto exit;
   }
   // log temp buf
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "temp_buf: %s\n", temp_buf);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "temp_buf (public key): %s\n", temp_buf);
 
   size_t public_key_base64_len = 0;
   char *begin = strstr((char *)temp_buf, "-----BEGIN PUBLIC KEY-----");
   char *end = strstr((char *)temp_buf, "-----END PUBLIC KEY-----");
   if (begin != NULL && end != NULL) {
-    // Move begin pointer to start of base64 content
+
     begin += strlen("-----BEGIN PUBLIC KEY-----");
     while (*begin == '\n' || *begin == '\r' || *begin == ' ')
-      begin++; // Skip newlines, carriage returns, and spaces
+      begin++;
 
-    // Copy base64 content
     for (char *src = begin, *dest = public_key_base64; src < end; ++src) {
-      if (*src != '\n' && *src != '\r') { // Skip newlines and carriage returns
+      if (*src != '\n' && *src != '\r') {
         *dest++ = *src;
         public_key_base64_len++;
       }
@@ -272,28 +271,26 @@ int atchops_rsa_key_generate(atchops_rsa_key_public_key *public_key, atchops_rsa
   }
 
   /*
-   * 6. Write to private_key_base64 buffer
+   * 6. Write to private_key_base64 buffer (PKCS#8 format)
    */
   memset(temp_buf, 0, sizeof(temp_buf));
   if ((ret = mbedtls_pk_write_key_pem(&pk, temp_buf, temp_buf_size)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to write private key\n");
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to write private key (PKCS#8 format)\n");
     goto exit;
   }
   // log temp buf
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "temp_buf: %s\n", temp_buf);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "temp_buf (private key): %s\n", temp_buf);
 
   size_t private_key_base64_len = 0;
   begin = strstr((char *)temp_buf, "-----BEGIN RSA PRIVATE KEY-----");
   end = strstr((char *)temp_buf, "-----END RSA PRIVATE KEY-----");
   if (begin != NULL && end != NULL) {
-    // Move begin pointer to start of base64 content
     begin += strlen("-----BEGIN RSA PRIVATE KEY-----");
     while (*begin == '\n' || *begin == '\r' || *begin == ' ')
-      begin++; // Skip newlines, carriage returns, and spaces
+      begin++;
 
-    // Copy base64 content
     for (char *src = begin, *dest = private_key_base64; src < end; ++src) {
-      if (*src != '\n' && *src != '\r') { // Skip newlines and carriage returns
+      if (*src != '\n' && *src != '\r') {
         *dest++ = *src;
         private_key_base64_len++;
       }

--- a/packages/atchops/src/rsa_key.c
+++ b/packages/atchops/src/rsa_key.c
@@ -250,8 +250,6 @@ int atchops_rsa_key_generate(atchops_rsa_key_public_key *public_key, atchops_rsa
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to write public key\n");
     goto exit;
   }
-  // log temp buf
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "temp_buf (public key): %s\n", temp_buf);
 
   size_t public_key_base64_len = 0;
   char *begin = strstr((char *)temp_buf, "-----BEGIN PUBLIC KEY-----");
@@ -278,8 +276,6 @@ int atchops_rsa_key_generate(atchops_rsa_key_public_key *public_key, atchops_rsa
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to write private key (PKCS#8 format)\n");
     goto exit;
   }
-  // log temp buf
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "temp_buf (private key): %s\n", temp_buf);
 
   size_t private_key_base64_len = 0;
   begin = strstr((char *)temp_buf, "-----BEGIN RSA PRIVATE KEY-----");
@@ -300,9 +296,6 @@ int atchops_rsa_key_generate(atchops_rsa_key_public_key *public_key, atchops_rsa
   /*
    * 7. Populate the atchops_rsa_key_public_key and atchops_rsa_key_private_key structs
    */
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Public Key (%lu): %s\n", public_key_base64_len, public_key_base64);
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Private Key (%lu): %s\n", private_key_base64_len,
-               private_key_base64);
 
   if ((ret = atchops_rsa_key_populate_public_key(public_key, (const char *)public_key_base64, public_key_base64_len)) !=
       0) {

--- a/packages/atchops/src/rsa_key.c
+++ b/packages/atchops/src/rsa_key.c
@@ -319,7 +319,9 @@ int atchops_rsa_key_generate(atchops_rsa_key_public_key *public_key, atchops_rsa
     goto exit;
   }
   memset(private_key_pkcs8, 0, sizeof(unsigned char) * private_key_pkcs8_size);
-  
+
+
+  // https://lapo.it/asn1js/ use this to debug
   // PrivateKeyInfo SEQUENCE (3 elements)
   private_key_pkcs8[0] = 0x30; // constructed sequence tag
   private_key_pkcs8[1] = 0x82; // 8 --> 1000 0000 (1 in MSB means that it is long form) and 2 --> 0010 0000 (the next 2

--- a/packages/atchops/tests/test_rsa_generate.c
+++ b/packages/atchops/tests/test_rsa_generate.c
@@ -1,0 +1,27 @@
+
+#include <atchops/rsa_key.h>
+#include <atlogger/atlogger.h>
+
+int main() {
+
+  int ret = 1;
+
+  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);
+
+  atchops_rsa_key_public_key public_key;
+  atchops_rsa_key_public_key_init(&public_key);
+
+  atchops_rsa_key_private_key private_key;
+  atchops_rsa_key_private_key_init(&private_key);
+
+  if ((ret = atchops_rsa_key_generate(&public_key, &private_key)) != 0) {
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to generate RSA key pair\n");
+    goto exit;
+  }
+
+exit: {
+  atchops_rsa_key_public_key_free(&public_key);
+  atchops_rsa_key_private_key_free(&private_key);
+  return ret;
+}
+}

--- a/packages/atchops/tests/test_rsa_generate.c
+++ b/packages/atchops/tests/test_rsa_generate.c
@@ -1,6 +1,9 @@
 
 #include <atchops/rsa_key.h>
+#include <atchops/rsa.h>
 #include <atlogger/atlogger.h>
+
+#define PLAINTEXT "Hello, World!"
 
 int main() {
 
@@ -13,6 +16,14 @@ int main() {
 
   atchops_rsa_key_private_key private_key;
   atchops_rsa_key_private_key_init(&private_key);
+
+  const size_t ciphertext_size = 256;
+  unsigned char ciphertext[ciphertext_size];
+  memset(ciphertext, 0, sizeof(unsigned char) * ciphertext_size);
+
+  const size_t plaintext_size = 256;
+  unsigned char plaintext[plaintext_size];
+  memset(plaintext, 0, sizeof(unsigned char) * plaintext_size);
 
   if ((ret = atchops_rsa_key_generate(&public_key, &private_key)) != 0) {
     atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to generate RSA key pair\n");
@@ -69,6 +80,40 @@ int main() {
     atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_ERROR, "Private key is not populated\n");
     goto exit;
   }
+
+  // use the public key to encrypt something
+  // use the private key to decrypt it
+
+  if((ret = atchops_rsa_encrypt(&public_key, (const unsigned char *)PLAINTEXT, strlen(PLAINTEXT), ciphertext)) != 0) {
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to encrypt plaintext\n");
+    goto exit;
+  }
+
+  // log the ciphertext
+  atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "Ciphertext: ");
+  for (size_t i = 0; i < ciphertext_size; i++) {
+    printf("%02x ", ciphertext[i]);
+  }
+  
+  size_t plaintext_len = 0;
+  if((ret = atchops_rsa_decrypt(&private_key, ciphertext, ciphertext_size, plaintext, plaintext_size, &plaintext_len)) != 0) {
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to decrypt ciphertext\n");
+    goto exit;
+  }
+
+  // log the plaintext
+  atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "Plaintext: ");
+  for (size_t i = 0; i < plaintext_len; i++) {
+    printf("%c", plaintext[i]);
+  }
+  printf("\n");
+
+  // check if plaintext is equal to PLAINTEXT
+  if (strncmp((const char *)plaintext, PLAINTEXT, strlen(PLAINTEXT)) != 0) {
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_ERROR, "Plaintext does not match original\n");
+    goto exit;
+  }
+
 
 exit: {
   atchops_rsa_key_public_key_free(&public_key);

--- a/packages/atchops/tests/test_rsa_generate.c
+++ b/packages/atchops/tests/test_rsa_generate.c
@@ -19,6 +19,57 @@ int main() {
     goto exit;
   }
 
+  // log the public key
+  if (atchops_rsa_key_is_public_key_populated(&public_key)) {
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "Public Key:\n");
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "N: ");
+    for (size_t i = 0; i < public_key.n.len; i++) {
+      printf("%02x ", public_key.n.value[i]);
+    }
+    printf("\n");
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "E: ");
+    for (size_t i = 0; i < public_key.e.len; i++) {
+      printf("%02x ", public_key.e.value[i]);
+    }
+    printf("\n");
+  } else {
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_ERROR, "Public key is not populated\n");
+    goto exit;
+  }
+
+  // log the private key
+  if (atchops_rsa_key_is_private_key_populated(&private_key)) {
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "Private Key:\n");
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "N: ");
+    for (size_t i = 0; i < private_key.n.len; i++) {
+      printf("%02x ", private_key.n.value[i]);
+    }
+    printf("\n");
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "E: ");
+    for (size_t i = 0; i < private_key.e.len; i++) {
+      printf("%02x ", private_key.e.value[i]);
+    }
+    printf("\n");
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "D: ");
+    for (size_t i = 0; i < private_key.d.len; i++) {
+      printf("%02x ", private_key.d.value[i]);
+    }
+    printf("\n");
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "P: ");
+    for (size_t i = 0; i < private_key.p.len; i++) {
+      printf("%02x ", private_key.p.value[i]);
+    }
+    printf("\n");
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_INFO, "Q: ");
+    for (size_t i = 0; i < private_key.q.len; i++) {
+      printf("%02x ", private_key.q.value[i]);
+    }
+    printf("\n");
+  } else {
+    atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_ERROR, "Private key is not populated\n");
+    goto exit;
+  }
+
 exit: {
   atchops_rsa_key_public_key_free(&public_key);
   atchops_rsa_key_private_key_free(&private_key);

--- a/packages/atchops/tests/test_rsadecrypt.c
+++ b/packages/atchops/tests/test_rsadecrypt.c
@@ -1,9 +1,14 @@
 #include "atchops/rsa.h"
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stddef.h>
 
+// a pkcs8 formatted key in base64 from C SDK generation
+// #define PRIVATEKEYBASE64
+// "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCzn72C2fNOzP3Uwy3gkSQiYPQalzMIJnyM51amjYzsaP20CNo5y2NQV6Nx1bwcpn1MBoPx4AK26hD7d9ijjOS2lU5glPiSf0ZA68e24zi7NsyRgvD1jhYH2H8coNc7eRlukfy/7BbJsf2H33CBcjLPXEdp46kdABqP6iudbXzG33HQKGnfjaaQWWHePdNU3T1btTQJ8Mv+sH+caJ6DdRu95ZdKuoiVip7qHCZ2jlNHn46BJjSL9r2MiYF2i4G/pkdmSVvC15xnp/x13f+GDKIMAerj62I0UyGasTJQlfEn1wYBNlghKlIyyMSsFpv9Ugi/R06gK3GGTaeL7kZmNQ8JAgMBAAECggEAESCVKGnxyjy/o07tC/Gq+WA3RmXOZuOMkr7oQz9SBaTJNCZ38HTVRm7k1dDke/LgFaS1ZhXPDHPrJJ871/RyRnqcG5d40Dc0krIou+aUnT1PajyLD076CMt661bmzvPwGdvvtrkjPx4qp48FokIqWB1bbdxYXryIy9ovSHaNJEU3IYpuUA0BW3798rshwQK1UlrK0BdStfXPpmN7sCdbymb4atJynFqoZph0BobC4hXgXaxSeNhY5pIGfuQd97etFq9v3sFcn6ZjwDJzRormff4E7TbRHQ9Yl2b0tb1kz2cpUFqAr7ap32Re6LZ8TD32GVTRYVriFAn6v2OmwuXU5QKBgQDdgLiBEE07RUqwLPNR8CmnIiJxopxMld7lJFWcwNOE4fxsOZzLnz2Xwl21f/Xyo33RxAMNuW9PvqIoTfVRT0AfnDINp4GU7GlvFdtWWQ7kJLAAqklzEyU/57g9s3m34fpzIOOTxABucUGgfonfm2EdJ07FdEUoGIUaNvONAVJhiwKBgQDPmVFat8PIOcvRiO+KMgHHQmBdGR6NiAOOvpJ93OOMN6+JInNXKxiE1Iv8agw20hCtOx9LewgoACw12UqSHC+4BJHasjTUrrKiklmdDMjFSC9XrZ6PuTpugu/wM6h4fhwf3K9PEVx1mDlAZoSfwhQ4MGkqKbewqvGw9S7oz5Q8OwKBgQCmcFuzd2lhGR8XJJ+tOTZDRQ32r0ac8ZysN9Iw2F/YIOtI8z2Tb9ObXkyF3mIT8a/QWGYnAOjYVhmJCZNFhrRbTEX8JprjKYXMF/NZfdAHtF2gElTgqEk8LMUvb9YNSzujGNqIpSXh1y6GB69YG2wsuOWiz0xL5ajWWuZFVPHvIwKBgDrbuEIlOeAJ6uyki22+Ed0Bx7p9hbkQ6BlPlM8UkntNynnyB4ueT1xRusK8+muMkWfcDFplLoHQ0rgNvGPClBDzUrsTrYDjawhGwBuT5VRxy+Jq+jq7hIKSox6SNuC6uJScCCQ9wt4gY5MLvexhpUPtDdQDce4n+VB3o24kdF3DAoGAc4q30FsexTKZNMUekkDm3ZYdGCYoRDF5+A2JOSTqlSKubb1dfSxGPvBe55dSfO1G0yR7Z8rZcG0+6gdv6tqi+ndRVyVApGuetMK7jhiuyzYEv9dJWdvVBg5T7+ElaKUxzAEapEaLvVplg8XBjq3c1BwFFj08T+6LXd3gy1eu92g="
+
+// a pkcs8 formatted key in base64 from Dart SDK generation
 #define PRIVATEKEYBASE64                                                                                               \
   "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCDc/"                                                             \
   "uZ5+pmDYY1A+IQdiKeZNhRxttbYCv1aLksIP+5Fk1GJAnKlsBBum+"                                                              \
@@ -69,7 +74,5 @@ int main() {
 
   goto ret;
 
-ret: {
-  return ret;
-}
+ret: { return ret; }
 }


### PR DESCRIPTION
#closes #74 

**- What I did**

- Implemented atchops_rsa_generate
- made it so that it takes the PKCS#1 formatted private RSA-2048 key from MbedTLS and we convert it ourselves into a PKCS#8 formatted private RSA-2048 key
- Added a test for rsa generate

**- How to verify it**
- Added a test `test_rsa_generate.c` that does two things: 1. generate a RSA key pair and populate our atchops structs successfully and 2. use the key to encrypt/decrypt and check if the plaintext matches 
- All previous rsa tests pass

**- Description for the changelog**
feat: atchops_rsa_generate

