### PR TITLE
chore: allow tests to be overridden at build time with different atSigns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,11 @@ message(STATUS "Building atauth")
 set(ATAUTH_BUILD_TESTS ${ATSDK_BUILD_TESTS})
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/packages/atauth)
 
+if(${ATSDK_BUILD_TESTS})
+  message(STATUS "Building functional tests")
+  add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/tests/functional_tests)
+endif()
+
 if(NOT ESP_PLATFORM)
   # install dependencies
   set(

--- a/packages/atchops/tests/CMakeLists.txt
+++ b/packages/atchops/tests/CMakeLists.txt
@@ -1,12 +1,22 @@
+option(FIRST_ATSIGN "First atSign used for all functional tests")
+if(${FIRST_ATSIGN})
+  add_compile_definitions(FIRST_ATSIGN)
+endif()
+
+option(SECOND_ATSIGN "Second atSign for two-way atSign functional tests")
+if(${SECOND_ATSIGN})
+  add_compile_definitions(SECOND_ATSIGN)
+endif()
+
 # loop through every .c file in this directory
 file(GLOB_RECURSE files ${CMAKE_CURRENT_LIST_DIR}/test_*.c)
 
 foreach(file ${files})
-    # ${filename} - without `.c`
-    get_filename_component(filename ${file} NAME)
-    string(REPLACE ".c" "" filename ${filename})
+  # ${filename} - without `.c`
+  get_filename_component(filename ${file} NAME)
+  string(REPLACE ".c" "" filename ${filename})
 
-    add_executable(${filename} ${file})
-    target_link_libraries(${filename} PRIVATE atchops atlogger)
-    add_test(NAME ${filename} COMMAND $<TARGET_FILE:${filename}>)
+  add_executable(${filename} ${file})
+  target_link_libraries(${filename} PRIVATE atchops atlogger)
+  add_test(NAME ${filename} COMMAND $<TARGET_FILE:${filename}>)
 endforeach()

--- a/packages/atchops/tests/test_aes_generate.c
+++ b/packages/atchops/tests/test_aes_generate.c
@@ -1,9 +1,9 @@
 #include "atchops/aes.h"
 #include "atchops/aes_ctr.h"
 #include "atchops/iv.h"
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
-#include <stddef.h>
 
 #define PLAINTEXT "Hello World!\n"
 
@@ -33,16 +33,15 @@ int main() {
     goto exit;
   }
   // log the key
-  printf("key (%d): ", keysize);
+  printf("key (%zu): ", keysize);
   for (size_t i = 0; i < keysize; i++) {
     printf("%02x ", key[i]);
   }
   printf("\n");
 
-
   memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_BUFFER_SIZE);
-  ret = atchops_aes_ctr_encrypt(key, ATCHOPS_AES_256, iv, (const unsigned char *)PLAINTEXT,
-                               strlen(PLAINTEXT), ciphertext, ciphertextsize, &ciphertextlen);
+  ret = atchops_aes_ctr_encrypt(key, ATCHOPS_AES_256, iv, (const unsigned char *)PLAINTEXT, strlen(PLAINTEXT),
+                                ciphertext, ciphertextsize, &ciphertextlen);
   if (ret != 0) {
     printf("Error encrypting\n");
     goto exit;
@@ -55,28 +54,28 @@ int main() {
   }
 
   // log ciphertext bytes
-  printf("ciphertext (%d): ", ciphertextlen);
+  printf("ciphertext (%zu): ", ciphertextlen);
   for (size_t i = 0; i < ciphertextlen; i++) {
     printf("%02x ", ciphertext[i]);
   }
   printf("\n");
 
   memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_BUFFER_SIZE);
-  ret = atchops_aes_ctr_decrypt(key, ATCHOPS_AES_256, iv, ciphertext, ciphertextlen,
-                               plaintext2, plaintext2size, &plaintext2len);
+  ret = atchops_aes_ctr_decrypt(key, ATCHOPS_AES_256, iv, ciphertext, ciphertextlen, plaintext2, plaintext2size,
+                                &plaintext2len);
   if (ret != 0) {
     printf("Error decrypting\n");
     goto exit;
   }
 
   // log plaintext2 bytes
-  printf("plaintext2 (%d): ", plaintext2len);
+  printf("plaintext2 (%zu): ", plaintext2len);
   for (size_t i = 0; i < plaintext2len; i++) {
     printf("%02x ", plaintext2[i]);
   }
   printf("\n");
 
-  if(strcmp(PLAINTEXT, (char *)plaintext2) != 0) {
+  if (strcmp(PLAINTEXT, (char *)plaintext2) != 0) {
     printf("plaintext2 is \"%.*s\" when it should be \"%s\"\n", (int)plaintext2len, plaintext2, PLAINTEXT);
     ret = 1;
     goto exit;

--- a/packages/atchops/tests/test_aesctr.c
+++ b/packages/atchops/tests/test_aesctr.c
@@ -1,10 +1,10 @@
 #include "atchops/aes_ctr.h"
 #include "atchops/base64.h"
 #include "atchops/iv.h"
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stddef.h>
 
 #define PLAINTEXT "I like to eat pizza 123"
 #define AESKEY_BASE64 "1DPU9OP3CYvamnVBMwGgL7fm8yB1klAap0Uc5Z9R79g="
@@ -32,22 +32,22 @@ int main() {
   unsigned char iv[ATCHOPS_IV_BUFFER_SIZE];
   memset(iv, 0, sizeof(unsigned char) * ATCHOPS_IV_BUFFER_SIZE);
 
-  ret = atchops_base64_decode(AESKEY_BASE64, strlen(AESKEY_BASE64), key, keysize, &keylen);
-  if(ret != 0) {
+  ret = atchops_base64_decode((unsigned char *)AESKEY_BASE64, strlen(AESKEY_BASE64), key, keysize, &keylen);
+  if (ret != 0) {
     printf("atchops_base64_decode (failed): %d\n", ret);
     goto exit;
   }
 
-  ret = atchops_aes_ctr_encrypt(key, ATCHOPS_AES_256, iv, (unsigned char *) PLAINTEXT,
-                               strlen(PLAINTEXT), ciphertext, ciphertextsize, &ciphertextlen);
+  ret = atchops_aes_ctr_encrypt((unsigned char *)key, ATCHOPS_AES_256, iv, (unsigned char *)PLAINTEXT,
+                                strlen(PLAINTEXT), ciphertext, ciphertextsize, &ciphertextlen);
   if (ret != 0) {
     printf("atchops_aes_ctr_encrypt (failed): %d\n", ret);
     goto exit;
   }
 
   memset(iv, 0, sizeof(unsigned char) * 16);
-  ret = atchops_aes_ctr_decrypt(key, ATCHOPS_AES_256, iv, ciphertext, ciphertextlen, plaintext2,
-                               plaintext2size, &plaintext2len);
+  ret = atchops_aes_ctr_decrypt((unsigned char *)key, ATCHOPS_AES_256, iv, ciphertext, ciphertextlen, plaintext2,
+                                plaintext2size, &plaintext2len);
   if (ret != 0) {
     printf("atchops_aes_ctr_decrypt (failed): %d\n", ret);
     goto exit;
@@ -55,7 +55,5 @@ int main() {
 
   goto exit;
 
-exit: {
-  return ret;
-}
+exit: { return ret; }
 }

--- a/packages/atchops/tests/test_aesctr_decrypt.c
+++ b/packages/atchops/tests/test_aesctr_decrypt.c
@@ -1,10 +1,10 @@
 #include "atchops/aes_ctr.h"
-#include "atchops/iv.h"
 #include "atchops/base64.h"
+#include "atchops/iv.h"
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stddef.h>
 
 #define CIPHERTEXTBASE64                                                                                               \
   "yY9vOA8bbzyADNGOxFPdT6bGxySKmNd6usP5/"                                                                              \
@@ -56,27 +56,27 @@ int main() {
   size_t keylen = 0;
 
   unsigned char *iv = malloc(sizeof(unsigned char) * ATCHOPS_IV_BUFFER_SIZE);
-  if(iv == NULL) {
+  if (iv == NULL) {
     printf("malloc (failed): %d\n", ret);
     goto exit;
   }
   memset(iv, 0, ATCHOPS_IV_BUFFER_SIZE); // keys in the atKeys file are encrypted with AES with IV {0} * 16
 
-  ret = atchops_base64_decode(CIPHERTEXTBASE64, strlen(CIPHERTEXTBASE64), ciphertext, ciphertextsize, &ciphertextlen);
-  if(ret != 0) {
+  ret = atchops_base64_decode((unsigned char *)CIPHERTEXTBASE64, strlen(CIPHERTEXTBASE64), ciphertext, ciphertextsize,
+                              &ciphertextlen);
+  if (ret != 0) {
     printf("atchops_base64_decode (failed): %d\n", ret);
     goto exit;
   }
 
-  ret = atchops_base64_decode(AESKEYBASE64, strlen(AESKEYBASE64), key, 32, &keylen);
-  if(ret != 0) {
+  ret = atchops_base64_decode((unsigned char *)AESKEYBASE64, strlen(AESKEYBASE64), key, 32, &keylen);
+  if (ret != 0) {
     printf("atchops_base64_decode (failed): %d\n", ret);
     goto exit;
   }
 
-  ret = atchops_aes_ctr_decrypt(key, ATCHOPS_AES_256, iv,
-                              ciphertext, ciphertextlen,
-                              plaintext, plaintextsize, &plaintextlen);
+  ret = atchops_aes_ctr_decrypt(key, ATCHOPS_AES_256, iv, ciphertext, ciphertextlen, plaintext, plaintextsize,
+                                &plaintextlen);
   if (ret != 0) {
     printf("atchops_aes_ctr_decrypt (failed): %d\n", ret);
     goto exit;
@@ -90,7 +90,7 @@ int main() {
   printf("decrypted text: %.*s\n", (int)plaintextlen, plaintext);
 
   printf("decrypted bytes:\n");
-  for (int i = 0; i < plaintextlen && i < plaintextsize; i++) {
+  for (size_t i = 0; i < plaintextlen && i < plaintextsize; i++) {
     printf("%02x ", *(plaintext + i));
   }
   printf("\n");

--- a/packages/atchops/tests/test_iv.c
+++ b/packages/atchops/tests/test_iv.c
@@ -1,9 +1,9 @@
 #include "atchops/iv.h"
+#include <atlogger/atlogger.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <atlogger/atlogger.h>
 
 #define TAG "test_iv"
 
@@ -18,9 +18,9 @@ int main() {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to generate IV\n");
     goto exit;
   }
-  
+
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "IV (%d bytes): ", ivsize);
-  for (int i = 0; i < ivsize; i++) {
+  for (size_t i = 0; i < ivsize; i++) {
     printf("%02x ", iv[i]);
   }
   printf("\n");

--- a/tests/functional_tests/CMakeLists.txt
+++ b/tests/functional_tests/CMakeLists.txt
@@ -1,12 +1,24 @@
+option(FIRST_ATSIGN "First atSign used for all functional tests" OFF)
+if(NOT "${FIRST_ATSIGN}" STREQUAL OFF)
+  message("Functional tests override first atsign: ${FIRST_ATSIGN}")
+  add_compile_definitions(FIRST_ATSIGN=${FIRST_ATSIGN})
+endif()
+
+option(SECOND_ATSIGN "Second atSign for two-way atSign functional tests" OFF)
+if(NOT "${SECOND_ATSIGN}" STREQUAL OFF)
+  message("Functional tests override second atsign: ${SECOND_ATSIGN}")
+  add_compile_definitions(SECOND_ATSIGN=${SECOND_ATSIGN})
+endif()
+
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_C_STANDARD 99)
 
 project(
-    functional_tests
-    VERSION 0.0.1
-    DESCRIPTION "Functional tests for atsdk"
-    HOMEPAGE_URL https://atsign.com
-    LANGUAGES C
+  functional_tests
+  VERSION 0.0.1
+  DESCRIPTION "Functional tests for atsdk"
+  HOMEPAGE_URL https://atsign.com
+  LANGUAGES C
 )
 
 find_package(atsdk CONFIG REQUIRED)
@@ -18,15 +30,18 @@ enable_testing()
 file(GLOB_RECURSE files ${CMAKE_CURRENT_LIST_DIR}/tests/*test_*.c)
 
 foreach(file ${files})
-    # ${filename} - without `.c`
-    get_filename_component(filename ${file} NAME)
-    string(REPLACE ".c" "" filename ${filename})
+  # ${filename} - without `.c`
+  get_filename_component(filename ${file} NAME)
+  string(REPLACE ".c" "" filename ${filename})
 
-    add_executable(${filename} ${file})
-    target_include_directories(${filename} PRIVATE ${CMAKE_CURRENT_LIST_DIR}/tests/)
-    target_link_libraries(${filename} PRIVATE atsdk::atclient atsdk::functional_tests_lib)
-    add_test(
-        NAME ${filename}
-        COMMAND ${filename}
-    )
+  add_executable(${filename} ${file})
+  target_include_directories(
+    ${filename}
+    PRIVATE ${CMAKE_CURRENT_LIST_DIR}/tests/
+  )
+  target_link_libraries(
+    ${filename}
+    PRIVATE atsdk::atclient atsdk::functional_tests_lib
+  )
+  add_test(NAME ${filename} COMMAND ${filename})
 endforeach()

--- a/tests/functional_tests/config.json
+++ b/tests/functional_tests/config.json
@@ -1,8 +1,7 @@
-
-
 {
-    "rootHost": "root.atsign.org",
-    "rootPort": 64,
-    "firstAtSign": "@12alpaca",
-    "secondAtSign": "@12snowboating"
+  "rootHost": "root.atsign.org",
+  "rootPort": 64,
+  "firstAtSign": "@12alpaca",
+  "secondAtSign": "@12snowboating"
 }
+

--- a/tests/functional_tests/lib/CMakeLists.txt
+++ b/tests/functional_tests/lib/CMakeLists.txt
@@ -1,31 +1,25 @@
 # check if subdirectory
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-    set(FUNCTIONAL_TESTS_LIB_SUBDIRECTORY FALSE)
+  set(FUNCTIONAL_TESTS_LIB_SUBDIRECTORY FALSE)
 else()
-    set(FUNCTIONAL_TESTS_LIB_SUBDIRECTORY TRUE)
+  set(FUNCTIONAL_TESTS_LIB_SUBDIRECTORY TRUE)
 endif()
 
-set(FUNCTIONAL_TESTS_LIB_SOURCES
-    ${CMAKE_CURRENT_LIST_DIR}/src/config.c
-    ${CMAKE_CURRENT_LIST_DIR}/src/helpers.c
+set(
+  FUNCTIONAL_TESTS_LIB_SOURCES
+  ${CMAKE_CURRENT_LIST_DIR}/src/config.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/helpers.c
 )
 
-set(FUNCTIONAL_TESTS_LIB_INCLUDE_DIRS
-    ${CMAKE_CURRENT_LIST_DIR}/include
+set(FUNCTIONAL_TESTS_LIB_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/include)
+
+add_library(functional_tests_lib STATIC ${FUNCTIONAL_TESTS_LIB_SOURCES})
+
+target_include_directories(
+  functional_tests_lib
+  PUBLIC ${FUNCTIONAL_TESTS_LIB_INCLUDE_DIRS}
 )
 
-add_library(functional_tests_lib STATIC
-    ${FUNCTIONAL_TESTS_LIB_SOURCES}
-)
-
-target_include_directories(functional_tests_lib
-    PUBLIC
-    ${FUNCTIONAL_TESTS_LIB_INCLUDE_DIRS}
-)
-
-target_link_libraries(functional_tests_lib
-    PUBLIC
-    atsdk::atclient
-)
+target_link_libraries(functional_tests_lib PUBLIC atsdk::atclient)
 
 add_library(atsdk::functional_tests_lib ALIAS functional_tests_lib)

--- a/tests/functional_tests/lib/include/functional_tests/config.h
+++ b/tests/functional_tests/lib/include/functional_tests/config.h
@@ -9,8 +9,13 @@ extern "C" {
 #define ROOT_HOST "root.atsign.org"
 #define ROOT_PORT 64
 
+#ifndef FIRST_ATSIGN
 #define FIRST_ATSIGN "@12alpaca"
+#endif
+
+#ifndef SECOND_ATSIGN
 #define SECOND_ATSIGN "@12snowboating"
+#endif
 
 /**
  * @brief Get the atkeys file path for the given atSign.

--- a/tests/functional_tests/tests/test_atclient_get_atkeys.c
+++ b/tests/functional_tests/tests/test_atclient_get_atkeys.c
@@ -1,5 +1,6 @@
 #include <atclient/atclient.h>
 #include <atlogger/atlogger.h>
+#include <functional_tests/config.h>
 #include <functional_tests/helpers.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -9,7 +10,7 @@
 
 #define SCAN_REGEX ".*"
 
-#define ATSIGN1 "@12alpaca"
+#define ATSIGN1 FIRST_ATSIGN
 
 static int test_1_atclient_get_atkeys(atclient *ctx, const char *scan_regex, const bool showhidden);
 static int test_2_atclient_get_atkeys_null(atclient *ctx, const char *scan_regex, const bool showhidden);
@@ -47,12 +48,12 @@ int main() {
     goto exit;
   }
 
-  if((ret = test_3_atclient_get_atkeys_null_ctx(SCAN_REGEX, false)) != 0) {
+  if ((ret = test_3_atclient_get_atkeys_null_ctx(SCAN_REGEX, false)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_3_atclient_get_atkeys_null_ctx failed: %d", ret);
     goto exit;
   }
 
-  if((ret = test_4_atclient_get_atkeys_null_regex(&atclient1, SCAN_REGEX, false)) != 0) {
+  if ((ret = test_4_atclient_get_atkeys_null_regex(&atclient1, SCAN_REGEX, false)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_4_atclient_get_atkeys_null_regex failed: %d", ret);
     goto exit;
   }
@@ -79,7 +80,7 @@ static int test_1_atclient_get_atkeys(atclient *ctx, const char *scan_regex, con
     goto exit;
   }
 
-  for(size_t i = 0; i < atkey_array_len; i++) {
+  for (size_t i = 0; i < atkey_array_len; i++) {
     char *atkeystr = NULL;
     atclient_atkey_to_string(&atkey_array[i], &atkeystr);
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "atkey_array[%zu]: %s\n", i, atkeystr);
@@ -119,8 +120,7 @@ exit: {
 }
 }
 
-static int test_3_atclient_get_atkeys_null_ctx(const char *scan_regex, const bool showhidden)
-{
+static int test_3_atclient_get_atkeys_null_ctx(const char *scan_regex, const bool showhidden) {
   int ret = 1;
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "test_3_atclient_get_atkeys_null_ctx\n");
@@ -144,8 +144,7 @@ exit: {
 }
 }
 
-static int test_4_atclient_get_atkeys_null_regex(atclient *ctx, const char *scan_regex, const bool showhidden)
-{
+static int test_4_atclient_get_atkeys_null_regex(atclient *ctx, const char *scan_regex, const bool showhidden) {
   int ret = 1;
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "test_4_atclient_get_atkeys_null_regex\n");

--- a/tests/functional_tests/tests/test_atclient_utils_find_atserver_address.c
+++ b/tests/functional_tests/tests/test_atclient_utils_find_atserver_address.c
@@ -1,15 +1,17 @@
 #include <atclient/atclient_utils.h>
 #include <atlogger/atlogger.h>
+#include <functional_tests/config.h>
 #include <stdlib.h>
 #include <string.h>
 
 #define ATDIRECTORY_HOST "root.atsign.org"
 #define ATDIRECTORY_PORT 64
 
-#define ATSIGN "@12alpaca"
-
 #define TAG "test_atclient_find_atserver_address"
 
+// This ATSIGN should be pinned, we don't need the keys for it
+// we want to test for a successful lookup in the atDirectory
+#define ATSIGN "@12alpaca"
 #define EXPECTED_HOST "228aafb0-94d3-5aa2-a3b3-e36af115480d.swarm0002.atsign.zone"
 #define EXPECTED_PORT 6943
 
@@ -85,7 +87,8 @@ static int test_2_find_atserver_address_should_fail() {
 
   if ((ret = atclient_utils_find_atserver_address(ATDIRECTORY_HOST, ATDIRECTORY_PORT, "asjdflasjdf", &atserver_host,
                                                   &atserver_port)) == 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_find_atserver_address passed with exit code 0, when it was expected to fail... %d\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "atclient_find_atserver_address passed with exit code 0, when it was expected to fail... %d\n", ret);
     goto exit;
   }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Allow the test atsigns to be overridden in cmake:
```sh
cmake -B $repo_base/build -S $repo_base \
  -DCMAKE_INSTALL_PREFIX="$HOME/.local/" \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_C_COMPILER=gcc \
  -DCMAKE_C_FLAGS="-std=c99 -Werror" \
  -DATSDK_BUILD_TESTS=ON \
  -DFIRST_ATSIGN='"@first"' \
  -DSECOND_ATSIGN='"@second"'
```

- The inner quotes are necessary, otherwise the define statement will be processed as:
`#define FIRST @first` instead of `#define FIRST "@first"`

- Fixed build errors in tests (casting issues, and format specifiers)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: allow tests to be overridden at build time with different atSigns
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
