### PR TITLE
chore: wrap all .h files with extern "C" macros

### DIFF
--- a/examples/desktop/repl/include/repl/args.h
+++ b/examples/desktop/repl/include/repl/args.h
@@ -1,5 +1,8 @@
 #ifndef REPL_ARGS_H
 #define REPL_ARGS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stdint.h>
 
@@ -9,9 +12,9 @@
 #define REPL_ARGS_ROOT_URL_DEFAULT "root.atsign.org:64"
 
 typedef struct repl_args {
-    char *atsign;
-    char *root_url;
-    char *key_file;
+  char *atsign;
+  char *root_url;
+  char *key_file;
 } repl_args;
 
 void repl_args_init(repl_args *args);
@@ -19,4 +22,7 @@ void repl_args_free(repl_args *args);
 
 int repl_args_parse(repl_args *args, const int argc, const char *argv[]);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atchops/include/atchops/aes.h
+++ b/packages/atchops/include/atchops/aes.h
@@ -1,5 +1,8 @@
 #ifndef ATCHOPS_AES_H
 #define ATCHOPS_AES_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stddef.h>
 
@@ -7,7 +10,7 @@ enum atchops_aes_size {
   ATCHOPS_AES_NONE = 0,
   ATCHOPS_AES_128 = 128, // not tested
   ATCHOPS_AES_256 = 256,
-} ;
+};
 
 /**
  * @brief Generate an AES key of size keylen bits
@@ -18,4 +21,7 @@ enum atchops_aes_size {
  */
 int atchops_aes_generate_key(unsigned char *key, const enum atchops_aes_size key_bits);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atchops/include/atchops/aes_ctr.h
+++ b/packages/atchops/include/atchops/aes_ctr.h
@@ -1,5 +1,8 @@
 #ifndef ATCHOPS_AES_CTR_H
 #define ATCHOPS_AES_CTR_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atchops/aes.h"
 #include <stddef.h>
@@ -18,9 +21,9 @@
  * @return int 0 on success
  */
 int atchops_aes_ctr_encrypt(const unsigned char *key, const enum atchops_aes_size key_bits,
-                           unsigned char *iv, // always 16 bytes long
-                           const unsigned char *plaintext, const size_t plaintext_len, unsigned char *ciphertext,
-                           const size_t ciphertext_size, size_t *ciphertext_len);
+                            unsigned char *iv, // always 16 bytes long
+                            const unsigned char *plaintext, const size_t plaintext_len, unsigned char *ciphertext,
+                            const size_t ciphertext_size, size_t *ciphertext_len);
 
 /**
  * @brief AES CTR decrypt ciphertextbase64 to plaintext
@@ -36,12 +39,13 @@ int atchops_aes_ctr_encrypt(const unsigned char *key, const enum atchops_aes_siz
  * @return int 0 on success
  */
 int atchops_aes_ctr_decrypt(const unsigned char *key, const enum atchops_aes_size key_bits,
-                           unsigned char *iv, // always 16 bytes long
-                           const unsigned char *ciphertext, const size_t ciphertext_len, unsigned char *plaintext,
-                           const size_t plaintextsize, size_t *plaintext_len);
+                            unsigned char *iv, // always 16 bytes long
+                            const unsigned char *ciphertext, const size_t ciphertext_len, unsigned char *plaintext,
+                            const size_t plaintextsize, size_t *plaintext_len);
 
 /**
- * @brief Used to calculate the length of the ciphertext buffer given the plaintext length. This is used when encrypting.
+ * @brief Used to calculate the length of the ciphertext buffer given the plaintext length. This is used when
+ * encrypting.
  *
  * @param plaintext_len the length of the plaintext string
  * @return a sufficient length of the ciphertext buffer
@@ -49,11 +53,15 @@ int atchops_aes_ctr_decrypt(const unsigned char *key, const enum atchops_aes_siz
 size_t atchops_aes_ctr_ciphertext_size(const size_t plaintext_len);
 
 /**
- * @brief Used to calculate the a sufficient buffer size of the plaintext buffer given the ciphertext length. This is used when decrypting.
+ * @brief Used to calculate the a sufficient buffer size of the plaintext buffer given the ciphertext length. This is
+ * used when decrypting.
  *
  * @param ciphertext_len the length of the ciphertext string
  * @return a sufficient length of the plaintext buffer
  */
 size_t atchops_aes_ctr_plaintext_size(const size_t ciphertext_len);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atchops/include/atchops/base64.h
+++ b/packages/atchops/include/atchops/base64.h
@@ -1,5 +1,8 @@
 #ifndef ATCHOPS_BASE64_H
 #define ATCHOPS_BASE64_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stddef.h>
 
@@ -13,8 +16,8 @@
  * @param dstlen the length of the result after operation, NULLable if you don't want the length
  * @return int 0 on success
  */
-int atchops_base64_encode(const unsigned char *src, const size_t srcsize, unsigned char *dst,
-                          size_t dstsize, size_t *dstlen);
+int atchops_base64_encode(const unsigned char *src, const size_t srcsize, unsigned char *dst, size_t dstsize,
+                          size_t *dstlen);
 
 /**
  * @brief Base64 decode some bytes
@@ -26,12 +29,12 @@ int atchops_base64_encode(const unsigned char *src, const size_t srcsize, unsign
  * @param dstlen the length of the result after operation, NULLable if you don't want the length
  * @return int 0 on success
  */
-int atchops_base64_decode(const unsigned char *src, const size_t srcsize, unsigned char *dst,
-                          size_t dstsize, size_t *dstlen);
-
+int atchops_base64_decode(const unsigned char *src, const size_t srcsize, unsigned char *dst, size_t dstsize,
+                          size_t *dstlen);
 
 /**
- * @brief calculate the size of the base64 encoded string. This function is usually called before encoding to allocate the optimal buffer size
+ * @brief calculate the size of the base64 encoded string. This function is usually called before encoding to allocate
+ * the optimal buffer size
  *
  * @param plaintextsize the size of the original plain text (to be encoded)
  * @return size_t the output buffer size needed to store the encoded base64 string
@@ -39,11 +42,15 @@ int atchops_base64_decode(const unsigned char *src, const size_t srcsize, unsign
 size_t atchops_base64_encoded_size(const size_t plaintextsize);
 
 /**
- * @brief calculate the size of the base64 decoded string. This function is usually called before decoding to allocate the optimal buffer size
+ * @brief calculate the size of the base64 decoded string. This function is usually called before decoding to allocate
+ * the optimal buffer size
  *
  * @param encodedsize the size of the base64 encoded string (to be decoded)
  * @return size_t the output buffer size needed to store the decoded plain text
  */
 size_t atchops_base64_decoded_size(const size_t encodedsize);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atchops/include/atchops/constants.h
+++ b/packages/atchops/include/atchops/constants.h
@@ -1,6 +1,12 @@
 #ifndef ATCHOPS_CONSTANTS_H
 #define ATCHOPS_CONSTANTS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define ATCHOPS_RNG_PERSONALIZATION "@atchops12345"
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atchops/include/atchops/iv.h
+++ b/packages/atchops/include/atchops/iv.h
@@ -1,5 +1,8 @@
 #ifndef ATCHOPS_IV_H
 #define ATCHOPS_IV_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stddef.h>
 
@@ -13,4 +16,7 @@
  */
 int atchops_iv_generate(unsigned char *iv);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atchops/include/atchops/mbedtls.h
+++ b/packages/atchops/include/atchops/mbedtls.h
@@ -1,5 +1,8 @@
 #ifndef ATCHOPS_MBEDTLS_H
 #define ATCHOPS_MBEDTLS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <mbedtls/aes.h>         // IWYU pragma: export
 #include <mbedtls/asn1.h>        // IWYU pragma: export
@@ -15,4 +18,7 @@
 
 extern const mbedtls_md_type_t atchops_mbedtls_md_map[];
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atchops/include/atchops/rsa.h
+++ b/packages/atchops/include/atchops/rsa.h
@@ -1,5 +1,8 @@
 #ifndef ATCHOPS_RSA_H
 #define ATCHOPS_RSA_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atchops/constants.h"
 #include "atchops/rsa_key.h"
@@ -10,8 +13,8 @@
  * @brief Sign a hashed message with an RSA private key
  *
  * @param private_key the private key struct to use for signing, see atchops_rsa_key_populate_private_key
- * @param md_type the hash type to use, see atchops_md_type, e.g. ATCHOPS_MD_SHA256. The message will be hashed with this
- * algorithm before signing
+ * @param md_type the hash type to use, see atchops_md_type, e.g. ATCHOPS_MD_SHA256. The message will be hashed with
+ * this algorithm before signing
  * @param message the message to sign
  * @param message_len the length of the message, most people use strlen() to find this length
  * @param signature the signature buffer to populate, must be pre-allocated. Signature size will correspond to the
@@ -74,4 +77,7 @@ int atchops_rsa_decrypt(const atchops_rsa_key_private_key *private_key, const un
 int atchops_rsa_generate(atchops_rsa_key_public_key *public_key, atchops_rsa_key_private_key *private_key,
                          const atchops_md_type md_type);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atchops/include/atchops/rsa_key.h
+++ b/packages/atchops/include/atchops/rsa_key.h
@@ -1,11 +1,14 @@
 #ifndef ATCHOPS_RSA_KEY_H
 #define ATCHOPS_RSA_KEY_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stdbool.h>
 #include <stddef.h>
 
 typedef struct atchops_rsa_key_param {
-  size_t len;                    // length of the number in bytes
+  size_t len;                     // length of the number in bytes
   unsigned char *value;           // hex byte array of the number
   bool _is_value_initialized : 1; // whether the value is allocated
 } atchops_rsa_key_param;
@@ -47,17 +50,21 @@ int atchops_rsa_key_private_key_clone(const atchops_rsa_key_private_key *src, at
 
 /**
  * Generate a new RSA-2048 key pair (public and private)
- * 
- * @param public_key_base64 this should be a NULL pointer that will be allocated and populated for you by the function. this buffer will be null-terminated for you.  this will hold the public key in raw bytes.
- * @param private_key_base64 this should be a NULL pointer that will be allocated and populated for you by the function. this buffer will be null-terminated for you. this will hold the private key in base64 encoding.
+ *
+ * @param public_key_base64 this should be a NULL pointer that will be allocated and populated for you by the function.
+ * this buffer will be null-terminated for you.  this will hold the public key in raw bytes.
+ * @param private_key_base64 this should be a NULL pointer that will be allocated and populated for you by the function.
+ * this buffer will be null-terminated for you. this will hold the private key in base64 encoding.
  */
 int atchops_rsa_key_generate_base64(unsigned char **public_key_base64, unsigned char **private_key_base64);
 
 /**
  * @brief Generate a new RSA 2048 key pair (public and private)
- * 
- * @param public_key the public key struct to populate, assumed to be allocated and initialized. initialized via atchops_rsa_key_public_key_init
- * @param private_key the private key struct to populate, assumed to be allocated and initialized. initialized via atchops_rsa_key_private_key_init
+ *
+ * @param public_key the public key struct to populate, assumed to be allocated and initialized. initialized via
+ * atchops_rsa_key_public_key_init
+ * @param private_key the private key struct to populate, assumed to be allocated and initialized. initialized via
+ * atchops_rsa_key_private_key_init
  */
 int atchops_rsa_key_generate(atchops_rsa_key_public_key *public_key, atchops_rsa_key_private_key *private_key);
 
@@ -70,7 +77,7 @@ int atchops_rsa_key_generate(atchops_rsa_key_public_key *public_key, atchops_rsa
  * @return int 0 on success
  */
 int atchops_rsa_key_populate_public_key(atchops_rsa_key_public_key *public_key_struct, const char *public_key_base64,
-                                      const size_t public_key_base64_len);
+                                        const size_t public_key_base64_len);
 
 /**
  * @brief Populate a private key struct from a base64 string
@@ -80,53 +87,64 @@ int atchops_rsa_key_populate_public_key(atchops_rsa_key_public_key *public_key_s
  * @param private_key_base64_len the length of the base64 string
  * @return int 0 on success
  */
-int atchops_rsa_key_populate_private_key(atchops_rsa_key_private_key *private_key_struct, const char *private_key_base64,
-                                       const size_t privatekeprivate_key_base64_lenybase64len);
+int atchops_rsa_key_populate_private_key(atchops_rsa_key_private_key *private_key_struct,
+                                         const char *private_key_base64,
+                                         const size_t privatekeprivate_key_base64_lenybase64len);
 
 bool atchops_rsa_key_is_public_key_populated(const atchops_rsa_key_public_key *public_key);
 bool atchops_rsa_key_is_private_key_populated(const atchops_rsa_key_private_key *private_key);
 
-int atchops_rsa_key_public_key_set_ne(atchops_rsa_key_public_key *public_key, const unsigned char *n, const size_t n_len,
-                                    const unsigned char *e, const size_t e_len);
+int atchops_rsa_key_public_key_set_ne(atchops_rsa_key_public_key *public_key, const unsigned char *n,
+                                      const size_t n_len, const unsigned char *e, const size_t e_len);
 
 bool atchops_rsa_key_public_key_is_n_initialized(const atchops_rsa_key_public_key *public_key);
 void atchops_rsa_key_public_key_set_n_initialized(atchops_rsa_key_public_key *public_key, const bool initialized);
-int atchops_rsa_key_public_key_set_n(atchops_rsa_key_public_key *public_key, const unsigned char *n, const size_t n_len);
+int atchops_rsa_key_public_key_set_n(atchops_rsa_key_public_key *public_key, const unsigned char *n,
+                                     const size_t n_len);
 void atchops_rsa_key_public_key_unset_n(atchops_rsa_key_public_key *public_key);
 
 bool atchops_rsa_key_public_key_is_e_initialized(const atchops_rsa_key_public_key *public_key);
 void atchops_rsa_key_public_key_set_e_initialized(atchops_rsa_key_public_key *public_key, const bool initialized);
-int atchops_rsa_key_public_key_set_e(atchops_rsa_key_public_key *public_key, const unsigned char *e, const size_t e_len);
+int atchops_rsa_key_public_key_set_e(atchops_rsa_key_public_key *public_key, const unsigned char *e,
+                                     const size_t e_len);
 void atchops_rsa_key_public_key_unset_e(atchops_rsa_key_public_key *public_key);
 
 int atchops_rsa_key_private_key_set_nedpq(atchops_rsa_key_private_key *private_key, const unsigned char *n,
-                                        const size_t n_len, const unsigned char *e, const size_t e_len,
-                                        const unsigned char *d, const size_t d_len, const unsigned char *p,
-                                        const size_t p_len, const unsigned char *q, const size_t q_len);
+                                          const size_t n_len, const unsigned char *e, const size_t e_len,
+                                          const unsigned char *d, const size_t d_len, const unsigned char *p,
+                                          const size_t p_len, const unsigned char *q, const size_t q_len);
 
 bool atchops_rsa_key_private_key_is_n_initialized(const atchops_rsa_key_private_key *private_key);
 void atchops_rsa_key_private_key_set_n_initialized(atchops_rsa_key_private_key *private_key, const bool initialized);
-int atchops_rsa_key_private_key_set_n(atchops_rsa_key_private_key *private_key, const unsigned char *n, const size_t n_len);
+int atchops_rsa_key_private_key_set_n(atchops_rsa_key_private_key *private_key, const unsigned char *n,
+                                      const size_t n_len);
 void atchops_rsa_key_private_key_unset_n(atchops_rsa_key_private_key *private_key);
 
 bool atchops_rsa_key_private_key_is_e_initialized(const atchops_rsa_key_private_key *private_key);
 void atchops_rsa_key_private_key_set_e_initialized(atchops_rsa_key_private_key *private_key, const bool initialized);
-int atchops_rsa_key_private_key_set_e(atchops_rsa_key_private_key *private_key, const unsigned char *e, const size_t e_len);
+int atchops_rsa_key_private_key_set_e(atchops_rsa_key_private_key *private_key, const unsigned char *e,
+                                      const size_t e_len);
 void atchops_rsa_key_private_key_unset_e(atchops_rsa_key_private_key *private_key);
 
 bool atchops_rsa_key_private_key_is_d_initialized(const atchops_rsa_key_private_key *private_key);
 void atchops_rsa_key_private_key_set_d_initialized(atchops_rsa_key_private_key *private_key, const bool initialized);
-int atchops_rsa_key_private_key_set_d(atchops_rsa_key_private_key *private_key, const unsigned char *d, const size_t d_len);
+int atchops_rsa_key_private_key_set_d(atchops_rsa_key_private_key *private_key, const unsigned char *d,
+                                      const size_t d_len);
 void atchops_rsa_key_private_key_unset_d(atchops_rsa_key_private_key *private_key);
 
 bool atchops_rsa_key_private_key_is_p_initialized(const atchops_rsa_key_private_key *private_key);
 void atchops_rsa_key_private_key_set_p_initialized(atchops_rsa_key_private_key *private_key, const bool initialized);
-int atchops_rsa_key_private_key_set_p(atchops_rsa_key_private_key *private_key, const unsigned char *p, const size_t p_len);
+int atchops_rsa_key_private_key_set_p(atchops_rsa_key_private_key *private_key, const unsigned char *p,
+                                      const size_t p_len);
 void atchops_rsa_key_private_key_unset_p(atchops_rsa_key_private_key *private_key);
 
 bool atchops_rsa_key_private_key_is_q_initialized(const atchops_rsa_key_private_key *private_key);
 void atchops_rsa_key_private_key_set_q_initialized(atchops_rsa_key_private_key *private_key, const bool initialized);
-int atchops_rsa_key_private_key_set_q(atchops_rsa_key_private_key *private_key, const unsigned char *q, const size_t q_len);
+int atchops_rsa_key_private_key_set_q(atchops_rsa_key_private_key *private_key, const unsigned char *q,
+                                      const size_t q_len);
 void atchops_rsa_key_private_key_unset_q(atchops_rsa_key_private_key *private_key);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atchops/include/atchops/sha.h
+++ b/packages/atchops/include/atchops/sha.h
@@ -1,5 +1,8 @@
 #ifndef ATCHOPS_SHA_H
 #define ATCHOPS_SHA_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <atchops/constants.h>
 #include <stddef.h>
@@ -32,4 +35,7 @@ typedef enum atchops_md_type {
 int atchops_sha_hash(const atchops_md_type md_type, const unsigned char *input, const size_t input_len,
                      unsigned char *output);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atchops/include/atchops/uuid.h
+++ b/packages/atchops/include/atchops/uuid.h
@@ -1,5 +1,8 @@
 #ifndef ATCHOPS_UUID_H
 #define ATCHOPS_UUID_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stddef.h>
 
@@ -19,4 +22,7 @@ int atchops_uuid_init(void);
  */
 int atchops_uuid_generate(char *uuid_str, const size_t uuid_str_len);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/atclient.h
+++ b/packages/atclient/include/atclient/atclient.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_ATCLIENT_H
 #define ATCLIENT_ATCLIENT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atclient/atkey.h"
 #include "atclient/atkeys.h"
@@ -123,10 +126,12 @@ void atclient_stop_atserver_connection(atclient *ctx);
  * @param atsign the atsign the atkeys belong to, this string is assumed to be null terminated
  * @return int 0 on success, non-zero on error
  */
-int atclient_pkam_authenticate(atclient *ctx, const char *atsign, const atclient_atkeys *atkeys, atclient_pkam_authenticate_options *options);
+int atclient_pkam_authenticate(atclient *ctx, const char *atsign, const atclient_atkeys *atkeys,
+                               atclient_pkam_authenticate_options *options);
 
 /**
- * @brief Put a string value into a self key into your atServer. Putting a self key is a private value and is encrypted only for you
+ * @brief Put a string value into a self key into your atServer. Putting a self key is a private value and is encrypted
+ * only for you
  *
  * @param ctx the atclient context, must be initialized with atclient_init() and authenticated via
  * atclient_pkam_authenticate()
@@ -142,7 +147,8 @@ int atclient_put_self_key(atclient *ctx, atclient_atkey *atkey, const char *valu
                           const atclient_put_self_key_request_options *request_options, int *commit_id);
 
 /**
- * @brief Put a string value into a shared key into your atServer. Putting a shared key is a shared value and is encrypted for you and the person you shared it with
+ * @brief Put a string value into a shared key into your atServer. Putting a shared key is a shared value and is
+ * encrypted for you and the person you shared it with
  *
  * @param ctx the atclient context, must be initialized with atclient_init() and authenticated via
  * atclient_pkam_authenticate()
@@ -158,16 +164,21 @@ int atclient_put_shared_key(atclient *ctx, atclient_atkey *atkey, const char *va
                             const atclient_put_shared_key_request_options *request_options, int *commit_id);
 
 /**
- * @brief Put a string value into a public key into your atServer. Putting a public key is a public value and not encrypted
- * 
- * @param ctx the atclient context, must be initialized with atclient_init() and authenticated via atclient_pkam_authenticate()
- * @param atkey the atkey to put the value into, must be initialized with atclient_atkey_init() and have populated values (sharedby, key and optionally namespace)
+ * @brief Put a string value into a public key into your atServer. Putting a public key is a public value and not
+ * encrypted
+ *
+ * @param ctx the atclient context, must be initialized with atclient_init() and authenticated via
+ * atclient_pkam_authenticate()
+ * @param atkey the atkey to put the value into, must be initialized with atclient_atkey_init() and have populated
+ * values (sharedby, key and optionally namespace)
  * @param value the value to put into the atServer, assumed to be non-null and null-terminated
  * @param request_options the options for the put operation, can be NULL if you don't need to set any options
- * @param commit_id the output commit_id of the put operation that the atServer returns, can be NULL if you don't care about the commit_id
+ * @param commit_id the output commit_id of the put operation that the atServer returns, can be NULL if you don't care
+ * about the commit_id
  * @return int 0 on success
  */
-int atclient_put_public_key(atclient *ctx, atclient_atkey *atkey, const char *value, const atclient_put_public_key_request_options *request_options, int *commit_id);
+int atclient_put_public_key(atclient *ctx, atclient_atkey *atkey, const char *value,
+                            const atclient_put_public_key_request_options *request_options, int *commit_id);
 
 /**
  * @brief Get a string value from your atServer.
@@ -182,11 +193,13 @@ int atclient_put_public_key(atclient *ctx, atclient_atkey *atkey, const char *va
  *
  * @param atclient the atclient context (must satisfy the two conditions stated above)
  * @param atkey the populated atkey to get the value from (must satisfy the two conditions stated above)
- * @param value double pointer to hold value gotten from atServer, can be NULL if you don't need the value, if it is non-null, caller is responsible for freeing the memory
+ * @param value double pointer to hold value gotten from atServer, can be NULL if you don't need the value, if it is
+ * non-null, caller is responsible for freeing the memory
  * @param value_len the size of the buffer to hold the value gotten from atServer
  * @return int 0 on success
  */
-int atclient_get_self_key(atclient *atclient, atclient_atkey *atkey, char **value, const atclient_get_self_key_request_options *request_options);
+int atclient_get_self_key(atclient *atclient, atclient_atkey *atkey, char **value,
+                          const atclient_get_self_key_request_options *request_options);
 
 /**
  * @brief Get a publickey from your atServer or another atServer
@@ -201,11 +214,13 @@ int atclient_get_self_key(atclient *atclient, atclient_atkey *atkey, char **valu
  *
  * @param atclient the atclient context (must satisfy the two conditions stated above)
  * @param atkey the populated atkey to get the value from (must satisfy the two conditions stated above)
- * @param value double pointer to hold value gotten from atServer, can be NULL if you don't need the value, if it is non-null, caller is responsible for freeing the memory
+ * @param value double pointer to hold value gotten from atServer, can be NULL if you don't need the value, if it is
+ * non-null, caller is responsible for freeing the memory
  * @param request_options the options for the get operation, can be NULL if you don't need to set any options
  * @return int 0 on success
  */
-int atclient_get_public_key(atclient *atclient, atclient_atkey *atkey, char **value, atclient_get_public_key_request_options *request_options);
+int atclient_get_public_key(atclient *atclient, atclient_atkey *atkey, char **value,
+                            atclient_get_public_key_request_options *request_options);
 
 /**
  * @brief Get a sharedkey either shared by you or shared with you and receive the decrypted plaintext value.
@@ -220,11 +235,13 @@ int atclient_get_public_key(atclient *atclient, atclient_atkey *atkey, char **va
  *
  * @param atclient The atclient context (must satisfy the two conditions stated above)
  * @param atkey The populated atkey to get the value from (must satisfy the two conditions stated above)
- * @param value A pointer that will be allocated for you to hold value gotten from atServer, can be NULL if you don't need the value, if it is non-null, caller is responsible for freeing the memory
+ * @param value A pointer that will be allocated for you to hold value gotten from atServer, can be NULL if you don't
+ * need the value, if it is non-null, caller is responsible for freeing the memory
  * @param request_options The options for the get operation, can be NULL if you don't need to set any options
  * @return int 0 on success
  */
-int atclient_get_shared_key(atclient *atclient, atclient_atkey *atkey, char **value, const atclient_get_shared_key_request_options *request_options);
+int atclient_get_shared_key(atclient *atclient, atclient_atkey *atkey, char **value,
+                            const atclient_get_shared_key_request_options *request_options);
 
 /**
  * @brief Delete an atkey from your atserver
@@ -259,7 +276,8 @@ int atclient_delete(atclient *atclient, const atclient_atkey *atkey, const atcli
  * @param output_array_len (output): the overall size of the array that was allocated
  * @return int 0 on success
  */
-int atclient_get_atkeys(atclient *atclient, atclient_atkey **atkey, size_t *output_array_len, const atclient_get_atkeys_request_options *request_options);
+int atclient_get_atkeys(atclient *atclient, atclient_atkey **atkey, size_t *output_array_len,
+                        const atclient_get_atkeys_request_options *request_options);
 
 /**
  * @brief Send a heartbeat (noop)
@@ -291,4 +309,7 @@ bool atclient_is_connected(atclient *ctx);
  */
 void atclient_set_read_timeout(atclient *ctx, int timeout_ms);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/atclient_utils.h
+++ b/packages/atclient/include/atclient/atclient_utils.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_ATCLIENT_UTILS_H
 #define ATCLIENT_ATCLIENT_UTILS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atclient/atkeys.h"
 
@@ -26,4 +29,7 @@ int atclient_utils_find_atserver_address(const char *atdirectory_host, const int
  */
 int atclient_utils_populate_atkeys_from_homedir(atclient_atkeys *atkeys, const char *atsign);
 
+#ifdef __cplusplus
+}
+#endif
 #endif // ATCLIENT_UTILS_H

--- a/packages/atclient/include/atclient/atkey.h
+++ b/packages/atclient/include/atclient/atkey.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_ATKEY_H
 #define ATCLIENT_ATKEY_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atclient/metadata.h"
 #include <stddef.h>
@@ -52,7 +55,7 @@ void atclient_atkey_init(atclient_atkey *atkey);
 
 /**
  * @brief Clones an atkey struct. The function will allocate new memory on everything
- * 
+ *
  * @param dst the atkey struct to clone to, assumed to be already initialized via atclient_atkey_init
  * @param src the atkey struct to clone from, assumed to be already initialized via atclient_atkey_init
  * @return int 0 on success
@@ -113,8 +116,8 @@ bool atclient_atkey_is_key_initialized(const atclient_atkey *atkey);
  *
  * @param atkey the atkey struct to read
  * @return true, if the namespace_str is initialized and allocated and is safe for reading
- * @return false, if the namespace_str is not initialized and not allocated and is not safe for reading, high chance that
- * it holds garbage
+ * @return false, if the namespace_str is not initialized and not allocated and is not safe for reading, high chance
+ * that it holds garbage
  */
 bool atclient_atkey_is_namespacestr_initialized(const atclient_atkey *atkey);
 
@@ -172,8 +175,8 @@ int atclient_atkey_set_namespace_str(atclient_atkey *atkey, const char *namespac
 int atclient_atkey_set_shared_by(atclient_atkey *atkey, const char *shared_by);
 
 /**
- * @brief Dynamically allocates memory and duplicates shared_with to be stored in the atkey struct. If this is allocated,
- * then it is freed with atclient_atkey_free by the end of life of your struct
+ * @brief Dynamically allocates memory and duplicates shared_with to be stored in the atkey struct. If this is
+ * allocated, then it is freed with atclient_atkey_free by the end of life of your struct
  *
  * @param atkey  (mandatory, NON-NULL) The atkey struct to populate, assumed that this was already initialized via
  * atclient_atkey_init
@@ -201,7 +204,8 @@ void atclient_atkey_unset_namespace_str(atclient_atkey *atkey);
 
 /**
  * @brief Free the memory allocated for the shared_by in the atkey struct. This is already called by atclient_atkey_free
- * and should only be used for advanced pruposes, if you want to free the shared_by before the end of life of your struct
+ * and should only be used for advanced pruposes, if you want to free the shared_by before the end of life of your
+ * struct
  *
  * @param atkey the atkey struct that holds the allocated atkey->shared_by memory
  */
@@ -235,7 +239,8 @@ atclient_atkey_type atclient_atkey_get_type(const atclient_atkey *atkey);
  * @param namespace_str the namespace of your application, e.g. "banking_app" (NULLABLE)
  * @return int 0 on success
  */
-int atclient_atkey_create_public_key(atclient_atkey *atkey, const char *name, const char *shared_by, const char *namespace_str);
+int atclient_atkey_create_public_key(atclient_atkey *atkey, const char *name, const char *shared_by,
+                                     const char *namespace_str);
 
 /**
  * @brief Populate an atkey struct representing a SelfKey AtKey with null terminated strings. An example of a SelfKey
@@ -248,13 +253,14 @@ int atclient_atkey_create_public_key(atclient_atkey *atkey, const char *name, co
  * @param namespace_str the namespace of your application, e.g. "banking_app" (NULLABLE)
  * @return int 0 on success
  */
-int atclient_atkey_create_self_key(atclient_atkey *atkey, const char *name, const char *shared_by, const char *namespace_str);
+int atclient_atkey_create_self_key(atclient_atkey *atkey, const char *name, const char *shared_by,
+                                   const char *namespace_str);
 
 /**
  * @brief Populate an atkey struct representing a SharedKey AtKey given null terminated strings. An example of a
- * SharedKey AtKey would be '@shared_with:name.namesapce@shared_by'. SharedKeys can only be accessible by the shared_with
- * and shared_by atsigns, as they are encrypted with a shared AES key which is encrypted with the each of their RSA keys.
- * Be sure to call the atclient_atkey_init function before calling this function.
+ * SharedKey AtKey would be '@shared_with:name.namesapce@shared_by'. SharedKeys can only be accessible by the
+ * shared_with and shared_by atsigns, as they are encrypted with a shared AES key which is encrypted with the each of
+ * their RSA keys. Be sure to call the atclient_atkey_init function before calling this function.
  *
  * @param atkey the atkey struct to populate, assumed that this was already initialized via atclient_atkey_init
  * @param name name of your key, e.g. "name"
@@ -264,6 +270,9 @@ int atclient_atkey_create_self_key(atclient_atkey *atkey, const char *name, cons
  * @return int 0 on success
  */
 int atclient_atkey_create_shared_key(atclient_atkey *atkey, const char *name, const char *shared_by,
-                                    const char *shared_with, const char *namespace_str);
+                                     const char *shared_with, const char *namespace_str);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/atkeys.h
+++ b/packages/atclient/include/atclient/atkeys.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_ATKEYS_H
 #define ATCLIENT_ATKEYS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atchops/rsa_key.h"
 #include "atclient/atkeys_file.h"
@@ -178,4 +181,7 @@ int atclient_atkeys_write_to_atkeys_file(atclient_atkeys *atkeys, atclient_atkey
 
 int atclient_atkeys_write_to_path(atclient_atkeys *atkeys, const char *path);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/atkeys_file.h
+++ b/packages/atclient/include/atclient/atkeys_file.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_ATKEYS_FILE_H
 #define ATCLIENT_ATKEYS_FILE_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -78,8 +81,9 @@ int atclient_atkeys_file_from_string(atclient_atkeys_file *atkeys_file, const ch
 
 /**
  * @brief Write the struct to a file.
- * 
- * @param atkeys_file the struct to be written to the file, assumed to be NON-NULL and initialized with atclient_atkeys_file_init
+ *
+ * @param atkeys_file the struct to be written to the file, assumed to be NON-NULL and initialized with
+ * atclient_atkeys_file_init
  * @param path  Example "$HOME/.atsign/keys/@alice_key.atKeys"
  */
 int atclient_atkeys_file_write_to_path(atclient_atkeys_file *atkeys_file, const char *path);
@@ -120,4 +124,7 @@ int atclient_atkeys_file_set_apkam_symmetric_key_str(atclient_atkeys_file *atkey
 int atclient_atkeys_file_set_enrollment_id_str(atclient_atkeys_file *atkeys_file, const char *enrollment_id_str,
                                                const size_t enrollment_id_str_len);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/atnotification.h
+++ b/packages/atclient/include/atclient/atnotification.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_ATNOTIFICATION_H
 #define ATCLIENT_ATNOTIFICATION_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atclient/cjson.h"
 #include <stdbool.h>
@@ -49,24 +52,24 @@
  */
 typedef struct atclient_atnotification {
   // _initalizedfields[0]
-  char *id;           // holds notification id, typically a 36 + 1 null terminated string
-  char *from;         // holds the from atSign (who sent the notification)
-  char *to;           // holds the to atSign (who the notification is for)
-  char *key;          // holds the key of the notification (e.g. "@bob:location.app@alice")
-  char *value;        // holds the value that is read from the notification, this would typically be base64 encoded and
-                      // encrypted, see decrypted_value for the decrypted value
-  char *operation;    // holds the operation of the notification (e.g. "update", "delete")
+  char *id;            // holds notification id, typically a 36 + 1 null terminated string
+  char *from;          // holds the from atSign (who sent the notification)
+  char *to;            // holds the to atSign (who the notification is for)
+  char *key;           // holds the key of the notification (e.g. "@bob:location.app@alice")
+  char *value;         // holds the value that is read from the notification, this would typically be base64 encoded and
+                       // encrypted, see decrypted_value for the decrypted value
+  char *operation;     // holds the operation of the notification (e.g. "update", "delete")
   size_t epoch_millis; // holds the epoch time in milliseconds when the notification was sent
   char *message_type;  // holds the message type of the notification (e.g. "data", "error")
 
   // _initalizedfields[1]
   bool is_encrypted : 1;
   char *enc_key_name;     // in metaData
-  char *enc_algo;        // in metaData
-  char *iv_nonce;        // in metaData
-  char *ske_enc_key_name;  // in metaData
+  char *enc_algo;         // in metaData
+  char *iv_nonce;         // in metaData
+  char *ske_enc_key_name; // in metaData
   char *ske_enc_algo;     // in metaData
-  char *decrypted_value; // if is_encrypted, this will be the decrypted value
+  char *decrypted_value;  // if is_encrypted, this will be the decrypted value
 
   uint8_t _initialized_fields[2];
 } atclient_atnotification;
@@ -147,4 +150,7 @@ int atclient_atnotification_set_ske_enc_key_name(atclient_atnotification *notifi
 int atclient_atnotification_set_ske_enc_algo(atclient_atnotification *notification, const char *ske_enc_algo);
 int atclient_atnotification_set_decrypted_value(atclient_atnotification *notification, const char *decrypted_value);
 
+#ifdef __cplusplus
+}
+#endif
 #endif // ATCLIENT_ATNOTIFICATION_H

--- a/packages/atclient/include/atclient/cacerts.h
+++ b/packages/atclient/include/atclient/cacerts.h
@@ -10,6 +10,9 @@
 
 #ifndef ATCLIENT_CACERTS_H
 #define ATCLIENT_CACERTS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // ISRG Root X1
 // ============
@@ -209,4 +212,7 @@
   "S9VWqHB73Q+OyIVvIbKYcSc2w/aSuFKGSA==\r\n"                                                                           \
   "-----END CERTIFICATE-----\r\n"
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/cjson.h
+++ b/packages/atclient/include/atclient/cjson.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_CJSON_H
 #define ATCLIENT_CJSON_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #if defined(CONFIG_IDF_TARGET_ESP32)
 #include <cjson.h> // IWYU pragma: export
@@ -7,4 +10,7 @@
 #include <cJSON.h> // IWYU pragma: export
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -1,8 +1,11 @@
 #ifndef ATCLIENT_CONNECTION_H
 #define ATCLIENT_CONNECTION_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-#include "atclient/connection_hooks.h"
 #include "atchops/mbedtls.h"
+#include "atclient/connection_hooks.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -15,10 +18,10 @@ typedef enum atclient_connection_type {
 typedef struct atclient_connection {
   atclient_connection_type type; // set in atclient_connection_init
 
-  bool _is_host_initialized: 1;
+  bool _is_host_initialized : 1;
   char *host; // example: "root.atsign.org"
 
-  bool _is_port_initialized: 1;
+  bool _is_port_initialized : 1;
   uint16_t port; // example: 64
 
   // atclient_connection_connect sets this to true and atclient_connection_disconnect sets this to false
@@ -26,7 +29,7 @@ typedef struct atclient_connection {
   // once, at some  point, check atclient_connection_is_connected for a live status on the connection
   // _is_connection_enabled also serves as an internal boolean to check if the following mbedlts contexts have been
   // initialized and need to be freed at the end
-  bool _is_connection_enabled: 1;
+  bool _is_connection_enabled : 1;
   mbedtls_net_context net;
   mbedtls_ssl_context ssl;
   mbedtls_ssl_config ssl_config;
@@ -34,7 +37,7 @@ typedef struct atclient_connection {
   mbedtls_entropy_context entropy;
   mbedtls_ctr_drbg_context ctr_drbg;
 
-  bool _is_hooks_enabled: 1;
+  bool _is_hooks_enabled : 1;
   atclient_connection_hooks *hooks;
 } atclient_connection;
 
@@ -69,12 +72,15 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
  * @brief Reads data from the connection
  *
  * @param ctx the connection initialized and connected using atclient_connection_init and atclient_connection_connect
- * @param value a double pointer that will be allocated by the function to the data read, assumed to be non-null and a null pointer
- * @param value_len the length of the data read, will be set by the function, setting this to NULL will skip setting the length
+ * @param value a double pointer that will be allocated by the function to the data read, assumed to be non-null and a
+ * null pointer
+ * @param value_len the length of the data read, will be set by the function, setting this to NULL will skip setting the
+ * length
  * @param value_max_len the maximum length of the data to read, setting this to 0 means no limit
  * @return int 0 on success
  */
-int atclient_connection_read(atclient_connection *ctx, unsigned char **value, size_t *value_len, const size_t value_max_len);
+int atclient_connection_read(atclient_connection *ctx, unsigned char **value, size_t *value_len,
+                             const size_t value_max_len);
 
 /**
  * @brief Write data to the connection
@@ -118,4 +124,7 @@ int atclient_connection_disconnect(atclient_connection *ctx);
  */
 bool atclient_connection_is_connected(atclient_connection *ctx);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/connection_hooks.h
+++ b/packages/atclient/include/atclient/connection_hooks.h
@@ -1,9 +1,12 @@
 #ifndef ATCLIENT_CONNECTION_HOOKS_H
 #define ATCLIENT_CONNECTION_HOOKS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdbool.h>
 
 #define VALUE_INITIALIZED 0b00000001
 
@@ -52,12 +55,15 @@ void atclient_connection_hooks_disable(struct atclient_connection *conn);
 
 // Q. Why is hook a void pointer?
 // A. In case we want to add future hook types which use a different function signature
-int atclient_connection_hooks_set(struct atclient_connection *ctx, const atclient_connection_hook_type type, void *hook);
+int atclient_connection_hooks_set(struct atclient_connection *ctx, const atclient_connection_hook_type type,
+                                  void *hook);
 
 bool atclient_connection_hooks_is_pre_read_initialized(const struct atclient_connection *ctx);
 bool atclient_connection_hooks_is_post_read_initialized(const struct atclient_connection *ctx);
 bool atclient_connection_hooks_is_pre_write_initialized(const struct atclient_connection *ctx);
 bool atclient_connection_hooks_is_post_write_initialized(const struct atclient_connection *ctx);
 
-
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/constants.h
+++ b/packages/atclient/include/atclient/constants.h
@@ -1,11 +1,14 @@
 #ifndef ATCLIENT_CONSTANTS_H
 #define ATCLIENT_CONSTANTS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define ATCLIENT_ATDIRECTORY_PRODUCTION_HOST "root.atsign.org"
 #define ATCLIENT_ATDIRECTORY_PRODUCTION_PORT 64
 
-#define ATCLIENT_ATSIGN_INNER_LEN 55                                                             // 55 utf7 chars
-#define ATCLIENT_ATSIGN_FULL_LEN (1 + ATCLIENT_ATSIGN_INNER_LEN)                                 // '@' + 55 utf7 chars
+#define ATCLIENT_ATSIGN_INNER_LEN 55                             // 55 utf7 chars
+#define ATCLIENT_ATSIGN_FULL_LEN (1 + ATCLIENT_ATSIGN_INNER_LEN) // '@' + 55 utf7 chars
 
 #define ATCLIENT_CLIENT_READ_TIMEOUT_MS 3 * 1000  // 3 seconds to time out if no data is available
 #define ATCLIENT_MONITOR_READ_TIMEOUT_MS 3 * 1000 // 3 seconds to time out if no data is available
@@ -97,4 +100,7 @@
 #define CRESET "\e[0m"
 #define COLOR_RESET "\e[0m"
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/encryption_key_helpers.h
+++ b/packages/atclient/include/atclient/encryption_key_helpers.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_ENCRYPTION_KEY_HELPERS_H
 #define ATCLIENT_ENCRYPTION_KEY_HELPERS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atclient/atclient.h"
 #include "atclient/atkey.h"
@@ -62,7 +65,9 @@ int atclient_get_shared_encryption_key_shared_by_other(atclient *ctx, const char
  * @return int 0 on success, error otherwise
  */
 int atclient_create_shared_encryption_key_pair_for_me_and_other(
-    atclient *atclient, const char *shared_with,
-    unsigned char *shared_encryption_key_shared_by_me_with_other);
+    atclient *atclient, const char *shared_with, unsigned char *shared_encryption_key_shared_by_me_with_other);
 
+#ifdef __cplusplus
+}
+#endif
 #endif // ATCLIENT_ENCRYPTION_KEY_HELPERS_H

--- a/packages/atclient/include/atclient/mbedtls.h
+++ b/packages/atclient/include/atclient/mbedtls.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_MBEDTLS_H
 #define ATCLIENT_MBEDTLS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <mbedtls/ctr_drbg.h>
 #include <mbedtls/entropy.h>
@@ -7,4 +10,7 @@
 #include <mbedtls/ssl.h>
 #include <mbedtls/threading.h>
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/metadata.h
+++ b/packages/atclient/include/atclient/metadata.h
@@ -1,6 +1,8 @@
-
 #ifndef ATCLIENT_METADATA_H
 #define ATCLIENT_METADATA_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atclient/cjson.h"
 #include <stdbool.h>
@@ -412,4 +414,7 @@ int atclient_atkey_metadata_set_ske_enc_algo(atclient_atkey_metadata *metadata, 
  */
 void atclient_atkey_metadata_free(atclient_atkey_metadata *metadata);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_MONITOR_H
 #define ATCLIENT_MONITOR_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atclient/atclient.h"
 #include "atclient/atnotification.h"
@@ -149,4 +152,7 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
  */
 bool atclient_monitor_is_connected(atclient *monitor_conn);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/notify.h
+++ b/packages/atclient/include/atclient/notify.h
@@ -1,9 +1,15 @@
 #ifndef ATCLIENT_NOTIFY_H
 #define ATCLIENT_NOTIFY_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atclient/atclient.h"
 #include "atclient/notify_params.h"
 
 int atclient_notify(atclient *ctx, const atclient_notify_params *params, char **notification_id);
 
+#ifdef __cplusplus
+}
+#endif
 #endif // ATCLIENT_NOTIFY_H

--- a/packages/atclient/include/atclient/notify_params.h
+++ b/packages/atclient/include/atclient/notify_params.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_NOTIFY_PARAMS_H
 #define ATCLIENT_NOTIFY_PARAMS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atclient/atkey.h"
 #include <stdint.h>
@@ -146,4 +149,7 @@ void atclient_notify_params_unset_notifier(atclient_notify_params *params);
 void atclient_notify_params_unset_notification_expiry(atclient_notify_params *params);
 void atclient_notify_params_unset_shared_encryption_key(atclient_notify_params *params);
 
+#ifdef __cplusplus
+}
+#endif
 #endif // ATCLIENT_NOTIFY_PARAMS_H

--- a/packages/atclient/include/atclient/request_options.h
+++ b/packages/atclient/include/atclient/request_options.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_REQUEST_OPTIONS_H
 #define ATCLIENT_REQUEST_OPTIONS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -244,25 +247,34 @@ int atclient_get_atkeys_request_options_set_show_hidden(atclient_get_atkeys_requ
 void atclient_get_atkeys_request_options_unset_show_hidden(atclient_get_atkeys_request_options *options);
 
 /*
-* 5. AtClient_PKAM_Authenticate Options
-*/
+ * 5. AtClient_PKAM_Authenticate Options
+ */
 void atclient_pkam_authenticate_options_init(atclient_pkam_authenticate_options *options);
 void atclient_pkam_authenticate_options_free(atclient_pkam_authenticate_options *options);
 
-bool atclient_pkam_authenticate_options_is_atdirectory_host_initialized(const atclient_pkam_authenticate_options *options);
-int atclient_pkam_authenticate_options_set_at_directory_host(atclient_pkam_authenticate_options *options, char *atdirectory_host);
+bool atclient_pkam_authenticate_options_is_atdirectory_host_initialized(
+    const atclient_pkam_authenticate_options *options);
+int atclient_pkam_authenticate_options_set_at_directory_host(atclient_pkam_authenticate_options *options,
+                                                             char *atdirectory_host);
 void atclient_pkam_authenticate_options_unset_at_directory_host(atclient_pkam_authenticate_options *options);
 
-bool atclient_pkam_authenticate_options_is_atdirectory_port_initialized(const atclient_pkam_authenticate_options *options);
-int atclient_pkam_authenticate_options_set_at_directory_port(atclient_pkam_authenticate_options *options, int atdirectory_port);
+bool atclient_pkam_authenticate_options_is_atdirectory_port_initialized(
+    const atclient_pkam_authenticate_options *options);
+int atclient_pkam_authenticate_options_set_at_directory_port(atclient_pkam_authenticate_options *options,
+                                                             int atdirectory_port);
 void atclient_pkam_authenticate_options_unset_at_directory_port(atclient_pkam_authenticate_options *options);
 
 bool atclient_pkam_authenticate_options_is_atserver_host_initialized(const atclient_pkam_authenticate_options *options);
-int atclient_pkam_authenticate_options_set_atserver_host(atclient_pkam_authenticate_options *options, char *atserver_host);
+int atclient_pkam_authenticate_options_set_atserver_host(atclient_pkam_authenticate_options *options,
+                                                         char *atserver_host);
 void atclient_pkam_authenticate_options_unset_atserver_host(atclient_pkam_authenticate_options *options);
 
 bool atclient_pkam_authenticate_options_is_atserver_port_initialized(const atclient_pkam_authenticate_options *options);
-int atclient_pkam_authenticate_options_set_atserver_port(atclient_pkam_authenticate_options *options, int atserver_port);
+int atclient_pkam_authenticate_options_set_atserver_port(atclient_pkam_authenticate_options *options,
+                                                         int atserver_port);
 void atclient_pkam_authenticate_options_unset_atserver_port(atclient_pkam_authenticate_options *options);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/string_utils.h
+++ b/packages/atclient/include/atclient/string_utils.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_STRINGUTILS_H
 #define ATCLIENT_STRINGUTILS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -82,4 +85,7 @@ int atclient_string_utils_long_strlen(long n);
  */
 int atclient_string_utils_int64_strlen(int64_t n);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atclient/include/atclient/version.h
+++ b/packages/atclient/include/atclient/version.h
@@ -1,6 +1,12 @@
 #ifndef ATCLIENT_VERSION_H
 #define ATCLIENT_VERSION_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define ATCLIENT_ATSDK_VERSION "0.3.2"
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/packages/atlogger/include/atlogger/atlogger.h
+++ b/packages/atlogger/include/atlogger/atlogger.h
@@ -1,5 +1,8 @@
 #ifndef ATCLIENT_ATLOGGER_H
 #define ATCLIENT_ATLOGGER_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stddef.h>
 
@@ -21,4 +24,7 @@ void atlogger_set_opts(int opts);
 void atlogger_log(const char *tag, const enum atlogger_logging_level level, const char *format, ...);
 void atlogger_fix_stdout_buffer(char *str, const size_t strlen);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/tests/functional_tests/lib/include/functional_tests/config.h
+++ b/tests/functional_tests/lib/include/functional_tests/config.h
@@ -1,5 +1,8 @@
 #ifndef FUNCTIONAL_TESTS_CONFIG_H
 #define FUNCTIONAL_TESTS_CONFIG_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include <stddef.h>
 
@@ -19,6 +22,10 @@
  * @param pathlen the output length of the path
  * @return int, 0 on success
  */
-int functional_tests_get_atkeys_path(const char *atsign, const size_t atsignlen, char *path, const size_t pathsize, size_t *pathlen);
+int functional_tests_get_atkeys_path(const char *atsign, const size_t atsignlen, char *path, const size_t pathsize,
+                                     size_t *pathlen);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/tests/functional_tests/lib/include/functional_tests/helpers.h
+++ b/tests/functional_tests/lib/include/functional_tests/helpers.h
@@ -1,5 +1,8 @@
 #ifndef FUNCTIONAL_TESTS_HELPERS_H
 #define FUNCTIONAL_TESTS_HELPERS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "atclient/atclient.h"
 #include <stddef.h>
@@ -9,8 +12,11 @@ int functional_tests_pkam_auth(atclient *atclient, atclient_atkeys *atkeys, cons
 int functional_tests_publickey_exists(atclient *atclient, const char *key, const char *shared_by,
                                       const char *knamespace);
 int functional_tests_selfkey_exists(atclient *atclient, const char *key, const char *shared_by, const char *knamespace);
-int functional_tests_sharedkey_exists(atclient *atclient, const char *key, const char *shared_by, const char *shared_with,
-                                      const char *knamespace);
-int functional_tests_tear_down_sharedenckeys(atclient *atclient, const char *recipient);                                      
+int functional_tests_sharedkey_exists(atclient *atclient, const char *key, const char *shared_by,
+                                      const char *shared_with, const char *knamespace);
+int functional_tests_tear_down_sharedenckeys(atclient *atclient, const char *recipient);
 
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added extern C macros to all header files in the project.

**- How I did it**

**- How to verify it**

- **Enable ignore whitespace for the review**
  > a bunch of those files were not following our standard formatting rules

- I checked to see that the macros were well formed, but I couldn't find any
  clear information as to what is allowed inside them... I'm not sure how the
  linker resolves includes and defines inside the extern block, nor do I have a
  C++ project to test.

**- Description for the changelog**
chore: wrap all .h files with extern "C" macros
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
