### PR TITLE
fix: Print int64 types

### DIFF
--- a/packages/atclient/CHANGELOG.md
+++ b/packages/atclient/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.1
+
+- **Breaking changes** to `atclient_atkey_metadata` and `atclient_notify_params`
+  - Some `int64_t` definitions were stored as `uint64_t` in the struct
+  - `uint64_t` type for `notification_expiry` changed to `int64_t` since it also maps to a dart int (int64)
+
 ## 0.3.0
 
 - **Breaking changes** to `atclient_atkey_metadata` and `atclient_notify_params`

--- a/packages/atclient/include/atclient/metadata.h
+++ b/packages/atclient/include/atclient/metadata.h
@@ -144,7 +144,7 @@ typedef struct atclient_atkey_metadata {
   // Example ttl=86400 means the atkey will live for a day.
   // This field is read from protocol string and and set by the developer.
   // This field is written to protocol string by the SDK. (See atclient_atkey_metadata_to_protocolstr)
-  uint64_t ttl;
+  int64_t ttl;
 
   // Time to birth in milliseconds
   // Represents the amount of time it takes for atkey to exist.
@@ -152,7 +152,7 @@ typedef struct atclient_atkey_metadata {
   // and received by the atServer
   // This field is read from protocol string and and set by the developer.
   // This field is written to protocol string by the SDK. (See atclient_atkey_metadata_to_protocolstr)
-  uint64_t ttb;
+  int64_t ttb;
 
   // Time to refresh in milliseconds
   // Represents the amount of time the cached shared atkey will refresh and update to the latest data stored by the
@@ -161,7 +161,7 @@ typedef struct atclient_atkey_metadata {
   // a ttr is not applicable to this type of atkey (because it may be a selfkey), which has the same effect as 0.
   // This field is read from protocol string and and set by the developer.
   // This field is written to protocol string by the SDK. (See atclient_atkey_metadata_to_protocolstr)
-  uint64_t ttr;
+  int64_t ttr;
 
   // Cascade Delete
   // ccd=1 means this cached keys will be deleted upon the deletion of the original copy

--- a/packages/atclient/include/atclient/notify_params.h
+++ b/packages/atclient/include/atclient/notify_params.h
@@ -102,7 +102,7 @@ typedef struct atclient_notify_params {
   enum atclient_notify_strategy strategy;
   int64_t latest_n;
   char *notifier;
-  uint64_t notification_expiry;
+  int64_t notification_expiry;
   unsigned char *shared_encryption_key;
 
   uint8_t _initialized_fields[2];
@@ -150,7 +150,7 @@ int atclient_notify_params_set_priority(atclient_notify_params *params, const en
 int atclient_notify_params_set_strategy(atclient_notify_params *params, const enum atclient_notify_strategy strategy);
 int atclient_notify_params_set_latest_n(atclient_notify_params *params, const int64_t latest_n);
 int atclient_notify_params_set_notifier(atclient_notify_params *params, const char *notifier);
-int atclient_notify_params_set_notification_expiry(atclient_notify_params *params, const uint64_t notification_expiry);
+int atclient_notify_params_set_notification_expiry(atclient_notify_params *params, const int64_t notification_expiry);
 int atclient_notify_params_set_shared_encryption_key(atclient_notify_params *params,
                                                      const unsigned char *shared_encryption_key);
 

--- a/packages/atclient/include/atclient/version.h
+++ b/packages/atclient/include/atclient/version.h
@@ -1,6 +1,6 @@
 #ifndef ATCLIENT_VERSION_H
 #define ATCLIENT_VERSION_H
 
-#define ATCLIENT_ATSDK_VERSION "0.3.0"
+#define ATCLIENT_ATSDK_VERSION "0.3.1"
 
 #endif

--- a/packages/atclient/src/metadata.c
+++ b/packages/atclient/src/metadata.c
@@ -1,7 +1,8 @@
 #include "atclient/metadata.h"
+#include "atclient/cjson.h"
 #include "atclient/string_utils.h"
 #include "atlogger/atlogger.h"
-#include "cJSON.h"
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -1212,17 +1213,17 @@ int atclient_atkey_metadata_to_protocol_str(const atclient_atkey_metadata *metad
   memset(*metadata_str, 0, sizeof(char) * metadata_str_size);
 
   if (atclient_atkey_metadata_is_ttl_initialized(metadata)) {
-    sprintf((*metadata_str) + pos, ":ttl:%lld", metadata->ttl);
+    sprintf((*metadata_str) + pos, ":ttl:" PRId64, metadata->ttl); // NOLINT(*format-extra-args)
     pos += atclient_atkey_metadata_ttl_strlen(metadata);
   }
 
   if (atclient_atkey_metadata_is_ttb_initialized(metadata)) {
-    sprintf((*metadata_str) + pos, ":ttb:%lld", metadata->ttb);
+    sprintf((*metadata_str) + pos, ":ttb:" PRId64, metadata->ttb); // NOLINT(*format-extra-args)
     pos += atclient_atkey_metadata_ttb_strlen(metadata);
   }
 
   if (atclient_atkey_metadata_is_ttr_initialized(metadata)) {
-    sprintf((*metadata_str) + pos, ":ttr:%lld", metadata->ttr);
+    sprintf((*metadata_str) + pos, ":ttr:" PRId64, metadata->ttr); // NOLINT(*format-extra-args)
     pos += atclient_atkey_metadata_ttr_strlen(metadata);
   }
 

--- a/packages/atclient/src/metadata.c
+++ b/packages/atclient/src/metadata.c
@@ -1213,17 +1213,17 @@ int atclient_atkey_metadata_to_protocol_str(const atclient_atkey_metadata *metad
   memset(*metadata_str, 0, sizeof(char) * metadata_str_size);
 
   if (atclient_atkey_metadata_is_ttl_initialized(metadata)) {
-    sprintf((*metadata_str) + pos, ":ttl:" PRId64, metadata->ttl); // NOLINT(*format-extra-args)
+    sprintf((*metadata_str) + pos, ":ttl:%" PRId64, metadata->ttl);
     pos += atclient_atkey_metadata_ttl_strlen(metadata);
   }
 
   if (atclient_atkey_metadata_is_ttb_initialized(metadata)) {
-    sprintf((*metadata_str) + pos, ":ttb:" PRId64, metadata->ttb); // NOLINT(*format-extra-args)
+    sprintf((*metadata_str) + pos, ":ttb:%" PRId64, metadata->ttb);
     pos += atclient_atkey_metadata_ttb_strlen(metadata);
   }
 
   if (atclient_atkey_metadata_is_ttr_initialized(metadata)) {
-    sprintf((*metadata_str) + pos, ":ttr:" PRId64, metadata->ttr); // NOLINT(*format-extra-args)
+    sprintf((*metadata_str) + pos, ":ttr:%" PRId64, metadata->ttr);
     pos += atclient_atkey_metadata_ttr_strlen(metadata);
   }
 

--- a/packages/atclient/src/notify.c
+++ b/packages/atclient/src/notify.c
@@ -313,7 +313,7 @@ static int generate_cmd(const atclient_notify_params *params, const char *cmdval
   }
 
   if (atclient_notify_params_is_notification_expiry_initialized(params) && params->notification_expiry > 0) {
-    snprintf(cmd + off, cmdsize - off, ":ttln:" PRIu64, params->notification_expiry); // NOLINT(*format-extra-args)
+    snprintf(cmd + off, cmdsize - off, ":ttln:%" PRIu64, params->notification_expiry);
     off += strlen(":ttln:") + atclient_string_utils_long_strlen(params->notification_expiry);
   }
 

--- a/packages/atclient/src/notify.c
+++ b/packages/atclient/src/notify.c
@@ -313,7 +313,7 @@ static int generate_cmd(const atclient_notify_params *params, const char *cmdval
   }
 
   if (atclient_notify_params_is_notification_expiry_initialized(params) && params->notification_expiry > 0) {
-    snprintf(cmd + off, cmdsize - off, ":ttln:%llu", params->notification_expiry);
+    snprintf(cmd + off, cmdsize - off, ":ttln:" PRIu64, params->notification_expiry); // NOLINT(*format-extra-args)
     off += strlen(":ttln:") + atclient_string_utils_long_strlen(params->notification_expiry);
   }
 

--- a/packages/atclient/src/notify_params.c
+++ b/packages/atclient/src/notify_params.c
@@ -340,7 +340,7 @@ int atclient_notify_params_set_notifier(atclient_notify_params *params, const ch
 exit: { return ret; }
 }
 
-int atclient_notify_params_set_notification_expiry(atclient_notify_params *params, const uint64_t notification_expiry) {
+int atclient_notify_params_set_notification_expiry(atclient_notify_params *params, const int64_t notification_expiry) {
   params->notification_expiry = notification_expiry;
   atclient_notify_params_set_notification_expiry_initialized(params, true);
   return 0;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Use `PRId64` as the platform dependent format string for `int64_t`
- Changed some of the `uint64_t` types in structs to `int64_t` (function signatures were `int64_t` but structs were mistakingly `uint64_t`

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: Print int64 types
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
