### PR TITLE
fix: unused notify variables defined in header

### DIFF
--- a/.github/workflows/build_source_tests.yaml
+++ b/.github/workflows/build_source_tests.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [trunk]
 
-permissions:  # added using https://github.com/step-security/secure-repo
+permissions: # added using https://github.com/step-security/secure-repo
   contents: read
 
 jobs:
@@ -23,11 +23,10 @@ jobs:
       - name: Build sample_cmake_project
         working-directory: examples/desktop/sample_cmake_project
         run: |
-          cmake -S . -B build -Datsdk="/usr/local/bin/cmake/atsdk"
+          cmake -S . -B build -Datsdk="/usr/local/bin/cmake/atsdk" -DCMAKE_C_COMPILER=gcc -DCMAKE_C_FLAGS="-Wall -Wextra -Werror-implicit-function-declaration"
           cmake --build build
 
       - name: Run sample_cmake_project executable
         working-directory: examples/desktop/sample_cmake_project
         run: |
           ./build/main
- 

--- a/packages/atclient/CHANGELOG.md
+++ b/packages/atclient/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+- Fix unused include warnings in notify
+
 ## 0.3.1
 
 - **Breaking changes** to `atclient_atkey_metadata` and `atclient_notify_params`

--- a/packages/atclient/include/atclient/notify_params.h
+++ b/packages/atclient/include/atclient/notify_params.h
@@ -51,20 +51,10 @@ enum atclient_notify_operation {
   ATCLIENT_NOTIFY_OPERATION_DELETE
 };
 
-static const char *atclient_notify_operation_str[] = {
-    [ATCLIENT_NOTIFY_OPERATION_UPDATE] = "update",
-    [ATCLIENT_NOTIFY_OPERATION_DELETE] = "delete",
-};
-
 enum atclient_notify_message_type {
   ATCLIENT_NOTIFY_MESSAGE_TYPE_NONE,
   ATCLIENT_NOTIFY_MESSAGE_TYPE_KEY,
   ATCLIENT_NOTIFY_MESSAGE_TYPE_TEXT
-};
-
-static const char *atclient_notify_message_type_str[] = {
-    [ATCLIENT_NOTIFY_MESSAGE_TYPE_KEY] = "key",
-    [ATCLIENT_NOTIFY_MESSAGE_TYPE_TEXT] = "text", // legacy
 };
 
 enum atclient_notify_priority {
@@ -74,21 +64,10 @@ enum atclient_notify_priority {
   ATCLIENT_NOTIFY_PRIORITY_HIGH
 };
 
-static const char *atclient_notify_priority_str[] = {
-    [ATCLIENT_NOTIFY_PRIORITY_LOW] = "low",
-    [ATCLIENT_NOTIFY_PRIORITY_MEDIUM] = "medium",
-    [ATCLIENT_NOTIFY_PRIORITY_HIGH] = "high",
-};
-
 enum atclient_notify_strategy {
   ATCLIENT_NOTIFY_STRATEGY_NONE,
   ATCLIENT_NOTIFY_STRATEGY_ALL,
   ATCLIENT_NOTIFY_STRATEGY_LATEST
-};
-
-static const char *atclient_notify_strategy_str[] = {
-    [ATCLIENT_NOTIFY_STRATEGY_ALL] = "all",
-    [ATCLIENT_NOTIFY_STRATEGY_LATEST] = "latest",
 };
 
 typedef struct atclient_notify_params {

--- a/packages/atclient/include/atclient/version.h
+++ b/packages/atclient/include/atclient/version.h
@@ -1,6 +1,6 @@
 #ifndef ATCLIENT_VERSION_H
 #define ATCLIENT_VERSION_H
 
-#define ATCLIENT_ATSDK_VERSION "0.3.1"
+#define ATCLIENT_ATSDK_VERSION "0.3.2"
 
 #endif

--- a/packages/atclient/src/notify.c
+++ b/packages/atclient/src/notify.c
@@ -20,6 +20,27 @@
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
+static const char *atclient_notify_operation_str[] = {
+    [ATCLIENT_NOTIFY_OPERATION_UPDATE] = "update",
+    [ATCLIENT_NOTIFY_OPERATION_DELETE] = "delete",
+};
+
+static const char *atclient_notify_message_type_str[] = {
+    [ATCLIENT_NOTIFY_MESSAGE_TYPE_KEY] = "key",
+    [ATCLIENT_NOTIFY_MESSAGE_TYPE_TEXT] = "text", // legacy
+};
+
+static const char *atclient_notify_priority_str[] = {
+    [ATCLIENT_NOTIFY_PRIORITY_LOW] = "low",
+    [ATCLIENT_NOTIFY_PRIORITY_MEDIUM] = "medium",
+    [ATCLIENT_NOTIFY_PRIORITY_HIGH] = "high",
+};
+
+static const char *atclient_notify_strategy_str[] = {
+    [ATCLIENT_NOTIFY_STRATEGY_ALL] = "all",
+    [ATCLIENT_NOTIFY_STRATEGY_LATEST] = "latest",
+};
+
 static int generate_cmd(const atclient_notify_params *params, const char *cmdvalue, const size_t cmdvaluelen,
                         char **ocmd, size_t *ocmdolen);
 static size_t calculate_cmd_size(const atclient_notify_params *params, const size_t cmdvaluelen, size_t *atkeyolen,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Moved the static <type>[] wrappers around enums to the .c file

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: unused notify variables defined in header
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
