### PR TITLE
fix: use sized types for more consistent cross-platform support

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -2,7 +2,7 @@ CompileFlags:
   # Use gcc in development for better diagnostics
   # & Ensure that compilation doesn't fail due to warnings
   Compiler: gcc
-  Add: [-Wno-error]
+  Add: [-Wno-error, -xc, -std=c99]
 
 Index:
   # Enable background indexing for better symbol information
@@ -15,4 +15,3 @@ Diagnostics:
   # Avoid running slow clang-tidy checks
   ClangTidy:
     FastCheckFilter: Loose
-

--- a/packages/atchops/include/atchops/mbedtls.h
+++ b/packages/atchops/include/atchops/mbedtls.h
@@ -1,17 +1,17 @@
 #ifndef ATCHOPS_MBEDTLS_H
 #define ATCHOPS_MBEDTLS_H
 
-#include <mbedtls/aes.h>
-#include <mbedtls/ctr_drbg.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/md.h>
-#include <mbedtls/base64.h>
-#include <mbedtls/asn1.h>
-#include <mbedtls/md5.h>
-#include <mbedtls/rsa.h>
-#include <mbedtls/ssl.h>
-#include <mbedtls/net_sockets.h>
-#include <mbedtls/x509_crt.h>
+#include <mbedtls/aes.h>         // IWYU pragma: export
+#include <mbedtls/asn1.h>        // IWYU pragma: export
+#include <mbedtls/base64.h>      // IWYU pragma: export
+#include <mbedtls/ctr_drbg.h>    // IWYU pragma: export
+#include <mbedtls/entropy.h>     // IWYU pragma: export
+#include <mbedtls/md.h>          // IWYU pragma: export
+#include <mbedtls/md5.h>         // IWYU pragma: export
+#include <mbedtls/net_sockets.h> // IWYU pragma: export
+#include <mbedtls/rsa.h>         // IWYU pragma: export
+#include <mbedtls/ssl.h>         // IWYU pragma: export
+#include <mbedtls/x509_crt.h>    // IWYU pragma: export
 
 extern const mbedtls_md_type_t atchops_mbedtls_md_map[];
 

--- a/packages/atchops/src/rsa_key.c
+++ b/packages/atchops/src/rsa_key.c
@@ -375,8 +375,9 @@ int atchops_rsa_key_generate_base64(unsigned char **public_key_base64_output,
   size_t private_key_base64_pkcs8_len = 0;
 
   // 8b. Encode the PKCS#8 formatted private key
-  if ((ret = atchops_base64_encode(private_key_pkcs8, 26 + private_key_non_base64_len, private_key_pkcs8_base64,
-                                   private_key_base64_pkcs8_size, &private_key_base64_pkcs8_len)) != 0) {
+  if ((ret = atchops_base64_encode(private_key_pkcs8, 26 + private_key_non_base64_len,
+                                   (unsigned char *)private_key_pkcs8_base64, private_key_base64_pkcs8_size,
+                                   &private_key_base64_pkcs8_len)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to encode private key\n");
     goto exit;
   }

--- a/packages/atclient/CHANGELOG.md
+++ b/packages/atclient/CHANGELOG.md
@@ -1,3 +1,14 @@
-## v0.0.1
+## 0.3.0
 
-- Initial work in progress
+- **Breaking changes** to `atclient_atkey_metadata` and `atclient_notify_params`
+  - `long` and `int` type changed to `int64_t` (metadata: `ttb`, `ttr`, `ttl`; notify: `latest_n`)
+  - `unsigned long` type changed to `uint64_t` (notify: `notification_expiry`)
+
+## 0.2.0
+
+- New release to use MbedTLS 3.6.1 to resolve a bug when building NoPorts on arm64 with musl libc
+
+## 0.1.0
+
+- Initial MVP release
+

--- a/packages/atclient/include/atclient/atkeys.h
+++ b/packages/atclient/include/atclient/atkeys.h
@@ -1,6 +1,7 @@
 #ifndef ATCLIENT_ATKEYS_H
 #define ATCLIENT_ATKEYS_H
 
+#include "atchops/rsa_key.h"
 #include "atclient/atkeys_file.h"
 #include <atchops/rsa.h>
 #include <stddef.h>

--- a/packages/atclient/include/atclient/cjson.h
+++ b/packages/atclient/include/atclient/cjson.h
@@ -2,9 +2,9 @@
 #define ATCLIENT_CJSON_H
 
 #if defined(CONFIG_IDF_TARGET_ESP32)
-#include <cjson.h>
+#include <cjson.h> // IWYU pragma: export
 #else
-#include <cJSON.h>
+#include <cJSON.h> // IWYU pragma: export
 #endif
 
 #endif

--- a/packages/atclient/include/atclient/metadata.h
+++ b/packages/atclient/include/atclient/metadata.h
@@ -134,8 +134,8 @@ typedef struct atclient_atkey_metadata {
   // This field is not written to the protocol string by the SDK. It is a strictly client-side metadata.
   bool is_public : 1;
 
-  // is_cached=true means the key contains 'cached:', written and used by client SDK only, not written to protocol string
-  // is_cached=false means the key does not contain 'cached:'
+  // is_cached=true means the key contains 'cached:', written and used by client SDK only, not written to protocol
+  // string is_cached=false means the key does not contain 'cached:'
   bool is_cached : 1;
   // This field is not written to the protocol string by the SDK. It is a strictly client-side metadata.
 
@@ -144,7 +144,7 @@ typedef struct atclient_atkey_metadata {
   // Example ttl=86400 means the atkey will live for a day.
   // This field is read from protocol string and and set by the developer.
   // This field is written to protocol string by the SDK. (See atclient_atkey_metadata_to_protocolstr)
-  long ttl;
+  uint64_t ttl;
 
   // Time to birth in milliseconds
   // Represents the amount of time it takes for atkey to exist.
@@ -152,7 +152,7 @@ typedef struct atclient_atkey_metadata {
   // and received by the atServer
   // This field is read from protocol string and and set by the developer.
   // This field is written to protocol string by the SDK. (See atclient_atkey_metadata_to_protocolstr)
-  long ttb;
+  uint64_t ttb;
 
   // Time to refresh in milliseconds
   // Represents the amount of time the cached shared atkey will refresh and update to the latest data stored by the
@@ -161,7 +161,7 @@ typedef struct atclient_atkey_metadata {
   // a ttr is not applicable to this type of atkey (because it may be a selfkey), which has the same effect as 0.
   // This field is read from protocol string and and set by the developer.
   // This field is written to protocol string by the SDK. (See atclient_atkey_metadata_to_protocolstr)
-  long ttr;
+  uint64_t ttr;
 
   // Cascade Delete
   // ccd=1 means this cached keys will be deleted upon the deletion of the original copy
@@ -221,11 +221,10 @@ typedef struct atclient_atkey_metadata {
   char *encoding;
 
   // The name of the key used to encrypt the value. If not provided, use sharedKeyEnc in the metadata. If sharedKeyEnc
-  // is not provided, use the default shared key. If enc_key_name is provided, just the key name must be provided example
-  // without the sharedWith suffix and sharedBy prefix, nor visibility prefix. Example '@bob:shared_key.wavi@alice',
-  // must be only be 'shared_key.wavi'
-  // This field is read from protocol string and set by the developer.
-  // This field is written to protocol string by the SDK. (See atclient_atkey_metadata_to_protocolstr)
+  // is not provided, use the default shared key. If enc_key_name is provided, just the key name must be provided
+  // example without the sharedWith suffix and sharedBy prefix, nor visibility prefix. Example
+  // '@bob:shared_key.wavi@alice', must be only be 'shared_key.wavi' This field is read from protocol string and set by
+  // the developer. This field is written to protocol string by the SDK. (See atclient_atkey_metadata_to_protocolstr)
   char *enc_key_name;
 
   // The name of the algorithm used to encrypt the value. For data, the default algorithm is 'AES/SIC/PKCS7Padding', for
@@ -292,6 +291,7 @@ int atclient_atkey_metadata_from_json_str(atclient_atkey_metadata *metadata, con
  * @param json the json object to populate from
  * @return int 0 on success
  */
+
 int atclient_atkey_metadata_from_cjson_node(atclient_atkey_metadata *metadata, const cJSON *json);
 
 /**
@@ -387,9 +387,9 @@ bool atclient_atkey_metadata_is_ske_enc_algo_initialized(const atclient_atkey_me
 
 int atclient_atkey_metadata_set_is_public(atclient_atkey_metadata *metadata, const bool is_public);
 int atclient_atkey_metadata_set_is_cached(atclient_atkey_metadata *metadata, const bool is_cached);
-int atclient_atkey_metadata_set_ttl(atclient_atkey_metadata *metadata, const long ttl);
-int atclient_atkey_metadata_set_ttb(atclient_atkey_metadata *metadata, const long ttb);
-int atclient_atkey_metadata_set_ttr(atclient_atkey_metadata *metadata, const long ttr);
+int atclient_atkey_metadata_set_ttl(atclient_atkey_metadata *metadata, const int64_t ttl);
+int atclient_atkey_metadata_set_ttb(atclient_atkey_metadata *metadata, const int64_t ttb);
+int atclient_atkey_metadata_set_ttr(atclient_atkey_metadata *metadata, const int64_t ttr);
 int atclient_atkey_metadata_set_ccd(atclient_atkey_metadata *metadata, const bool ccd);
 int atclient_atkey_metadata_set_is_binary(atclient_atkey_metadata *metadata, const bool is_binary);
 int atclient_atkey_metadata_set_is_encrypted(atclient_atkey_metadata *metadata, const bool is_encrypted);

--- a/packages/atclient/include/atclient/notify_params.h
+++ b/packages/atclient/include/atclient/notify_params.h
@@ -1,8 +1,8 @@
 #ifndef ATCLIENT_NOTIFY_PARAMS_H
 #define ATCLIENT_NOTIFY_PARAMS_H
 
-#include "atclient/atclient.h"
 #include "atclient/atkey.h"
+#include <stdint.h>
 
 #define ATCLIENT_DEFAULT_NOTIFIER "SYSTEM"
 
@@ -37,7 +37,7 @@
 #define ATCLIENT_NOTIFY_PARAMS_SHARED_ENCRYPTION_KEY_INITIALIZED (VALUE_INITIALIZED << 3)
 
 // default param values for atclient_notify_params
-#define ATCLIENT_NOTIFY_PARAMS_DEFAULT_NOTIFICATION_EXPIRY 24 * 60 * 60 * 1000 //24 Hours in Milliseconds
+#define ATCLIENT_NOTIFY_PARAMS_DEFAULT_NOTIFICATION_EXPIRY 24 * 60 * 60 * 1000 // 24 Hours in Milliseconds
 #define ATCLIENT_NOTIFY_PARAMS_DEFAULT_LATEST_N 1
 #define ATCLIENT_NOTIFY_PARAMS_DEFAULT_SHOULD_ENCRYPT true
 #define ATCLIENT_NOTIFY_PARAMS_DEFAULT_OPERATION ATCLIENT_NOTIFY_OPERATION_NONE
@@ -100,9 +100,9 @@ typedef struct atclient_notify_params {
   enum atclient_notify_message_type message_type;
   enum atclient_notify_priority priority;
   enum atclient_notify_strategy strategy;
-  int latest_n;
+  int64_t latest_n;
   char *notifier;
-  unsigned long notification_expiry;
+  uint64_t notification_expiry;
   unsigned char *shared_encryption_key;
 
   uint8_t _initialized_fields[2];
@@ -135,20 +135,24 @@ void atclient_notify_params_set_strategy_initialized(atclient_notify_params *par
 void atclient_notify_params_set_latest_n_initialized(atclient_notify_params *params, const bool initialized);
 void atclient_notify_params_set_notifier_initialized(atclient_notify_params *params, const bool initialized);
 void atclient_notify_params_set_notification_expiry_initialized(atclient_notify_params *params, const bool initialized);
-void atclient_notify_params_set_shared_encryption_key_initialized(atclient_notify_params *params, const bool initialized);
+void atclient_notify_params_set_shared_encryption_key_initialized(atclient_notify_params *params,
+                                                                  const bool initialized);
 
 int atclient_notify_params_set_id(atclient_notify_params *params, const char *id);
 int atclient_notify_params_set_atkey(atclient_notify_params *params, const atclient_atkey *atkey);
 int atclient_notify_params_set_value(atclient_notify_params *params, const char *value);
 int atclient_notify_params_set_should_encrypt(atclient_notify_params *params, const bool should_encrypt);
-int atclient_notify_params_set_operation(atclient_notify_params *params, const enum atclient_notify_operation operation);
-int atclient_notify_params_set_message_type(atclient_notify_params *params, const enum atclient_notify_message_type message_type);
+int atclient_notify_params_set_operation(atclient_notify_params *params,
+                                         const enum atclient_notify_operation operation);
+int atclient_notify_params_set_message_type(atclient_notify_params *params,
+                                            const enum atclient_notify_message_type message_type);
 int atclient_notify_params_set_priority(atclient_notify_params *params, const enum atclient_notify_priority priority);
 int atclient_notify_params_set_strategy(atclient_notify_params *params, const enum atclient_notify_strategy strategy);
-int atclient_notify_params_set_latest_n(atclient_notify_params *params, const int latest_n);
+int atclient_notify_params_set_latest_n(atclient_notify_params *params, const int64_t latest_n);
 int atclient_notify_params_set_notifier(atclient_notify_params *params, const char *notifier);
-int atclient_notify_params_set_notification_expiry(atclient_notify_params *params, const unsigned long notification_expiry);
-int atclient_notify_params_set_shared_encryption_key(atclient_notify_params *params, const unsigned char *shared_encryption_key);
+int atclient_notify_params_set_notification_expiry(atclient_notify_params *params, const uint64_t notification_expiry);
+int atclient_notify_params_set_shared_encryption_key(atclient_notify_params *params,
+                                                     const unsigned char *shared_encryption_key);
 
 void atclient_notify_params_unset_id(atclient_notify_params *params);
 void atclient_notify_params_unset_atkey(atclient_notify_params *params);
@@ -163,4 +167,4 @@ void atclient_notify_params_unset_notifier(atclient_notify_params *params);
 void atclient_notify_params_unset_notification_expiry(atclient_notify_params *params);
 void atclient_notify_params_unset_shared_encryption_key(atclient_notify_params *params);
 
-#endif //ATCLIENT_NOTIFY_PARAMS_H
+#endif // ATCLIENT_NOTIFY_PARAMS_H

--- a/packages/atclient/include/atclient/string_utils.h
+++ b/packages/atclient/include/atclient/string_utils.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 /**
  * @brief trims leading/trailing whitespace/newline
@@ -15,7 +16,7 @@
  * @return int 0 on success, non-zero on failure
  */
 int atclient_string_utils_trim_whitespace(const char *string, const size_t stringlen, char *out, const size_t out_size,
-                                         size_t *out_len);
+                                          size_t *out_len);
 
 /**
  * @brief check if string starts with prefix
@@ -72,5 +73,13 @@ int atclient_string_utils_atsign_without_at(const char *original_atsign, char **
  * @return int the string length
  */
 int atclient_string_utils_long_strlen(long n);
+
+/**
+ * @brief get the length of an int64_t if it were converted to a string
+ *
+ * @param n the int64_t to check the length of
+ * @return int the string length
+ */
+int atclient_string_utils_int64_strlen(int64_t n);
 
 #endif

--- a/packages/atclient/include/atclient/version.h
+++ b/packages/atclient/include/atclient/version.h
@@ -1,6 +1,6 @@
 #ifndef ATCLIENT_VERSION_H
 #define ATCLIENT_VERSION_H
 
-#define ATCLIENT_ATSDK_VERSION "0.1.0"
+#define ATCLIENT_ATSDK_VERSION "0.3.0"
 
 #endif

--- a/packages/atclient/include/atclient/version.h
+++ b/packages/atclient/include/atclient/version.h
@@ -1,6 +1,6 @@
 #ifndef ATCLIENT_VERSION_H
 #define ATCLIENT_VERSION_H
 
-#define ATCLIENT_ATSDK_VERSION "0.0.1"
+#define ATCLIENT_ATSDK_VERSION "0.1.0"
 
 #endif

--- a/packages/atclient/src/metadata.c
+++ b/packages/atclient/src/metadata.c
@@ -3,6 +3,7 @@
 #include "atlogger/atlogger.h"
 #include "cJSON.h"
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -107,9 +108,9 @@ static int set_created_at(atclient_atkey_metadata *metadata, const char *created
 static int set_updated_at(atclient_atkey_metadata *metadata, const char *updated_at);
 static void set_is_public(atclient_atkey_metadata *metadata, const bool is_public);
 static void set_is_cached(atclient_atkey_metadata *metadata, const bool is_cached);
-static void set_ttl(atclient_atkey_metadata *metadata, const long ttl);
-static void set_ttb(atclient_atkey_metadata *metadata, const long ttb);
-static void set_ttr(atclient_atkey_metadata *metadata, const long ttr);
+static void set_ttl(atclient_atkey_metadata *metadata, const int64_t ttl);
+static void set_ttb(atclient_atkey_metadata *metadata, const int64_t ttb);
+static void set_ttr(atclient_atkey_metadata *metadata, const int64_t ttr);
 static void set_ccd(atclient_atkey_metadata *metadata, const bool ccd);
 static void set_is_binary(atclient_atkey_metadata *metadata, const bool is_binary);
 static void set_is_encrypted(atclient_atkey_metadata *metadata, const bool is_encrypted);
@@ -920,7 +921,7 @@ size_t atclient_atkey_metadata_protocol_strlen(const atclient_atkey_metadata *me
   /*
    * 2. Calculate length
    */
-  long len = 0;
+  int64_t len = 0;
   if (atclient_atkey_metadata_is_ttl_initialized(metadata)) {
     len += atclient_atkey_metadata_ttl_strlen(metadata);
   }
@@ -1000,7 +1001,7 @@ size_t atclient_atkey_metadata_ttl_strlen(const atclient_atkey_metadata *metadat
     return 0;
   }
   return strlen(":ttl:") // :ttl:
-         + atclient_string_utils_long_strlen(metadata->ttl);
+         + atclient_string_utils_int64_strlen(metadata->ttl);
 }
 
 size_t atclient_atkey_metadata_ttb_strlen(const atclient_atkey_metadata *metadata) {
@@ -1011,7 +1012,7 @@ size_t atclient_atkey_metadata_ttb_strlen(const atclient_atkey_metadata *metadat
     return 0;
   }
   return strlen(":ttb:") // :ttb:
-         + atclient_string_utils_long_strlen(metadata->ttb);
+         + atclient_string_utils_int64_strlen(metadata->ttb);
 }
 
 size_t atclient_atkey_metadata_ttr_strlen(const atclient_atkey_metadata *metadata) {
@@ -1022,7 +1023,7 @@ size_t atclient_atkey_metadata_ttr_strlen(const atclient_atkey_metadata *metadat
     return 0;
   }
   return strlen(":ttr:") // :ttr:
-         + atclient_string_utils_long_strlen(metadata->ttr);
+         + atclient_string_utils_int64_strlen(metadata->ttr);
 }
 
 size_t atclient_atkey_metadata_ccd_strlen(const atclient_atkey_metadata *metadata) {
@@ -1211,17 +1212,17 @@ int atclient_atkey_metadata_to_protocol_str(const atclient_atkey_metadata *metad
   memset(*metadata_str, 0, sizeof(char) * metadata_str_size);
 
   if (atclient_atkey_metadata_is_ttl_initialized(metadata)) {
-    sprintf((*metadata_str) + pos, ":ttl:%ld", metadata->ttl);
+    sprintf((*metadata_str) + pos, ":ttl:%lld", metadata->ttl);
     pos += atclient_atkey_metadata_ttl_strlen(metadata);
   }
 
   if (atclient_atkey_metadata_is_ttb_initialized(metadata)) {
-    sprintf((*metadata_str) + pos, ":ttb:%ld", metadata->ttb);
+    sprintf((*metadata_str) + pos, ":ttb:%lld", metadata->ttb);
     pos += atclient_atkey_metadata_ttb_strlen(metadata);
   }
 
   if (atclient_atkey_metadata_is_ttr_initialized(metadata)) {
-    sprintf((*metadata_str) + pos, ":ttr:%ld", metadata->ttr);
+    sprintf((*metadata_str) + pos, ":ttr:%lld", metadata->ttr);
     pos += atclient_atkey_metadata_ttr_strlen(metadata);
   }
 
@@ -1453,7 +1454,7 @@ int atclient_atkey_metadata_set_is_cached(atclient_atkey_metadata *metadata, con
   return 0;
 }
 
-int atclient_atkey_metadata_set_ttl(atclient_atkey_metadata *metadata, const long ttl) {
+int atclient_atkey_metadata_set_ttl(atclient_atkey_metadata *metadata, const int64_t ttl) {
   if (is_ttl_initialized(metadata)) {
     unset_ttl(metadata);
   }
@@ -1461,7 +1462,7 @@ int atclient_atkey_metadata_set_ttl(atclient_atkey_metadata *metadata, const lon
   return 0;
 }
 
-int atclient_atkey_metadata_set_ttb(atclient_atkey_metadata *metadata, const long ttb) {
+int atclient_atkey_metadata_set_ttb(atclient_atkey_metadata *metadata, const int64_t ttb) {
   if (is_ttb_initialized(metadata)) {
     unset_ttb(metadata);
   }
@@ -1469,7 +1470,7 @@ int atclient_atkey_metadata_set_ttb(atclient_atkey_metadata *metadata, const lon
   return 0;
 }
 
-int atclient_atkey_metadata_set_ttr(atclient_atkey_metadata *metadata, const long ttr) {
+int atclient_atkey_metadata_set_ttr(atclient_atkey_metadata *metadata, const int64_t ttr) {
   if (is_ttr_initialized(metadata)) {
     unset_ttr(metadata);
   }
@@ -2438,17 +2439,17 @@ static void set_is_cached(atclient_atkey_metadata *metadata, const bool is_cache
   set_is_is_cached_initialized(metadata, true);
 }
 
-static void set_ttl(atclient_atkey_metadata *metadata, const long ttl) {
+static void set_ttl(atclient_atkey_metadata *metadata, const int64_t ttl) {
   metadata->ttl = ttl;
   set_is_ttl_initialized(metadata, true);
 }
 
-static void set_ttb(atclient_atkey_metadata *metadata, const long ttb) {
+static void set_ttb(atclient_atkey_metadata *metadata, const int64_t ttb) {
   metadata->ttb = ttb;
   set_is_ttb_initialized(metadata, true);
 }
 
-static void set_ttr(atclient_atkey_metadata *metadata, const long ttr) {
+static void set_ttr(atclient_atkey_metadata *metadata, const int64_t ttr) {
   metadata->ttr = ttr;
   set_is_ttr_initialized(metadata, true);
 }

--- a/packages/atclient/src/notify.c
+++ b/packages/atclient/src/notify.c
@@ -1,6 +1,9 @@
 #include "atclient/notify.h"
+#include "atclient/atclient.h"
 #include "atclient/connection.h"
 #include "atclient/encryption_key_helpers.h"
+#include "atclient/metadata.h"
+#include "atclient/notify_params.h"
 #include "atclient/string_utils.h"
 #include <atchops/aes.h>
 #include <atchops/aes_ctr.h>
@@ -8,6 +11,7 @@
 #include <atchops/iv.h>
 #include <atchops/uuid.h>
 #include <atlogger/atlogger.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -309,7 +313,7 @@ static int generate_cmd(const atclient_notify_params *params, const char *cmdval
   }
 
   if (atclient_notify_params_is_notification_expiry_initialized(params) && params->notification_expiry > 0) {
-    snprintf(cmd + off, cmdsize - off, ":ttln:%lu", params->notification_expiry);
+    snprintf(cmd + off, cmdsize - off, ":ttln:%llu", params->notification_expiry);
     off += strlen(":ttln:") + atclient_string_utils_long_strlen(params->notification_expiry);
   }
 

--- a/packages/atclient/src/notify_params.c
+++ b/packages/atclient/src/notify_params.c
@@ -1,5 +1,6 @@
 #include "atclient/notify_params.h"
 #include "atchops/aes.h"
+#include "atclient/atkey.h"
 #include <atlogger/atlogger.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/packages/atclient/src/notify_params.c
+++ b/packages/atclient/src/notify_params.c
@@ -1,6 +1,7 @@
 #include "atclient/notify_params.h"
 #include "atchops/aes.h"
 #include <atlogger/atlogger.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -307,7 +308,7 @@ int atclient_notify_params_set_strategy(atclient_notify_params *params, const en
   return 0;
 }
 
-int atclient_notify_params_set_latest_n(atclient_notify_params *params, const int latest_n) {
+int atclient_notify_params_set_latest_n(atclient_notify_params *params, const int64_t latest_n) {
   params->latest_n = latest_n;
   atclient_notify_params_set_latest_n_initialized(params, true);
   return 0;
@@ -338,8 +339,7 @@ int atclient_notify_params_set_notifier(atclient_notify_params *params, const ch
 exit: { return ret; }
 }
 
-int atclient_notify_params_set_notification_expiry(atclient_notify_params *params,
-                                                   const unsigned long notification_expiry) {
+int atclient_notify_params_set_notification_expiry(atclient_notify_params *params, const uint64_t notification_expiry) {
   params->notification_expiry = notification_expiry;
   atclient_notify_params_set_notification_expiry_initialized(params, true);
   return 0;

--- a/packages/atclient/src/string_utils.c
+++ b/packages/atclient/src/string_utils.c
@@ -1,12 +1,13 @@
 #include "atclient/string_utils.h"
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 
 int atclient_string_utils_trim_whitespace(const char *string, const size_t string_len, char *out, const size_t out_size,
-                                         size_t *out_len) {
+                                          size_t *out_len) {
   int ret = 1;
 
   if (string == NULL) {
@@ -56,26 +57,25 @@ bool atclient_string_utils_ends_with(const char *string, const char *suffix) {
     return false;
   }
   return strncmp(string + string_len - suffix_len, suffix, suffix_len) == 0;
-
 }
 
-int atclient_string_utils_get_substring_position(const char* string, const char* substring, char** position) {
+int atclient_string_utils_get_substring_position(const char *string, const char *substring, char **position) {
   int ret = -1;
-  if(strlen(substring) > strlen(string)) {
+  if (strlen(substring) > strlen(string)) {
     ret = -1;
     goto exit;
   }
-  if(position == NULL) {
+  if (position == NULL) {
     ret = -1;
     goto exit;
   }
-  *position =  strstr(string, substring);
-  if(*position == NULL) {
+  *position = strstr(string, substring);
+  if (*position == NULL) {
     ret = -1;
     goto exit;
   }
   ret = 0;
-  exit:{ return ret;}
+exit: { return ret; }
 }
 
 int atclient_string_utils_atsign_with_at(const char *original_atsign, char **output_atsign_with_at_symbol) {
@@ -163,6 +163,26 @@ int atclient_string_utils_long_strlen(long n) {
   }
 
   for (long i = 1; i <= n; i *= 10) {
+    len++;
+  }
+
+  return len;
+}
+
+int atclient_string_utils_int64_strlen(int64_t n) {
+  // could use log10 for this, but it's probably slower...
+  size_t len = 0;
+
+  if (n == 0) {
+    return 1;
+  }
+
+  if (n < 0) {
+    n *= -1;
+    len++; // for the minus sign
+  }
+
+  for (int64_t i = 1; i <= n; i *= 10) {
     len++;
   }
 

--- a/packages/atclient/tests/test_atkey_create.c
+++ b/packages/atclient/tests/test_atkey_create.c
@@ -1,5 +1,4 @@
 #include "atclient/atkey.h"
-#include "atclient/constants.h"
 #include "atlogger/atlogger.h"
 #include <stddef.h>
 #include <stdlib.h>
@@ -82,7 +81,8 @@ static int test1_create_publickey() {
   }
 
   if (strcmp(atkey.shared_by, "@alice") != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_by.str is not @alice, it is \"%s\"\n", atkey.shared_by);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_by.str is not @alice, it is \"%s\"\n",
+                 atkey.shared_by);
     ret = 1;
     goto exit;
   }
@@ -224,7 +224,7 @@ static int test3_create_sharedkey() {
     goto exit;
   }
 
-  if(!atclient_atkey_is_key_initialized(&atkey)) {
+  if (!atclient_atkey_is_key_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey key is not initialized when it should be\n");
     goto exit;
@@ -236,7 +236,7 @@ static int test3_create_sharedkey() {
     goto exit;
   }
 
-  if(!atclient_atkey_is_shared_by_initialized(&atkey)) {
+  if (!atclient_atkey_is_shared_by_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey shared_by is not initialized when it should be\n");
     goto exit;
@@ -244,11 +244,12 @@ static int test3_create_sharedkey() {
 
   if (strcmp(atkey.shared_by, "@chess69lovely") != 0) {
     ret = 1;
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_by is not @chess69lovely, it is \"%s\"\n", atkey.shared_by);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_by is not @chess69lovely, it is \"%s\"\n",
+                 atkey.shared_by);
     goto exit;
   }
 
-  if(!atclient_atkey_is_shared_with_initialized(&atkey)) {
+  if (!atclient_atkey_is_shared_with_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey shared_with is not initialized when it should be\n");
     goto exit;
@@ -261,7 +262,7 @@ static int test3_create_sharedkey() {
     goto exit;
   }
 
-  if(!atclient_atkey_is_namespacestr_initialized(&atkey)) {
+  if (!atclient_atkey_is_namespacestr_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey namespace is not initialized when it should be\n");
     goto exit;

--- a/packages/atclient/tests/test_atkey_from_string.c
+++ b/packages/atclient/tests/test_atkey_from_string.c
@@ -1,4 +1,5 @@
 #include "atclient/atkey.h"
+#include "atclient/metadata.h"
 #include "atlogger/atlogger.h"
 #include <stdbool.h>
 #include <stddef.h>
@@ -192,8 +193,7 @@ static int test1b_publickey_without_namespace() {
     goto exit;
   }
 
-
-  if(!atclient_atkey_metadata_is_is_public_initialized(&atkey.metadata)) {
+  if (!atclient_atkey_metadata_is_is_public_initialized(&atkey.metadata)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.is_public is not initialized\n");
     goto exit;
@@ -496,7 +496,8 @@ static int test2a_sharedkey_with_namespace() {
   }
 
   if (strcmp(atkey.shared_with, "@alice") != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_with is not @alice, it is \"%s\"\n", atkey.shared_with);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_with is not @alice, it is \"%s\"\n",
+                 atkey.shared_with);
     ret = 1;
     goto exit;
   }
@@ -782,7 +783,7 @@ static int test2e_sharedkey_with_compounding_namespace() {
     goto exit;
   }
 
-  if(!atclient_atkey_is_shared_by_initialized(&atkey)) {
+  if (!atclient_atkey_is_shared_by_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_by is not initialized when it should be\n");
     goto exit;
@@ -941,7 +942,7 @@ static int test3a_privatehiddenkey_without_namespace() {
     goto exit;
   }
 
-  if(!atclient_atkey_is_key_initialized(&atkey)) {
+  if (!atclient_atkey_is_key_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.key is not initialized, when it should be\n");
     goto exit;
@@ -953,7 +954,7 @@ static int test3a_privatehiddenkey_without_namespace() {
     goto exit;
   }
 
-  if(!atclient_atkey_is_shared_by_initialized(&atkey)) {
+  if (!atclient_atkey_is_shared_by_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_by is not initialized, when it should be\n");
     goto exit;
@@ -1009,7 +1010,7 @@ static int test4a_selfkey_without_namespace() {
     goto exit;
   }
 
-  if(!atclient_atkey_is_key_initialized(&atkey)) {
+  if (!atclient_atkey_is_key_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.key is not initialized, when it should be\n");
     goto exit;
@@ -1021,7 +1022,7 @@ static int test4a_selfkey_without_namespace() {
     goto exit;
   }
 
-  if(!atclient_atkey_is_shared_by_initialized(&atkey)) {
+  if (!atclient_atkey_is_shared_by_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_by is not initialized, when it should be\n");
     goto exit;
@@ -1033,7 +1034,7 @@ static int test4a_selfkey_without_namespace() {
     goto exit;
   }
 
-  if(atclient_atkey_is_shared_with_initialized(&atkey)) {
+  if (atclient_atkey_is_shared_with_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_with is initialized when it should not be\n");
     goto exit;
@@ -1074,7 +1075,7 @@ static int test4b_selfkey_with_namespace() {
     goto exit;
   }
 
-  if(!atclient_atkey_is_key_initialized(&atkey)) {
+  if (!atclient_atkey_is_key_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.key is not initialized, when it should be\n");
     goto exit;
@@ -1086,7 +1087,7 @@ static int test4b_selfkey_with_namespace() {
     goto exit;
   }
 
-  if(!atclient_atkey_is_shared_by_initialized(&atkey)) {
+  if (!atclient_atkey_is_shared_by_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_by is not initialized, when it should be\n");
     goto exit;
@@ -1094,11 +1095,12 @@ static int test4b_selfkey_with_namespace() {
 
   if (strcmp(atkey.shared_by, "@jeremy_0") != 0) {
     ret = 1;
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_by is not @jeremy_0, it is \"%s\"\n", atkey.shared_by);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.shared_by is not @jeremy_0, it is \"%s\"\n",
+                 atkey.shared_by);
     goto exit;
   }
 
-  if(!atclient_atkey_is_namespacestr_initialized(&atkey)) {
+  if (!atclient_atkey_is_namespacestr_initialized(&atkey)) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.namespace_str is not initialized, when it should be\n");
     goto exit;

--- a/packages/atclient/tests/test_atkey_to_string.c
+++ b/packages/atclient/tests/test_atkey_to_string.c
@@ -1,5 +1,5 @@
 #include "atclient/atkey.h"
-#include "atclient/constants.h"
+#include "atclient/metadata.h"
 #include "atlogger/atlogger.h"
 #include <stdbool.h>
 #include <stddef.h>
@@ -138,12 +138,12 @@ static int test1a_cached_publickey_without_namespace() {
 
   const char *expected = TEST_ATKEY_TO_STRING_1A;
 
-  if((ret = atclient_atkey_metadata_set_is_cached(&(atkey.metadata), true)) != 0) {
+  if ((ret = atclient_atkey_metadata_set_is_cached(&(atkey.metadata), true)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_metadata_set_is_cached failed\n");
     goto exit;
   }
 
-  if((ret = atclient_atkey_metadata_set_is_public(&(atkey.metadata), true)) != 0) {
+  if ((ret = atclient_atkey_metadata_set_is_public(&(atkey.metadata), true)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_metadata_set_is_public failed\n");
     goto exit;
   }
@@ -190,7 +190,7 @@ static int test1b_publickey_without_namespace() {
 
   const char *expected = TEST_ATKEY_TO_STRING_1B; // "public:publickey@alice"
 
-  if((ret = atclient_atkey_metadata_set_is_public(&(atkey.metadata), true)) != 0) {
+  if ((ret = atclient_atkey_metadata_set_is_public(&(atkey.metadata), true)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_metadata_set_is_public failed\n");
     goto exit;
   }
@@ -288,12 +288,12 @@ static int test1d_cached_publickey_with_namespace() {
   const char *expected = TEST_ATKEY_TO_STRING_1D; // "cached:public:name.wavi@jeremy"
   const size_t expectedlen = strlen(expected);
 
-  if((ret = atclient_atkey_metadata_set_is_cached(&(atkey.metadata), true)) != 0) {
+  if ((ret = atclient_atkey_metadata_set_is_cached(&(atkey.metadata), true)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_metadata_set_is_cached failed\n");
     goto exit;
   }
 
-  if((ret = atclient_atkey_metadata_set_is_public(&(atkey.metadata), true)) != 0) {
+  if ((ret = atclient_atkey_metadata_set_is_public(&(atkey.metadata), true)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_metadata_set_is_public failed\n");
     goto exit;
   }
@@ -395,7 +395,7 @@ static int test2b_cached_sharedkey_without_namespace() {
 
   const char *expected = TEST_ATKEY_TO_STRING_2B; // "cached:@bob:name@alice"
 
-  if((ret = atclient_atkey_metadata_set_is_cached(&(atkey.metadata), true)) != 0) {
+  if ((ret = atclient_atkey_metadata_set_is_cached(&(atkey.metadata), true)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_metadata_set_is_cached failed\n");
     goto exit;
   }
@@ -499,7 +499,7 @@ static int test2d_cached_sharedkey_with_namespace() {
 
   const char *expected = TEST_ATKEY_TO_STRING_2D; // "cached:@bob:name.wavi@alice"
 
-  if((ret = atclient_atkey_metadata_set_is_cached(&(atkey.metadata), true)) != 0) {
+  if ((ret = atclient_atkey_metadata_set_is_cached(&(atkey.metadata), true)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_atkey_metadata_set_is_cached failed\n");
     goto exit;
   }

--- a/packages/atclient/tests/test_atkeys_write.c
+++ b/packages/atclient/tests/test_atkeys_write.c
@@ -1,6 +1,8 @@
 #include <atclient/atclient.h>
 #include <atclient/atkeys.h>
+#include <atclient/atkeys_file.h>
 #include <atlogger/atlogger.h>
+#include <string.h>
 
 #define TAG "test_atkeys_write"
 
@@ -102,13 +104,20 @@ int main(int argc, char *argv[]) {
   }
 
   // log what fields are initializwed
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_pkam_public_key_base64_initialized: %d\n", atclient_atkeys_is_pkam_public_key_base64_initialized(&atkeys));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_pkam_private_key_base64_initialized: %d\n", atclient_atkeys_is_pkam_private_key_base64_initialized(&atkeys));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_encrypt_public_key_base64_initialized: %d\n", atclient_atkeys_is_encrypt_public_key_base64_initialized(&atkeys));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_encrypt_private_key_base64_initialized: %d\n", atclient_atkeys_is_encrypt_private_key_base64_initialized(&atkeys));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_self_encryption_key_base64_initialized: %d\n", atclient_atkeys_is_self_encryption_key_base64_initialized(&atkeys));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_apkam_symmetric_key_base64_initialized: %d\n", atclient_atkeys_is_apkam_symmetric_key_base64_initialized(&atkeys));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_enrollment_id_initialized: %d\n", atclient_atkeys_is_enrollment_id_initialized(&atkeys));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_pkam_public_key_base64_initialized: %d\n",
+               atclient_atkeys_is_pkam_public_key_base64_initialized(&atkeys));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_pkam_private_key_base64_initialized: %d\n",
+               atclient_atkeys_is_pkam_private_key_base64_initialized(&atkeys));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_encrypt_public_key_base64_initialized: %d\n",
+               atclient_atkeys_is_encrypt_public_key_base64_initialized(&atkeys));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_encrypt_private_key_base64_initialized: %d\n",
+               atclient_atkeys_is_encrypt_private_key_base64_initialized(&atkeys));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_self_encryption_key_base64_initialized: %d\n",
+               atclient_atkeys_is_self_encryption_key_base64_initialized(&atkeys));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_apkam_symmetric_key_base64_initialized: %d\n",
+               atclient_atkeys_is_apkam_symmetric_key_base64_initialized(&atkeys));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_enrollment_id_initialized: %d\n",
+               atclient_atkeys_is_enrollment_id_initialized(&atkeys));
 
   if ((ret = atclient_atkeys_write_to_path(&atkeys, ATKEYS_8INCANTEATER_1_FILE_PATH))) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "failed to write to path\n");
@@ -121,13 +130,20 @@ int main(int argc, char *argv[]) {
   }
 
   // log what fields are initializwed
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_pkam_public_key_base64_initialized: %d\n", atclient_atkeys_is_pkam_public_key_base64_initialized(&atkeys1));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_pkam_private_key_base64_initialized: %d\n", atclient_atkeys_is_pkam_private_key_base64_initialized(&atkeys1));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_encrypt_public_key_base64_initialized: %d\n", atclient_atkeys_is_encrypt_public_key_base64_initialized(&atkeys1));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_encrypt_private_key_base64_initialized: %d\n", atclient_atkeys_is_encrypt_private_key_base64_initialized(&atkeys1));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_self_encryption_key_base64_initialized: %d\n", atclient_atkeys_is_self_encryption_key_base64_initialized(&atkeys1));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_apkam_symmetric_key_base64_initialized: %d\n", atclient_atkeys_is_apkam_symmetric_key_base64_initialized(&atkeys1));
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_enrollment_id_initialized: %d\n", atclient_atkeys_is_enrollment_id_initialized(&atkeys1));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_pkam_public_key_base64_initialized: %d\n",
+               atclient_atkeys_is_pkam_public_key_base64_initialized(&atkeys1));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_pkam_private_key_base64_initialized: %d\n",
+               atclient_atkeys_is_pkam_private_key_base64_initialized(&atkeys1));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_encrypt_public_key_base64_initialized: %d\n",
+               atclient_atkeys_is_encrypt_public_key_base64_initialized(&atkeys1));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_encrypt_private_key_base64_initialized: %d\n",
+               atclient_atkeys_is_encrypt_private_key_base64_initialized(&atkeys1));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_self_encryption_key_base64_initialized: %d\n",
+               atclient_atkeys_is_self_encryption_key_base64_initialized(&atkeys1));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_apkam_symmetric_key_base64_initialized: %d\n",
+               atclient_atkeys_is_apkam_symmetric_key_base64_initialized(&atkeys1));
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "is_enrollment_id_initialized: %d\n",
+               atclient_atkeys_is_enrollment_id_initialized(&atkeys1));
 
   // compare the two atkeys
   if (strcmp(atkeys.pkam_public_key_base64, atkeys1.pkam_public_key_base64) != 0) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Replaced occurences of int, long, unsigned long with uint64_t and int64_t.
  - Some of these are unlikely to overflow, but it doesn't hurt, since dart uses 64 bit integers, and these values are exchanged with the atServer.

**- How I did it**

**- How to verify it**

- When I make the same changes to NoPorts, I will be able to verify

**- Description for the changelog**
fix: use sized types for more consistent cross-platform support
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
