### PR TITLE
chore: clang-tidy and .clangd config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,41 @@
+# Basic options
+Checks: "clang-diagnostic-*,clang-analyzer-*" # base checks
+WarningsAsErrors: "" # warnings which should be considered errors
+CheckOptions:
+  # enforce uppercase suffixes on integer types (e.g. use 1L not 1l)
+  cert-dcl16-c.NewSuffixes: "L;LL;LU;LLU"
+  # Warns that you should check for errors on these functions
+  # & Allow suppressing the warning type by casting to void
+  cert-err33-c.CheckedFunctions: "^::aligned_alloc;^::asctime_s;^::at_quick_exit;^::atexit;^::bsearch;^::bsearch_s;^::btowc;^::c16rtomb;^::c32rtomb;^::calloc;^::clock;^::cnd_broadcast;^::cnd_init;^::cnd_signal;^::cnd_timedwait;^::cnd_wait;^::ctime_s;^::fclose;^::fflush;^::fgetc;^::fgetpos;^::fgets;^::fgetwc;^::fopen;^::fopen_s;^::fprintf;^::fprintf_s;^::fputc;^::fputs;^::fputwc;^::fputws;^::fread;^::freopen;^::freopen_s;^::fscanf;^::fscanf_s;^::fseek;^::fsetpos;^::ftell;^::fwprintf;^::fwprintf_s;^::fwrite;^::fwscanf;^::fwscanf_s;^::getc;^::getchar;^::getenv;^::getenv_s;^::gets_s;^::getwc;^::getwchar;^::gmtime;^::gmtime_s;^::localtime;^::localtime_s;^::malloc;^::mbrtoc16;^::mbrtoc32;^::mbsrtowcs;^::mbsrtowcs_s;^::mbstowcs;^::mbstowcs_s;^::memchr;^::mktime;^::mtx_init;^::mtx_lock;^::mtx_timedlock;^::mtx_trylock;^::mtx_unlock;^::printf_s;^::putc;^::putwc;^::raise;^::realloc;^::remove;^::rename;^::scanf;^::scanf_s;^::setlocale;^::setvbuf;^::signal;^::snprintf;^::snprintf_s;^::sprintf;^::sprintf_s;^::sscanf;^::sscanf_s;^::strchr;^::strerror_s;^::strftime;^::strpbrk;^::strrchr;^::strstr;^::strtod;^::strtof;^::strtoimax;^::strtok;^::strtok_s;^::strtol;^::strtold;^::strtoll;^::strtoul;^::strtoull;^::strtoumax;^::strxfrm;^::swprintf;^::swprintf_s;^::swscanf;^::swscanf_s;^::thrd_create;^::thrd_detach;^::thrd_join;^::thrd_sleep;^::time;^::timespec_get;^::tmpfile;^::tmpfile_s;^::tmpnam;^::tmpnam_s;^::tss_create;^::tss_get;^::tss_set;^::ungetc;^::ungetwc;^::vfprintf;^::vfprintf_s;^::vfscanf;^::vfscanf_s;^::vfwprintf;^::vfwprintf_s;^::vfwscanf;^::vfwscanf_s;^::vprintf_s;^::vscanf;^::vscanf_s;^::vsnprintf;^::vsnprintf_s;^::vsprintf;^::vsprintf_s;^::vsscanf;^::vsscanf_s;^::vswprintf;^::vswprintf_s;^::vswscanf;^::vswscanf_s;^::vwprintf_s;^::vwscanf;^::vwscanf_s;^::wcrtomb;^::wcschr;^::wcsftime;^::wcspbrk;^::wcsrchr;^::wcsrtombs;^::wcsrtombs_s;^::wcsstr;^::wcstod;^::wcstof;^::wcstoimax;^::wcstok;^::wcstok_s;^::wcstol;^::wcstold;^::wcstoll;^::wcstombs;^::wcstombs_s;^::wcstoul;^::wcstoull;^::wcstoumax;^::wcsxfrm;^::wctob;^::wctrans;^::wctype;^::wmemchr;^::wprintf_s;^::wscanf;^::wscanf_s;"
+  cert-err33-c.AllowCastToVoid: "true"
+  # Warns on implicit char casts in type comparisions
+  cert-str34-c.DiagnoseSignedUnsignedCharComparisons: "true"
+  # Enforce the use of braces in short statements for readability
+  google-readability-braces-around-statements.ShortStatementLines: "1"
+  # Warn when functions exceed 800 statements
+  google-readability-function-size.StatementThreshold: "800"
+  # Attempt to remove pointless else statements on guard clauses
+  # & Warn if it's not possible for this be automatically fixed
+  readability-else-after-return.WarnOnConditionVariables: "true"
+  readability-else-after-return.WarnOnUnfixable: "true"
+
+# Formatting
+FormatStyle: file # use .clang-format file for formatting
+
+# File types
+HeaderFileExtensions:
+  - ""
+  - h
+  - hh
+  - hpp
+  - hxx
+ImplementationFileExtensions:
+  - c
+  - cc
+  - cpp
+  - cxx
+
+# Header configurations
+HeaderFilterRegex: ""
+ExcludeHeaderFilterRegex: ""
+SystemHeaders: false # Hide errors in system headers

--- a/.clangd
+++ b/.clangd
@@ -1,7 +1,7 @@
 CompileFlags:
-  # Use gcc to compile for diagnostics
+  # Use gcc in development for better diagnostics
+  # & Ensure that compilation doesn't fail due to warnings
   Compiler: gcc
-  # Ensure that compiles don't fail due to warnings during development
   Add: [-Wno-error]
 
 Index:

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,18 @@
+CompileFlags:
+  # Use gcc to compile for diagnostics
+  Compiler: gcc
+  # Ensure that compiles don't fail due to warnings during development
+  Add: [-Wno-error]
+
+Index:
+  # Enable background indexing for better symbol information
+  Background: Build
+
+Diagnostics:
+  # IWYU for header files
+  UnusedIncludes: Strict
+  MissingIncludes: Strict
+  # Avoid running slow clang-tidy checks
+  ClangTidy:
+    FastCheckFilter: Loose
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Took my local config and ported over diagnostics and readability warnings that I used to ensure good code quality (mostly llvm / clangd default behavior)
- Tell clangd to use gcc instead of clang for compiliation, as it results in better diagnotics (in my experience)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: clang-tidy and .clangd config
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
