### PR TITLE
feat: atclient_pkam_authenticate now supports staging root

### DIFF
--- a/examples/desktop/repl/src/main.c
+++ b/examples/desktop/repl/src/main.c
@@ -133,12 +133,12 @@ static int set_up_pkam_auth_options(atclient_authenticate_options *pkam_authenti
       goto exit;
     }
 
-    if ((ret = atclient_authenticate_options_set_at_directory_host(pkam_authenticate_options, root_host)) != 0) {
+    if ((ret = atclient_authenticate_options_set_atdirectory_host(pkam_authenticate_options, root_host)) != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set at directory host\n");
       goto exit;
     }
 
-    if ((ret = atclient_authenticate_options_set_at_directory_port(pkam_authenticate_options, root_port)) != 0) {
+    if ((ret = atclient_authenticate_options_set_atdirectory_port(pkam_authenticate_options, root_port)) != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set at directory port\n");
       goto exit;
     }

--- a/packages/atclient/include/atclient/request_options.h
+++ b/packages/atclient/include/atclient/request_options.h
@@ -39,12 +39,12 @@ extern "C" {
 #define ATCLIENT_GET_ATKEYS_REQUEST_OPTIONS_REGEX_INITIALIZED (VALUE_INITIALIZED << 0)
 #define ATCLIENT_GET_ATKEYS_REQUEST_OPTIONS_SHOW_HIDDEN_INITIALIZED (VALUE_INITIALIZED << 1)
 
-#define ATCLIENT_AUTHENTICATE_OPTIONS_AT_DIRECTORY_HOST_INDEX 0
-#define ATCLIENT_AUTHENTICATE_OPTIONS_AT_DIRECTORY_PORT_INDEX 0
+#define ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INDEX 0
+#define ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INDEX 0
 #define ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INDEX 0
 #define ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INDEX 0
-#define ATCLIENT_AUTHENTICATE_OPTIONS_AT_DIRECTORY_HOST_INITIALIZED (VALUE_INITIALIZED << 0)
-#define ATCLIENT_AUTHENTICATE_OPTIONS_AT_DIRECTORY_PORT_INITIALIZED (VALUE_INITIALIZED << 1)
+#define ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INITIALIZED (VALUE_INITIALIZED << 0)
+#define ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INITIALIZED (VALUE_INITIALIZED << 1)
 #define ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INITIALIZED (VALUE_INITIALIZED << 2)
 #define ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INITIALIZED (VALUE_INITIALIZED << 3)
 
@@ -260,12 +260,12 @@ void atclient_authenticate_options_init(atclient_authenticate_options *options);
 void atclient_authenticate_options_free(atclient_authenticate_options *options);
 
 bool atclient_authenticate_options_is_atdirectory_host_initialized(const atclient_authenticate_options *options);
-int atclient_authenticate_options_set_at_directory_host(atclient_authenticate_options *options, char *atdirectory_host);
-void atclient_authenticate_options_unset_at_directory_host(atclient_authenticate_options *options);
+int atclient_authenticate_options_set_atdirectory_host(atclient_authenticate_options *options, char *atdirectory_host);
+void atclient_authenticate_options_unset_atdirectory_host(atclient_authenticate_options *options);
 
 bool atclient_authenticate_options_is_atdirectory_port_initialized(const atclient_authenticate_options *options);
-int atclient_authenticate_options_set_at_directory_port(atclient_authenticate_options *options, int atdirectory_port);
-void atclient_authenticate_options_unset_at_directory_port(atclient_authenticate_options *options);
+int atclient_authenticate_options_set_atdirectory_port(atclient_authenticate_options *options, int atdirectory_port);
+void atclient_authenticate_options_unset_atdirectory_port(atclient_authenticate_options *options);
 
 bool atclient_authenticate_options_is_atserver_host_initialized(const atclient_authenticate_options *options);
 int atclient_authenticate_options_set_atserver_host(atclient_authenticate_options *options, char *atserver_host);

--- a/packages/atclient/src/request_options.c
+++ b/packages/atclient/src/request_options.c
@@ -9,16 +9,34 @@
 
 #define TAG "request_options"
 
-// default param values for ATCLIENT PKAM AUTHENTICATE OPTIONS
-#define ATCLIENT_AUTHENTICATE_DEFAULT_ROOT_SERVER_HOST "root.atsign.org"
-#define ATCLIENT_AUTHENTICATE_DEFAULT_ROOT_SERVER_PORT 64
+/*
+ * 1A. Put Self Key
+ */
+static void atclient_get_self_key_request_options_set_store_atkey_metadata_initialized(
+    atclient_get_self_key_request_options *options, const bool initialized);
 
+/*
+ * 1B. Put SharedKey
+ */
 static void atclient_put_shared_key_request_options_set_shared_encryption_key_initialized(
     atclient_put_shared_key_request_options *options, const bool initialized);
 static void atclient_put_shared_key_request_options_set_iv_initialized(atclient_put_shared_key_request_options *options,
                                                                        const bool initialized);
+
+/*
+ * 1C. Put PublicKey
+ */
+// empty for now
+
+/*
+ * 2A. Get SelfKey
+ */
 static void atclient_get_self_key_request_options_set_store_atkey_metadata_initialized(
     atclient_get_self_key_request_options *options, const bool initialized);
+
+/*
+ * 2B. Get SharedKey
+ */
 static void atclient_get_shared_key_request_options_set_shared_encryption_key_initialized(
     atclient_get_shared_key_request_options *options, const bool initialized);
 static void atclient_get_shared_key_request_options_set_iv_initialized(atclient_get_shared_key_request_options *options,
@@ -28,19 +46,49 @@ atclient_get_shared_key_request_options_set_bypass_cache_initialized(atclient_ge
                                                                      const bool initialized);
 static void atclient_get_shared_key_request_options_set_store_atkey_metadata_initialized(
     atclient_get_shared_key_request_options *options, const bool initialized);
+
+/*
+ * 2C. Get PublicKey
+ */
 static void
 atclient_get_public_key_request_options_set_bypass_cache_initialized(atclient_get_public_key_request_options *options,
                                                                      const bool initialized);
 static void atclient_get_public_key_request_options_set_store_atkey_metadata_initialized(
     atclient_get_public_key_request_options *options, const bool initialized);
+
+/*
+ * 3. Delete
+ */
+static void
+atclient_delete_request_options_set_skip_shared_by_check_intitialized(atclient_delete_request_options *options,
+                                                                      const bool initialized);
+
+/*
+ * 4. Get AtKeys
+ */
 static void atclient_get_atkeys_request_options_set_regex_initialized(atclient_get_atkeys_request_options *options,
                                                                       const bool initialized);
 static void
 atclient_get_atkeys_request_options_set_show_hidden_initialized(atclient_get_atkeys_request_options *options,
                                                                 const bool initialized);
+
+/*
+ * 5. Authenticate Request Options
+ */
 static void
-atclient_delete_request_options_skip_shared_by_check_set_intitialized(atclient_delete_request_options *options,
-                                                                      const bool initialized);
+atclient_authenticate_options_set_atdirectory_host_initialized(atclient_authenticate_options *options,
+                                                                       const bool initialized);
+
+static void
+atclient_authenticate_options_set_atdirectory_port_initialized(atclient_authenticate_options *options,
+                                                                       const bool initialized);
+
+static void atclient_authenticate_options_set_atserver_host_initialized(atclient_authenticate_options *options,
+                                                                                const bool initialized);
+
+static void atclient_authenticate_options_set_atserver_port_initialized(atclient_authenticate_options *options,
+                                                                                const bool initialized);
+
 /*
  * =================
  * 1A. Put SelfKey
@@ -1226,8 +1274,8 @@ void atclient_delete_request_options_free(atclient_delete_request_options *optio
   }
 
   /*
-  * 2. Reset the value
-  */
+   * 2. Reset the value
+   */
   if (atclient_delete_request_options_is_skip_shared_by_check_flag_initialized(options)) {
     atclient_delete_request_options_unset_skip_shared_by_check(options);
   }
@@ -1252,7 +1300,7 @@ bool atclient_delete_request_options_is_skip_shared_by_check_flag_initialized(
 }
 
 static void
-atclient_delete_request_options_skip_shared_by_check_set_intitialized(atclient_delete_request_options *options,
+atclient_delete_request_options_set_skip_shared_by_check_intitialized(atclient_delete_request_options *options,
                                                                       const bool initialized) {
   /*
    * 1. Validate arguments
@@ -1296,8 +1344,8 @@ void atclient_delete_request_options_set_skip_shared_by_check(atclient_delete_re
   /*
    * 3. Set value and set intiliazed to true
    */
-   memcpy(&(options->skip_shared_by_check), &option, sizeof(option));
-  atclient_delete_request_options_skip_shared_by_check_set_intitialized(options, true);
+  memcpy(&(options->skip_shared_by_check), &option, sizeof(option));
+  atclient_delete_request_options_set_skip_shared_by_check_intitialized(options, true);
 }
 
 void atclient_delete_request_options_unset_skip_shared_by_check(atclient_delete_request_options *options) {
@@ -1311,7 +1359,7 @@ void atclient_delete_request_options_unset_skip_shared_by_check(atclient_delete_
   }
 
   options->skip_shared_by_check = false;
-  atclient_delete_request_options_skip_shared_by_check_set_intitialized(options, false);
+  atclient_delete_request_options_set_skip_shared_by_check_intitialized(options, false);
 }
 
 void atclient_get_atkeys_request_options_init(atclient_get_atkeys_request_options *options) {
@@ -1551,8 +1599,8 @@ void atclient_get_atkeys_request_options_unset_show_hidden(atclient_get_atkeys_r
 
 void atclient_authenticate_options_init(atclient_authenticate_options *options) {
   memset(options, 0, sizeof(atclient_authenticate_options));
-  options->atdirectory_host = ATCLIENT_AUTHENTICATE_DEFAULT_ROOT_SERVER_HOST;
-  options->atdirectory_port = ATCLIENT_AUTHENTICATE_DEFAULT_ROOT_SERVER_PORT;
+  options->atdirectory_host = ATCLIENT_ATDIRECTORY_PRODUCTION_HOST;
+  options->atdirectory_port = ATCLIENT_ATDIRECTORY_PRODUCTION_PORT;
   options->atserver_host = NULL;
   options->atserver_port = 0;
 }
@@ -1571,11 +1619,11 @@ void atclient_authenticate_options_free(atclient_authenticate_options *options) 
    */
 
   if (atclient_authenticate_options_is_atdirectory_host_initialized(options)) {
-    atclient_authenticate_options_unset_at_directory_host(options);
+    atclient_authenticate_options_unset_atdirectory_host(options);
   }
 
   if (atclient_authenticate_options_is_atdirectory_port_initialized(options)) {
-    atclient_authenticate_options_unset_at_directory_port(options);
+    atclient_authenticate_options_unset_atdirectory_port(options);
   }
 
   if (atclient_authenticate_options_is_atserver_host_initialized(options)) {
@@ -1601,8 +1649,8 @@ bool atclient_authenticate_options_is_atdirectory_host_initialized(const atclien
   /*
    * 2. Check if the at directory host is initialized
    */
-  return options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_AT_DIRECTORY_HOST_INDEX] &
-         ATCLIENT_AUTHENTICATE_OPTIONS_AT_DIRECTORY_HOST_INITIALIZED;
+  return options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INDEX] &
+         ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INITIALIZED;
 }
 
 bool atclient_authenticate_options_is_atdirectory_port_initialized(const atclient_authenticate_options *options) {
@@ -1619,8 +1667,8 @@ bool atclient_authenticate_options_is_atdirectory_port_initialized(const atclien
   /*
    * Check if the at directory port is initialized
    */
-  return options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_AT_DIRECTORY_PORT_INDEX] &
-         ATCLIENT_AUTHENTICATE_OPTIONS_AT_DIRECTORY_PORT_INITIALIZED;
+  return options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INDEX] &
+         ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INITIALIZED;
 }
 
 bool atclient_authenticate_options_is_atserver_host_initialized(const atclient_authenticate_options *options) {
@@ -1659,34 +1707,36 @@ bool atclient_authenticate_options_is_atserver_port_initialized(const atclient_a
          ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INITIALIZED;
 }
 
-void atclient_authenticate_options_unset_at_directory_host(atclient_authenticate_options *options) {
+void atclient_authenticate_options_unset_atdirectory_host(atclient_authenticate_options *options) {
   /*
    * 1. Validate arguments
    */
   if (options == NULL) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_unset_at_directory_host: Invalid arguments\n");
+                 "atclient_authenticate_options_unset_atdirectory_host: Invalid arguments\n");
     return;
   }
 
   /*
    * 2. Unsetat directory   */
-  if (atclient_authenticate_options_is_atdirectory_host_initialized(options)) {
+  if (atclient_authenticate_options_is_atdirectory_host_initialized(options) && options->atdirectory_host != NULL) {
     free(options->atdirectory_host);
   }
   options->atdirectory_host = NULL;
+  atclient_authenticate_options_set_atdirectory_host_initialized(options, false);
 }
 
-void atclient_authenticate_options_unset_at_directory_port(atclient_authenticate_options *options) {
+void atclient_authenticate_options_unset_atdirectory_port(atclient_authenticate_options *options) {
   /*
    * 1. Validate arguments
    */
   if (options == NULL) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_unset_at_directory_port: Invalid arguments\n");
+                 "atclient_authenticate_options_unset_atdirectory_port: Invalid arguments\n");
     return;
   }
-  options->atdirectory_port = 64;
+  options->atdirectory_port = ATCLIENT_ATDIRECTORY_PRODUCTION_PORT;
+  atclient_authenticate_options_set_atdirectory_port_initialized(options, false);
 }
 
 void atclient_authenticate_options_unset_atserver_host(atclient_authenticate_options *options) {
@@ -1702,10 +1752,11 @@ void atclient_authenticate_options_unset_atserver_host(atclient_authenticate_opt
   /*
    * 2. Unset atserver host
    */
-  if (atclient_authenticate_options_is_atserver_host_initialized(options)) {
+  if (atclient_authenticate_options_is_atserver_host_initialized(options) && options->atserver_host != NULL) {
     free(options->atserver_host);
   }
   options->atserver_host = NULL;
+  atclient_authenticate_options_set_atserver_host_initialized(options, false);
 }
 
 void atclient_authenticate_options_unset_atserver_port(atclient_authenticate_options *options) {
@@ -1718,9 +1769,10 @@ void atclient_authenticate_options_unset_atserver_port(atclient_authenticate_opt
     return;
   }
   options->atserver_port = 0;
+  atclient_authenticate_options_set_atserver_port_initialized(options, false);
 }
 
-int atclient_authenticate_options_set_at_directory_host(atclient_authenticate_options *options,
+int atclient_authenticate_options_set_atdirectory_host(atclient_authenticate_options *options,
                                                         char *atdirectory_host) {
   int ret = 1;
 
@@ -1730,7 +1782,7 @@ int atclient_authenticate_options_set_at_directory_host(atclient_authenticate_op
   if (options == NULL) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_set_at_directory_host: Invalid arguments\n");
+                 "atclient_authenticate_options_set_atdirectory_host: Invalid arguments\n");
     return ret;
   }
 
@@ -1738,19 +1790,34 @@ int atclient_authenticate_options_set_at_directory_host(atclient_authenticate_op
    * 2. Unset at directory host, if initialized
    */
   if (atclient_authenticate_options_is_atdirectory_host_initialized(options)) {
-    atclient_authenticate_options_unset_at_directory_host(options);
+    atclient_authenticate_options_unset_atdirectory_host(options);
   }
 
   /*
    * 3. Set at directory host
    */
-  options->atdirectory_host = atdirectory_host;
+  const size_t atdirectory_host_size = strlen(atdirectory_host) + 1;
+  if ((options->atdirectory_host = (char *)malloc(sizeof(char) * atdirectory_host_size)) == NULL) {
+    ret = 1;
+    atlogger_log(
+        TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+        "atclient_authenticate_options_set_atdirectory_host: Failed to allocate memory for at directory host\n");
+    goto exit;
+  }
+
+  atclient_authenticate_options_set_atdirectory_host_initialized(options, true);
+
+  const size_t atdirectory_host_len = strlen(atdirectory_host);
+  memcpy(options->atdirectory_host, atdirectory_host, atdirectory_host_len);
+  options->atdirectory_host[atdirectory_host_len] = '\0';
+
+
   ret = 0;
   goto exit;
 exit: { return ret; }
 }
 
-int atclient_authenticate_options_set_at_directory_port(atclient_authenticate_options *options, int atdirectory_port) {
+int atclient_authenticate_options_set_atdirectory_port(atclient_authenticate_options *options, int atdirectory_port) {
   int ret = 1;
 
   /*
@@ -1759,7 +1826,7 @@ int atclient_authenticate_options_set_at_directory_port(atclient_authenticate_op
   if (options == NULL) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_set_at_directory_port: Invalid arguments\n");
+                 "atclient_authenticate_options_set_atdirectory_port: Invalid arguments\n");
     return ret;
   }
 
@@ -1767,13 +1834,14 @@ int atclient_authenticate_options_set_at_directory_port(atclient_authenticate_op
    * 2. Unset at directory port, if initialized
    */
   if (atclient_authenticate_options_is_atdirectory_port_initialized(options)) {
-    atclient_authenticate_options_unset_at_directory_host(options);
+    atclient_authenticate_options_unset_atdirectory_host(options);
   }
 
   /*
    * 3. Set at directory port
    */
   options->atdirectory_port = atdirectory_port;
+  atclient_authenticate_options_set_atdirectory_port_initialized(options, true);
   ret = 0;
   goto exit;
 exit: { return ret; }
@@ -1802,7 +1870,19 @@ int atclient_authenticate_options_set_atserver_host(atclient_authenticate_option
   /*
    * 3. Set atserver host
    */
-  options->atserver_host = atserver_host;
+  const size_t atserver_host_size = strlen(atserver_host) + 1;
+  if((options->atserver_host = (char *)malloc(sizeof(char) * atserver_host_size)) == NULL) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "atclient_authenticate_options_set_atserver_host: Failed to allocate memory for atserver host\n");
+    return ret;
+  }
+
+  const size_t atserver_host_len = strlen(atserver_host);
+  memcpy(options->atserver_host, atserver_host, atserver_host_len);
+  options->atserver_host[atserver_host_len] = '\0';
+
+  atclient_authenticate_options_set_atserver_host_initialized(options, true);
 
   ret = 0;
   goto exit;
@@ -1834,9 +1914,102 @@ int atclient_authenticate_options_set_atserver_port(atclient_authenticate_option
    * 3. Set atserver port
    */
   options->atserver_port = atserver_port;
+  atclient_authenticate_options_set_atserver_port_initialized(options, true);
 
   ret = 0;
   goto exit;
 
 exit: { return ret; }
+}
+
+static void atclient_authenticate_options_set_atdirectory_host_initialized(atclient_authenticate_options *options,
+                                                                           const bool initialized) {
+  /*
+   * 1. Validate arguments
+   */
+  if (options == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_authenticate_options_set_atdirectory_host_initialized: "
+                                                    "Invalid arguments\n");
+    return;
+  }
+
+  /*
+   * 2. Set the at directory host initialized
+   */
+  if (initialized) {
+    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INDEX] |=
+        ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INITIALIZED;
+  } else {
+    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INDEX] &=
+        ~ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INITIALIZED;
+  }
+}
+
+static void atclient_authenticate_options_set_atdirectory_port_initialized(atclient_authenticate_options *options,
+                                                                           const bool initialized) {
+  /*
+   * 1. Validate arguments
+   */
+  if (options == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_authenticate_options_set_atdirectory_port_initialized: "
+                                                    "Invalid arguments\n");
+    return;
+  }
+
+  /*
+   * 2. Set the at directory port initialized
+   */
+  if (initialized) {
+    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INDEX] |=
+        ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INITIALIZED;
+  } else {
+    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INDEX] &=
+        ~ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INITIALIZED;
+  }
+}
+
+static void atclient_authenticate_options_set_atserver_host_initialized(atclient_authenticate_options *options,
+                                                                        const bool initialized) {
+  /*
+   * 1. Validate arguments
+   */
+  if (options == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_authenticate_options_set_atserver_host_initialized: "
+                                                    "Invalid arguments\n");
+    return;
+  }
+
+  /*
+   * 2. Set the atserver host initialized
+   */
+  if (initialized) {
+    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INDEX] |=
+        ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INITIALIZED;
+  } else {
+    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INDEX] &=
+        ~ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INITIALIZED;
+  }
+}
+
+static void atclient_authenticate_options_set_atserver_port_initialized(atclient_authenticate_options *options,
+                                                                        const bool initialized) {
+  /*
+   * 1. Validate arguments
+   */
+  if (options == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_authenticate_options_set_atserver_port_initialized: "
+                                                    "Invalid arguments\n");
+    return;
+  }
+
+  /*
+   * 2. Set the atserver port initialized
+   */
+  if (initialized) {
+    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INDEX] |=
+        ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INITIALIZED;
+  } else {
+    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INDEX] &=
+        ~ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INITIALIZED;
+  }
 }


### PR DESCRIPTION
closes #414 

**- What I did**
- `atclient_pkam_authenticate` in `atclient.c` will now read the `atclient_authenticate_options *options` parameter for a different atdirectory host and port to look up an atSign's atServer address.
- Fixed up `atclient_authenticate_options`'s initialization functions
- Refactored `at_directory` to be `atdirectory`
- Removed prod host and port constants in `request_options.c` and use the ones in `constants.h` instead

**- How to verify it**

Code (C)

```c
#include <atclient/atclient.h>
#include <atlogger/atlogger.h>

#define PLAYGROUND_ATSIGN "@alice🛠"
#define PLAYGROUND_ROOT_DOMAIN "vip.ve.atsign.zone"
#define PLAYGROUND_ROOT_PORT 64
#define PLAYGROUND_ATSIGN_KEY_PATH "/home/jeremy/.atsign/keys/@alice🛠_key.atKeys"

#define TAG "main"

int main() {
  int ret = 1;

  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);

  atclient_atkeys atkeys;
  atclient_atkeys_init(&atkeys);

  atclient_authenticate_options options;
  atclient_authenticate_options_init(&options);

  atclient atclient;
  atclient_init(&atclient);

  if ((ret = atclient_authenticate_options_set_atdirectory_host(&options, PLAYGROUND_ROOT_DOMAIN)) != 0) {
    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set at directory host");
    goto exit;
  }

  if ((ret = atclient_authenticate_options_set_atdirectory_port(&options, PLAYGROUND_ROOT_PORT)) != 0) {
    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set at directory port");
    goto exit;
  }

  if ((ret = atclient_atkeys_populate_from_path(&atkeys, PLAYGROUND_ATSIGN_KEY_PATH)) != 0) {
    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to populate atkeys from path");
    goto exit;
  }

  if ((ret = atclient_pkam_authenticate(&atclient, PLAYGROUND_ATSIGN, &atkeys, &options)) != 0) {
    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to authenticate");
    goto exit;
  }

  ret = 0;

exit: {
  // free everything
  atclient_atkeys_free(&atkeys);
  atclient_authenticate_options_free(&options);
  atclient_free(&atclient);
  return ret;
}
}
```

Output

```sh
jeremy@atsign:~/GitHub/at_c_fix/examples/desktop/playground$ ./build/main 
[INFO] 2024-12-05 20:40:39.523714 | atclient | Missing atServer host or port. Using vip.ve.atsign.zone:64 atDirectory to find atServer address
[INFO] 2024-12-05 20:40:39.533183 | connection | Connected
[DEBG] 2024-12-05 20:40:39.575777 | connection |        SENT: "alice🛠"
[DEBG] 2024-12-05 20:40:39.576170 | connection |        RECV: "vip.ve.atsign.zone:25000"
[INFO] 2024-12-05 20:40:39.586311 | connection | Connected
[DEBG] 2024-12-05 20:40:39.628738 | connection |        SENT: "from:alice🛠"
[DEBG] 2024-12-05 20:40:39.630528 | connection |        RECV: "data:_08315aa1-659a-4e4e-99c3-828f893b2883@alice🛠:3c1dcba1-9808-4e95-98a3-49a179b08deb"
[DEBG] 2024-12-05 20:40:39.641785 | connection |        SENT: "pkam:JK04e/fglVmo3J1M6yKxxl+ehJseAGdOJhXisjM3bBOqwFdDSI2SnZkCWFZnOP7Zerlnjm64+8ey915VPynv2m8DRVYB2YOTYEI/lo3hXsKdN3ATSNlOI4WhvszV0rfU2SXJMeXzgvutmTenr4jNBx7EJW6DgxTKbAdHeBbECwPVyaPbrSgWag6g1Qi7MiMhWJCoIEU3CdAYPwAxc1VRpcus1+Hi249wST5ukPbMhe4ZIN934Io97pBBI7NAPcXZVFV9kB6yCKAgjmZJYWpMb674bbuRZA3IIMQ3iwxmrI1pmpXmY6QrGvcsvJ5rksQPFK0/Z6lHA+XqPawloYfYKw=="
[DEBG] 2024-12-05 20:40:39.643669 | connection |        RECV: "data:success"
```

**- Description for the changelog**
feat: atclient_pkam_authenticate now supports staging root 
