### PR TITLE
feat: move mbedtls sockets into its own layer under connection

### DIFF
--- a/examples/desktop/repl/src/main.c
+++ b/examples/desktop/repl/src/main.c
@@ -24,8 +24,7 @@
  *     --key-file [~/.atsign/keys/@atsign_key.atKeys]
  */
 
-static int set_up_pkam_auth_options(atclient_authenticate_options *pkam_authenticate_options,
-                                    const char *root_url);
+static int set_up_pkam_auth_options(atclient_authenticate_options *pkam_authenticate_options, const char *root_url);
 static int start_repl_loop(atclient *atclient, repl_args *repl_args);
 
 int main(int argc, char *argv[]) {
@@ -97,8 +96,7 @@ exit: {
 }
 }
 
-static int set_up_pkam_auth_options(atclient_authenticate_options *pkam_authenticate_options,
-                                    const char *root_url) {
+static int set_up_pkam_auth_options(atclient_authenticate_options *pkam_authenticate_options, const char *root_url) {
   int ret = 1;
 
   if (pkam_authenticate_options == NULL) {
@@ -162,7 +160,7 @@ static int start_repl_loop(atclient *atclient, repl_args *repl_args) {
 
   bool loop = true;
 
-  const size_t stdin_buffer_size = STDIN_BUFFER_SIZE;
+  size_t stdin_buffer_size = STDIN_BUFFER_SIZE;
   char stdin_buffer[stdin_buffer_size];
   char *stdin_buffer_ptr = stdin_buffer;
   size_t stdin_buffer_len = 0;
@@ -202,7 +200,7 @@ static int start_repl_loop(atclient *atclient, repl_args *repl_args) {
         goto exit;
       }
 
-      if((ret = atclient_connection_read(&(atclient->atserver_connection), &recv, NULL, 0)) != 0) {
+      if ((ret = atclient_connection_read(&(atclient->atserver_connection), (unsigned char **)&recv, NULL)) != 0) {
         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read response\n");
         goto exit;
       }

--- a/generators/arduino/atsdk/generate.sh
+++ b/generators/arduino/atsdk/generate.sh
@@ -205,6 +205,7 @@ overrides() {
     echo '#define PRIu64 "llu"'
     echo "#define ATCHOPS_TARGET_ARDUINO"
     echo "#define ATCHOPS_MBEDTLS_VERSION_2"
+    echo "#define ATCLIENT_NET_SOCKET_PROVIDER_EXTERNAL"
   } >>$src_base/atchops/platform.h
 }
 

--- a/packages/atchops/include/atchops/platform.h
+++ b/packages/atchops/include/atchops/platform.h
@@ -7,8 +7,6 @@
 
 // Platforms we support
 
-// Default MbedTLS version
-
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #define ATCHOPS_TARGET_UNIX
 

--- a/packages/atclient/CMakeLists.txt
+++ b/packages/atclient/CMakeLists.txt
@@ -21,6 +21,8 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/src/atnotification.c
   ${CMAKE_CURRENT_LIST_DIR}/src/connection_hooks.c
   ${CMAKE_CURRENT_LIST_DIR}/src/connection.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/socket.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/socket_mbedtls.c
   ${CMAKE_CURRENT_LIST_DIR}/src/encryption_key_helpers.c
   ${CMAKE_CURRENT_LIST_DIR}/src/metadata.c
   ${CMAKE_CURRENT_LIST_DIR}/src/monitor.c

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -1,7 +1,7 @@
 /*
  *
  * The connection family of types and methods represents a single connection to
- * if you want a pure socket representation see net_socket.h.
+ * if you want a pure socket representation see socket.h.
  *
  * At the moment _socket represents a singular tcp socket, but in the future it may be altered
  * to be a union of different connection types, such as a websocket or other construct.

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -1,12 +1,24 @@
+/*
+ *
+ * The connection family of types and methods represents a single connection to
+ * if you want a pure socket representation see net_socket.h.
+ *
+ * At the moment _socket represents a singular tcp socket, but in the future it may be altered
+ * to be a union of different connection types, such as a websocket or other construct.
+ * It is considered an internal construct and is subject to breaking changes across
+ * minor releases, especially while at_c remains in beta status.
+ *
+ */
 #ifndef ATCLIENT_CONNECTION_H
 #define ATCLIENT_CONNECTION_H
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "atchops/mbedtls.h"
-#include "atclient/connection_hooks.h"
 #include <atchops/platform.h> // IWYU pragma: keep
+
+#include "atclient/connection_hooks.h"
+#include "atclient/socket.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -31,12 +43,8 @@ typedef struct atclient_connection {
   // _is_connection_enabled also serves as an internal boolean to check if the following mbedlts contexts have been
   // initialized and need to be freed at the end
   bool _is_connection_enabled : 1;
-  mbedtls_net_context net;
-  mbedtls_ssl_context ssl;
-  mbedtls_ssl_config ssl_config;
-  mbedtls_x509_crt cacert;
-  mbedtls_entropy_context entropy;
-  mbedtls_ctr_drbg_context ctr_drbg;
+
+  struct atclient_tls_socket _socket;
 
   bool _is_hooks_enabled : 1;
   atclient_connection_hooks *hooks;
@@ -80,8 +88,7 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
  * @param value_max_len the maximum length of the data to read, setting this to 0 means no limit
  * @return int 0 on success
  */
-int atclient_connection_read(atclient_connection *ctx, unsigned char **value, size_t *value_len,
-                             const size_t value_max_len);
+int atclient_connection_read(atclient_connection *ctx, unsigned char **value, size_t *value_len);
 
 /**
  * @brief Write data to the connection

--- a/packages/atclient/include/atclient/connection.h
+++ b/packages/atclient/include/atclient/connection.h
@@ -30,23 +30,21 @@ typedef enum atclient_connection_type {
 
 typedef struct atclient_connection {
   atclient_connection_type type; // set in atclient_connection_init
-
+  uint16_t port;                 // example: 64
   bool _is_host_initialized : 1;
-  char *host; // example: "root.atsign.org"
-
   bool _is_port_initialized : 1;
-  uint16_t port; // example: 64
+  bool _is_connection_enabled : 1;
+  bool _is_hooks_enabled : 1;
+
+  char *host; // example: "root.atsign.org"
 
   // atclient_connection_connect sets this to true and atclient_connection_disconnect sets this to false
   // this does not mean that the connection is still alive, it just means that the connection was established at least
   // once, at some  point, check atclient_connection_is_connected for a live status on the connection
   // _is_connection_enabled also serves as an internal boolean to check if the following mbedlts contexts have been
   // initialized and need to be freed at the end
-  bool _is_connection_enabled : 1;
 
   struct atclient_tls_socket _socket;
-
-  bool _is_hooks_enabled : 1;
   atclient_connection_hooks *hooks;
 } atclient_connection;
 

--- a/packages/atclient/include/atclient/mbedtls.h
+++ b/packages/atclient/include/atclient/mbedtls.h
@@ -4,10 +4,7 @@
 extern "C" {
 #endif
 
-#include <atchops/mbedtls.h>     // IWYU pragma: export
-#include <mbedtls/net_sockets.h> // IWYU pragma: export
-#include <mbedtls/ssl.h>         // IWYU pragma: export
-#include <mbedtls/threading.h>   // IWYU pragma: export
+#include <atchops/mbedtls.h> // IWYU pragma: export
 
 #ifdef __cplusplus
 }

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -9,6 +9,11 @@ extern "C" {
 #include <atchops/platform.h> // IWYU pragma: keep
 #include <stdbool.h>
 
+// HACK let's just get it working for now this is so wrong
+#ifndef MBEDTLS_ERR_SSL_TIMEOUT
+#define MBEDTLS_ERR_SSL_TIMEOUT -37
+#endif
+
 /**
  * @brief Represents a message received from the monitor connection, typically derived from the prefix of the response
  * (e.g. "data:ok"'s message type would be "data" = ATCLIENT_MONITOR_MESSAGE_TYPE_DATA_RESPONSE)

--- a/packages/atclient/include/atclient/monitor.h
+++ b/packages/atclient/include/atclient/monitor.h
@@ -6,13 +6,9 @@ extern "C" {
 
 #include "atclient/atclient.h"
 #include "atclient/atnotification.h"
+#include "atclient/socket.h"
 #include <atchops/platform.h> // IWYU pragma: keep
 #include <stdbool.h>
-
-// HACK let's just get it working for now this is so wrong
-#ifndef MBEDTLS_ERR_SSL_TIMEOUT
-#define MBEDTLS_ERR_SSL_TIMEOUT -37
-#endif
 
 /**
  * @brief Represents a message received from the monitor connection, typically derived from the prefix of the response

--- a/packages/atclient/include/atclient/socket.h
+++ b/packages/atclient/include/atclient/socket.h
@@ -1,0 +1,119 @@
+#ifndef ATCLIENT_SOCKET_H
+#define ATCLIENT_SOCKET_H
+#include <atchops/platform.h>
+#ifndef ATCLIENT_SOCKET_SHARED_H
+#include <atclient/socket_shared.h>
+#endif
+#include <stddef.h>
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// IWYU pragma: begin_exports
+
+// Export the appropriate platform specific struct implementation
+#if defined(ATCLIENT_SOCKET_PROVIDER_MBEDTLS)
+#include "socket_mbedtls.h"
+#endif
+
+// IWYU pragma: end_exports
+
+/**
+ * @brief Initializes a raw socket
+ *
+ * @param socket The socket structure to initialize
+ */
+void atclient_raw_socket_init(struct atclient_raw_socket *socket);
+
+/**
+ * @brief Frees resources associated with a network socket
+ *
+ * @param socket The socket structure to free resources from
+ */
+void atclient_raw_socket_free(struct atclient_raw_socket *socket);
+
+/**
+ * @brief Initializes a tls socket with the specified parameters
+ *
+ * @param socket The socket structure to initialize
+ */
+void atclient_tls_socket_init(struct atclient_tls_socket *socket);
+
+/**
+ * @brief Configures the SSL on a TLS socket
+ *
+ * @param ca_pem The X.509 CA certificates in pem format (leave NULL to use the provided default certificates)
+ * @param ca_pem_len Length of the ca_pem, ignored if ca_pem is NULL
+ *
+ * @return 0 on success, non-zero on failure
+ *
+ * @note Should be called after atclient_tls_socket_init, note that this
+ * contains the rest of the initialization operations which have potential
+ * to fail
+ */
+int atclient_tls_socket_configure(struct atclient_tls_socket *socket, unsigned char *ca_pem, size_t ca_pem_len);
+
+/**
+ * @brief Frees resources associated with a network socket
+ *
+ * @param socket The socket structure to free resources from
+ */
+void atclient_tls_socket_free(struct atclient_tls_socket *socket);
+
+/**
+ * @brief Establishes a connection to the specified host and port using the network socket
+ *
+ * @param socket Pointer to the initialized network socket structure
+ * @param host The hostname or IP address to connect to
+ * @param port The port number to connect to
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int atclient_tls_socket_connect(struct atclient_tls_socket *socket, const char *host, const uint16_t port);
+
+/**
+ * @brief Disconnects and closes an established network socket connection
+ *
+ * @param socket Pointer to the network socket structure to disconnect
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int atclient_tls_socket_disconnect(struct atclient_tls_socket *socket);
+
+/**
+ * @brief Writes data to an established network socket connection
+ *
+ * @param socket Pointer to the network socket structure
+ * @param value Pointer to the buffer containing data to write
+ * @param value_len Length of the data to write in bytes
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int atclient_tls_socket_write(struct atclient_tls_socket *socket, const unsigned char *value, size_t value_len);
+
+/**
+ * @brief Reads data from an established network socket connection
+ *
+ * @param socket Pointer to the network socket structure
+ * @param value Pointer to the buffer where read data will be stored
+ * @param value_len Pointer to store the length of data read in bytes
+ * @param options Options which specify the behaviour of reading the data
+ *
+ * @return 0 on success, non-zero on failure
+ */
+int atclient_tls_socket_read(struct atclient_tls_socket *socket, unsigned char **value, size_t *value_len,
+                             const struct atclient_socket_read_options options);
+
+/**
+ * @brief Sets the read timeout for a TLS socket
+ *
+ * @param socket Pointer to the initialized TLS socket structure
+ * @param timeout_ms The timeout value in milliseconds
+ */
+void atclient_tls_socket_set_read_timeout(struct atclient_tls_socket *socket, const int timeout_ms);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/packages/atclient/include/atclient/socket.h
+++ b/packages/atclient/include/atclient/socket.h
@@ -10,6 +10,22 @@
 extern "C" {
 #endif
 
+#ifndef ATCLIENT_SSL_TIMEOUT_EXITCODE
+
+#if defined(ATCLIENT_SOCKET_PROVIDER_MBEDTLS)
+#define ATCLIENT_SSL_TIMEOUT_EXITCODE MBEDTLS_ERR_SSL_TIMEOUT
+
+#elif defined(ATCLIENT_SOCKET_PROVIDER_ARDUINO_BEARSSL)
+// Most arduino libraries only use -1 or positive integers
+#define ATCLIENT_SSL_TIMEOUT_EXITCODE -101
+
+#else
+#error "ATCLIENT_ERR_SSL_TIMEOUT is undefined"
+
+#endif
+
+#endif
+
 // IWYU pragma: begin_exports
 
 // Export the appropriate platform specific struct implementation

--- a/packages/atclient/include/atclient/socket_mbedtls.h
+++ b/packages/atclient/include/atclient/socket_mbedtls.h
@@ -1,0 +1,34 @@
+// IWYU pragma: private, include "atclient/net_socket.h"
+// IWYU pragma: friend "net_socket_mbedtls.*"
+#ifndef ATCLIENT_NET_SOCKET_MBEDTLS_H
+#define ATCLIENT_NET_SOCKET_MBEDTLS_H
+#include <atchops/platform.h>
+#if defined(ATCLIENT_SOCKET_PROVIDER_MBEDTLS)
+#include <atclient/socket_shared.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/threading.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Make this type more portable to consume later
+struct atclient_raw_socket {
+  mbedtls_net_context net;
+};
+
+struct atclient_tls_socket {
+  struct atclient_raw_socket raw;
+  mbedtls_ssl_context ssl;
+  mbedtls_ssl_config ssl_config;
+  mbedtls_x509_crt cacert;
+  mbedtls_entropy_context entropy;
+  mbedtls_ctr_drbg_context ctr_drbg;
+};
+#ifdef __cplusplus
+}
+#endif
+#endif
+#endif

--- a/packages/atclient/include/atclient/socket_mbedtls.h
+++ b/packages/atclient/include/atclient/socket_mbedtls.h
@@ -1,7 +1,7 @@
-// IWYU pragma: private, include "atclient/net_socket.h"
-// IWYU pragma: friend "net_socket_mbedtls.*"
-#ifndef ATCLIENT_NET_SOCKET_MBEDTLS_H
-#define ATCLIENT_NET_SOCKET_MBEDTLS_H
+// IWYU pragma: private, include "atclient/socket.h"
+// IWYU pragma: friend "socket_mbedtls.*"
+#ifndef ATCLIENT_SOCKET_MBEDTLS_H
+#define ATCLIENT_SOCKET_MBEDTLS_H
 #include <atchops/platform.h>
 #if defined(ATCLIENT_SOCKET_PROVIDER_MBEDTLS)
 #include <atclient/socket_shared.h>
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-// Make this type more portable to consume later
+// TODO: Make this type more portable to consume later
 struct atclient_raw_socket {
   mbedtls_net_context net;
 };

--- a/packages/atclient/include/atclient/socket_shared.h
+++ b/packages/atclient/include/atclient/socket_shared.h
@@ -1,0 +1,69 @@
+// IWYU pragma: private, include "atclient/net_socket.h"
+// IWYU pragma: friend "net_socket_mbedtls.*"
+#ifndef ATCLIENT_SOCKET_SHARED_H
+#define ATCLIENT_SOCKET_SHARED_H
+#include <stddef.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <atchops/platform.h>
+
+#if defined(ATCLIENT_SOCKET_PROVIDER_EXTERNAL)
+// Noop, this indicates an external socket provider will be linked
+#else
+#define ATCLIENT_SOCKET_PROVIDER_MBEDTLS
+#endif
+
+#ifdef ATCLIENT_SOCKET_PROVIDER_EXTERNAL
+#include "../atsdk_socket.h" // IWYU pragma: export
+#else
+// Defined later based on platform specific implementation
+struct atclient_tls_socket;
+
+// Raw socket is only implemented as an internal construct for now
+// In the future it will be a supported standalone socket that can
+// be used directly
+struct atclient_raw_socket;
+#endif
+
+enum atclient_socket_read_type {
+  // ATCLIENT_SOCKET_READ_NUM_BYTES,
+  ATCLIENT_SOCKET_READ_UNTIL_CHAR,
+  ATCLIENT_SOCKET_READ_CLEAR_AT_PROMPT,
+};
+
+// Define how much we should try to read
+struct atclient_socket_read_options {
+  enum atclient_socket_read_type type;
+  union {
+    // size_t num_bytes;
+    char until_char;
+  };
+};
+
+/**
+ * @brief Creates read options configured to read until a number of characters have been read
+ *
+ * @param bytes The number of characters to try to read
+ *
+ * @return struct atclient_socket_read_options Configuration structure for read operation
+ */
+// struct atclient_socket_read_options atclient_socket_read_num_bytes(size_t bytes);
+
+/**
+ * @brief Creates read options configured to read until a specific character is encountered
+ *
+ * @param read_until The character to read until (delimiter)
+ */
+struct atclient_socket_read_options atclient_socket_read_until_char(char read_until);
+
+/**
+ * @brief Creates read options configured to read until a specific character is encountered
+ */
+struct atclient_socket_read_options atclient_socket_read_clear_at_prompt();
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/packages/atclient/include/atclient/socket_shared.h
+++ b/packages/atclient/include/atclient/socket_shared.h
@@ -1,5 +1,5 @@
-// IWYU pragma: private, include "atclient/net_socket.h"
-// IWYU pragma: friend "net_socket_mbedtls.*"
+// IWYU pragma: private, include "atclient/socket.h"
+// IWYU pragma: friend "socket_mbedtls.*"
 #ifndef ATCLIENT_SOCKET_SHARED_H
 #define ATCLIENT_SOCKET_SHARED_H
 #include <stddef.h>

--- a/packages/atclient/src/atclient_get_atkeys.c
+++ b/packages/atclient/src/atclient_get_atkeys.c
@@ -46,7 +46,7 @@ int atclient_get_atkeys(atclient *atclient, atclient_atkey **atkey, size_t *outp
 
   char scan_cmd[scan_cmd_size];
 
-  const size_t recv_size = 8192; // TODO change using atclient_connection_read which will handle realloc
+  const size_t recv_size = 16384; // TODO change using atclient_connection_read which will handle realloc
   unsigned char recv[recv_size];
   size_t recv_len = 0;
 

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -111,20 +111,17 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
   size_t buffer_len;
 
   int ret = atclient_tls_socket_read(&monitor_conn->atserver_connection._socket, &buffer, &buffer_len,
-                                     atclient_socket_read_until_char('@'));
+                                     atclient_socket_read_until_char('\n'));
 
-  // TODO: move this later for now it's fine as it should
-  if (ret == MBEDTLS_ERR_SSL_TIMEOUT) {
+  if (ret == ATCLIENT_SSL_TIMEOUT_EXITCODE) {
     // treat a timeout as empty message, non error
     message->type = ATCLIENT_MONITOR_MESSAGE_TYPE_EMPTY;
     ret = 0;
     goto exit;
-  }
-
-  if (ret <= 0) { // you should reconnect...
+  } else if (ret != 0) { // you should reconnect...
     message->type = ATCLIENT_MONITOR_ERROR_READ;
     message->error_read.error_code = ret;
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Read nothing from the monitor connection: %d\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Error: monitor exited with code %d\n", ret);
     goto exit;
   }
 

--- a/packages/atclient/src/socket.c
+++ b/packages/atclient/src/socket.c
@@ -1,7 +1,5 @@
 #include <atchops/platform.h>
 #include <atclient/socket.h>
-// Most of the implementation for net_socket is platform specific,
-// See the other net_socket_*.c files
 
 struct atclient_socket_read_options atclient_socket_read_until_char(char until) {
   return (struct atclient_socket_read_options){

--- a/packages/atclient/src/socket.c
+++ b/packages/atclient/src/socket.c
@@ -1,0 +1,18 @@
+#include <atchops/platform.h>
+#include <atclient/socket.h>
+// Most of the implementation for net_socket is platform specific,
+// See the other net_socket_*.c files
+
+struct atclient_socket_read_options atclient_socket_read_until_char(char until) {
+  return (struct atclient_socket_read_options){
+      ATCLIENT_SOCKET_READ_UNTIL_CHAR,
+      {.until_char = until},
+  };
+}
+
+// struct atclient_socket_read_options atclient_socket_read_num_bytes(size_t bytes) {
+//   return (struct atclient_socket_read_options){
+//       ATCLIENT_SOCKET_READ_NUM_BYTES,
+//       {.num_bytes = bytes},
+//   };
+// }

--- a/packages/atclient/src/socket_mbedtls.c
+++ b/packages/atclient/src/socket_mbedtls.c
@@ -1,0 +1,456 @@
+// These two headers must be included in a specific order
+#include "atchops/platform.h" // IWYU pragma: keep
+// Don't move them
+#include "atclient/socket.h"
+
+#if defined(ATCLIENT_SOCKET_PROVIDER_MBEDTLS)
+#include "atchops/constants.h"
+#include "atclient/cacerts.h"
+#include "atclient/constants.h"
+#include "atclient/socket_mbedtls.h"
+#include "atlogger/atlogger.h"
+#include "mbedtls/error.h"
+#include "mbedtls/net_sockets.h"
+#include "mbedtls/x509_crt.h"
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+#ifndef PRIu16
+#define PRIu16 "hu"
+#endif
+
+#define TAG "atclient_socket_mbedtls"
+
+#ifndef SIZE_T_MAX
+#define SIZE_T_MAX (size_t) - 1
+#endif
+// must be less than the maximum for a positive int
+// otherwise read_num_bytes may have undefined behavior
+#define READ_BLOCK_LEN 4096
+
+// I think the -1 is unnecessary but better safe than sorry
+#define MAX_READ_BLOCKS (SIZE_T_MAX / READ_BLOCK_LEN - 1)
+static const int MAX_READ_TIMEOUTS = 3;
+
+// Hey fellow engineer, if you want to understand this file, you better have this link on hand:
+// https://mbed-tls.readthedocs.io/projects/api/en/v3.6.1/api/file/ssl_8h
+// mbedtls sockets are tricky, reading and writing have gotchas
+// so you NEED to look at the documentation when you work with them.
+
+static void my_debug(void *ctx, int level, const char *file, int line, const char *str) {
+  ((void)level);
+  fprintf((FILE *)ctx, "%s:%04d: %s", file, line, str);
+  fflush((FILE *)ctx);
+}
+
+// Default CA certs for net_sockets
+static const char default_ca_pem[] = LETS_ENCRYPT_ROOT GOOGLE_GLOBAL_SIGN GOOGLE_GTS_ROOT_R1 GOOGLE_GTS_ROOT_R2
+    GOOGLE_GTS_ROOT_R3 GOOGLE_GTS_ROOT_R4 ZEROSSL_INTERMEDIATE "";
+
+void atclient_raw_socket_init(struct atclient_raw_socket *socket) { mbedtls_net_init(&socket->net); }
+
+void atclient_raw_socket_free(struct atclient_raw_socket *socket) { mbedtls_net_free(&socket->net); }
+
+void atclient_tls_socket_init(struct atclient_tls_socket *socket) {
+  memset(socket, 0, sizeof(struct atclient_tls_socket));
+  atclient_raw_socket_init(&socket->raw);
+
+  mbedtls_x509_crt_init(&(socket->cacert));
+  mbedtls_ctr_drbg_init(&(socket->ctr_drbg));
+  mbedtls_entropy_init(&(socket->entropy));
+  mbedtls_ssl_config_init(&socket->ssl_config);
+  mbedtls_ssl_init(&socket->ssl);
+}
+
+void atclient_tls_socket_set_read_timeout(struct atclient_tls_socket *socket, const int timeout_ms) {
+  mbedtls_ssl_conf_read_timeout(&socket->ssl_config, timeout_ms);
+}
+
+// Expected to be called after init
+int atclient_tls_socket_configure(struct atclient_tls_socket *socket, unsigned char *ca_pem, size_t ca_pem_len) {
+  int ret = 1;
+
+  // 1. Parse the CA certs
+  unsigned char *pem;
+  size_t pem_len;
+  if (ca_pem == NULL) {
+    pem = (unsigned char *)default_ca_pem;
+    pem_len = sizeof(default_ca_pem);
+  } else {
+    pem = ca_pem;
+    pem_len = ca_pem_len;
+  }
+
+  if ((ret = mbedtls_x509_crt_parse(&(socket->cacert), pem, pem_len)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_x509_crt_parse failed with exit code: %d\n", ret);
+    goto cancel_x509;
+  }
+
+  // 2. Seed RNG
+  if ((ret = mbedtls_ctr_drbg_seed(&(socket->ctr_drbg), mbedtls_entropy_func, &(socket->entropy),
+                                   (unsigned char *)ATCHOPS_RNG_PERSONALIZATION,
+                                   strlen(ATCHOPS_RNG_PERSONALIZATION))) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ctr_drbg_seed failed with exit code: %d\n", ret);
+    goto cancel_seed;
+  }
+
+  // 3. Configure SSL
+  if ((ret = mbedtls_ssl_config_defaults(&(socket->ssl_config), MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM,
+                                         MBEDTLS_SSL_PRESET_DEFAULT)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_config_defaults failed with exit code: %d\n", ret);
+    goto cancel_ssl_config;
+  }
+
+  mbedtls_ssl_conf_ca_chain(&(socket->ssl_config), &(socket->cacert), NULL);
+  mbedtls_ssl_conf_authmode(&(socket->ssl_config), MBEDTLS_SSL_VERIFY_REQUIRED);
+  mbedtls_ssl_conf_rng(&(socket->ssl_config), mbedtls_ctr_drbg_random, &(socket->ctr_drbg));
+  mbedtls_ssl_conf_dbg(&(socket->ssl_config), my_debug, stdout);
+  mbedtls_ssl_conf_read_timeout(&(socket->ssl_config),
+                                ATCLIENT_CLIENT_READ_TIMEOUT_MS); // recv will timeout after X seconds
+
+  // 4. Prepare the SSL context
+  if ((ret = mbedtls_ssl_setup(&(socket->ssl), &(socket->ssl_config))) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_setup failed with exit code: %d\n", ret);
+    goto cancel_ssl;
+  }
+
+  // we made it to the happy path: skip freeing all the things
+  ret = 0;
+  goto exit;
+cancel_ssl:
+  mbedtls_ssl_free(&socket->ssl);
+cancel_ssl_config:
+  mbedtls_ssl_config_free(&socket->ssl_config);
+cancel_seed:
+  mbedtls_entropy_free(&(socket->entropy));
+  mbedtls_ctr_drbg_free(&(socket->ctr_drbg));
+cancel_x509:
+  mbedtls_x509_crt_free(&(socket->cacert));
+exit:
+  return ret;
+}
+
+void atclient_tls_socket_free(struct atclient_tls_socket *socket) {
+  if (socket != NULL) {
+    atclient_raw_socket_free(&socket->raw);
+    mbedtls_ssl_free(&socket->ssl);
+    mbedtls_ssl_config_free(&socket->ssl_config);
+    mbedtls_entropy_free(&(socket->entropy));
+    mbedtls_ctr_drbg_free(&(socket->ctr_drbg));
+    mbedtls_x509_crt_free(&(socket->cacert));
+    memset(socket, 0, sizeof(struct atclient_tls_socket));
+  }
+}
+
+static int atclient_tls_socket_ssl_handshake(struct atclient_tls_socket *socket, const char *host);
+
+int atclient_tls_socket_connect(struct atclient_tls_socket *socket, const char *host, const uint16_t port) {
+  if (socket == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "tls socket is when trying to connect NULL\n");
+    return 1;
+  }
+
+  char port_str[5];
+  snprintf(port_str, 5, "%" PRIu16, port);
+
+  int ret;
+  // 1. Connect
+  // TODO: move to raw_connect function
+  if ((ret = mbedtls_net_connect(&socket->raw.net, host, port_str, MBEDTLS_NET_PROTO_TCP)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_net_connect failed with exit code: %d\n", ret);
+    return ret;
+  }
+
+  if ((ret = atclient_tls_socket_ssl_handshake(socket, host)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_tls_socket_ssl_handshake failed with exit code: %d\n",
+                 ret);
+    return ret;
+  }
+
+  return ret;
+}
+
+static int atclient_tls_socket_ssl_handshake(struct atclient_tls_socket *socket, const char *host) {
+  int ret;
+  // 2. Set SSL hostname
+  if ((ret = mbedtls_ssl_set_hostname(&socket->ssl, host)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_set_hostname failed with exit code: %d\n", ret);
+    return ret;
+  }
+
+  // 3. Link SSL to the raw socket
+  mbedtls_ssl_set_bio(&socket->ssl, &socket->raw.net, mbedtls_net_send, NULL, mbedtls_net_recv_timeout);
+
+  /*
+   * 4. Do SSL handshake
+   */
+  if ((ret = mbedtls_ssl_handshake(&socket->ssl)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_handshake failed with exit code: %d\n", ret);
+    return ret;
+  }
+
+  /*
+   * 5. Verify the certificate
+   */
+  if ((ret = mbedtls_ssl_get_verify_result(&socket->ssl)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_get_verify_result failed with exit code: %d\n", ret);
+    return ret;
+  }
+
+  return ret;
+}
+
+int atclient_tls_socket_disconnect(struct atclient_tls_socket *socket) {
+  if (socket == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_tls_socket_disconnect: socket is NULL\n");
+    return 1;
+  }
+
+  int ret = mbedtls_ssl_close_notify(&(socket->ssl));
+
+  // If we got a non want read/write error don't try again:
+  // we may segfault or deadlock trying to disconnect
+  // just warn that we silently closed the socket and move on
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN,
+                 "mbedtls_ssl_close_notify failed, socket will be silently closed, exit code: %d\n", ret);
+    return ret;
+  }
+
+  return ret;
+}
+
+static bool should_continue_write(size_t pos, size_t len, int ret) {
+  return pos < len || ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE ||
+         ret == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS || ret == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS;
+}
+int atclient_tls_socket_write(struct atclient_tls_socket *socket, const unsigned char *value, size_t value_len) {
+  if (socket == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_tls_socket_write: socket is NULL\n");
+    return 1;
+  }
+  if (value == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_tls_socket_write: value is NULL\n");
+    return 2;
+  }
+  size_t pos = 0;
+  int ret;
+  do {
+    ret = mbedtls_ssl_write(&socket->ssl, value + pos, value_len - pos);
+    if (ret > 0) {
+      pos += (size_t)ret;
+      ret = 0;
+      continue;
+    }
+  } while (should_continue_write(pos, value_len, ret));
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "mbedtls_ssl_write failed with exit code: %d\n", ret);
+  }
+  return ret;
+}
+
+static int atclient_tls_socket_read_until_char(struct atclient_tls_socket *socket, unsigned char **value,
+                                               size_t *value_len, char until_char);
+
+// static int atclient_tls_socket_read_num_bytes(struct atclient_tls_socket *socket, unsigned char **value,
+//                                               size_t *value_len, size_t num_bytes);
+int atclient_tls_socket_read(struct atclient_tls_socket *socket, unsigned char **value, size_t *value_len,
+                             const struct atclient_socket_read_options options) {
+  if (socket == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_tls_socket_read: socket is NULL\n");
+    return 1;
+  }
+
+  switch (options.type) {
+
+  // case ATCLIENT_SOCKET_READ_NUM_BYTES:
+  // return atclient_tls_socket_read_num_bytes(socket, value, value_len, options.num_bytes);
+  case ATCLIENT_SOCKET_READ_UNTIL_CHAR:
+    return atclient_tls_socket_read_until_char(socket, value, value_len, options.until_char);
+  default:
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_tls_socket_read: read type %d is not a valid type\n",
+                 options.type);
+    return 4;
+  }
+}
+// int atclient_tls_socket_read_num_bytes(struct atclient_tls_socket *socket, unsigned char **value, size_t *value_len,
+//                                        size_t num_bytes) {
+//   // Assume params have been validated by socket_read
+//   int ret;
+//   unsigned char *recv = NULL;
+//   size_t blocks = 0; // number of allocated blocks
+//
+//   do {
+//     size_t offset = READ_BLOCK_LEN * blocks; // offset to current block
+//     // Allocate memory
+//     unsigned char *temp = realloc(recv, sizeof(unsigned char) * (offset + READ_BLOCK_LEN));
+//     if (temp == NULL) {
+//       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate receive buffer\n");
+//       if (recv != NULL) {
+//         free(recv);
+//       }
+//       return 1;
+//     }
+//     recv = temp; // once we ensure realloc was successful we set recv to the new memory
+//
+//     // Read into current block
+//     size_t pos = 0; // position in current block
+//     do {
+//       size_t remaining_for_block;
+//       if (READ_BLOCK_LEN + offset > num_bytes) {
+//         // We are in the final block, so only read the amount that will make
+//         // us reach num_bytes
+//         remaining_for_block = num_bytes - (offset + pos);
+//       } else {
+//         remaining_for_block = READ_BLOCK_LEN - pos;
+//       }
+//
+//       ret = mbedtls_ssl_read(&socket->ssl, recv + offset + pos, remaining_for_block);
+//       if (ret > 0) {
+//         pos += ret; // successful read, increment pos
+//
+//         if (offset + pos == num_bytes) {
+//           *value = recv;
+//           *value_len = (offset + pos);
+//           return 0; // The only return where recv should not be freed
+//         }
+//
+//         continue; // not done reading yet
+//       }
+//
+//       // handle non-happy path
+//       switch (ret) {
+//       case 0:                                 // connection is closed
+//       case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY: // connection is closed
+//         atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Socket closed while reading: %d\n", ret);
+//         ret = MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY; // ensure ret val is not 0
+//         free(recv);
+//         return ret;
+//       case MBEDTLS_ERR_SSL_WANT_READ:          // handshake incomplete
+//       case MBEDTLS_ERR_SSL_WANT_WRITE:         // handshake incomplete
+//       case MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS:  // async operation in progress
+//       case MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS: // crypto operation in progress
+//                                                // async error, we need to try again
+//         break;
+//       case MBEDTLS_ERR_SSL_TIMEOUT: // treat a timeout as
+//
+//         if (value != NULL) {
+//           *value = recv;
+//         } else {
+//           free(recv);
+//         }
+//        if (value_len != NULL) {
+//           *value_len = (offset + pos);
+//         }
+//         return 0; // The only return where recv should not be freed
+//         // unexpected errors while reading
+//       default:
+//         if (ret > 0) {
+//           atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unexpected read value %d\n", ret);
+//         } else {
+//           char strerr[512];
+//           mbedtls_strerror(ret, strerr, 512);
+//           atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%s", strerr);
+//         }
+//         free(recv);
+//         return ret;
+//       } // don't put anything after switch without checking it first
+//     } while (pos < READ_BLOCK_LEN);
+//     blocks++;
+//   } while (blocks < MAX_READ_BLOCKS);
+//   // We should only arrive at this point if we max out blocks
+//   // Every other code path should return early
+//   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read within the maximum allowed number of read
+//   blocks\n"); free(recv); return 1;
+// }
+
+int atclient_tls_socket_read_until_char(struct atclient_tls_socket *socket, unsigned char **value, size_t *value_len,
+                                        char until_char) {
+  // Assume params have been validated by socket_read
+  int ret;
+  unsigned char *recv = NULL;
+  size_t blocks = 0; // number of allocated blocks
+
+  do {
+    size_t offset = READ_BLOCK_LEN * blocks; // offset to current block
+    // Allocate memory
+    unsigned char *temp = realloc(recv, sizeof(unsigned char) * (offset + READ_BLOCK_LEN));
+    if (temp == NULL) {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate receive buffer\n");
+      if (recv != NULL) {
+        free(recv);
+      }
+      return 1;
+    }
+    recv = temp; // once we ensure realloc was successful we set recv to the new memory
+
+    // Read into current block
+    size_t pos = 0; // position in current block
+    int timeout_count = 0;
+    do {
+      // When reading to a character we must read byte by byte to prevent
+      // over reading and risk corrupting the next message
+      // do not change the 1 without consulting the code below
+      ret = mbedtls_ssl_read(&socket->ssl, recv + offset + pos, 1);
+      if (ret > 0) {
+        if (until_char == *(recv + offset + pos)) { // check if this is the char we need
+          if (value != NULL) {
+            *value = recv;
+          } else {
+            free(recv);
+          }
+          if (value_len != NULL) {
+            *value_len = offset + pos + 1;
+          }
+          // The only return where recv should not be freed
+          return 0;
+        }
+        pos += ret; // successful read, increment position
+        continue;   // continue if not found char yet
+      }
+      // handle non-happy path
+      switch (ret) {
+      case 0:                                 // connection is closed
+      case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY: // connection is closed
+        atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Socket closed while reading: %d\n", ret);
+        ret = MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY; // ensure ret val is not 0
+        free(recv);
+        return ret;
+      case MBEDTLS_ERR_SSL_WANT_READ:          // handshake incomplete
+      case MBEDTLS_ERR_SSL_WANT_WRITE:         // handshake incomplete
+      case MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS:  // async operation in progress
+      case MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS: // crypto operation in progress
+                                               // async error, we need to try again
+        break;
+      case MBEDTLS_ERR_SSL_TIMEOUT: // timeout before reading the expected character
+                                    // timeout usually indicates nothing to read
+        timeout_count++;
+        if (timeout_count == MAX_READ_TIMEOUTS) {
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Failed to read the full message after %d attempts\n",
+                       MAX_READ_TIMEOUTS);
+          return ret;
+        }
+        usleep(1000);
+        break;
+        // unexpected errors while reading
+      default:
+        if (ret > 0) {
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unexpected read value %d\n", ret);
+        } else {
+          char strerr[512];
+          mbedtls_strerror(ret, strerr, 512);
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%s", strerr);
+        }
+        free(recv);
+        return ret;
+      } // don't put anything after switch without checking it first
+    } while (pos < READ_BLOCK_LEN);
+    blocks++;
+  } while (blocks < MAX_READ_BLOCKS);
+  // We should only arrive at this point if we max out blocks
+  // Every other code path should return early
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read within the maximum allowed number of read blocks\n");
+  free(recv);
+  return 1;
+}
+#endif

--- a/packages/atclient/src/socket_raw_mbedtls.c
+++ b/packages/atclient/src/socket_raw_mbedtls.c
@@ -1,0 +1,19 @@
+#include "atclient/socket.h"
+#include <atchops/platform.h>
+#include <string.h>
+
+#if defined(ATCLIENT_SOCKET_PROVIDER_MBEDTLS)
+
+void atclient_raw_socket_init(struct atclient_raw_socket *socket) {
+  memset(socket, 0, sizeof(struct atclient_raw_socket));
+  mbedtls_net_init(&socket->net);
+}
+
+void atclient_raw_socket_free(struct atclient_raw_socket *socket) {
+  if (socket != NULL) {
+    mbedtls_net_free(&socket->net);
+    memset(socket, 0, sizeof(struct atclient_raw_socket));
+  }
+}
+
+#endif

--- a/tests/functional_tests/lib/src/config.c
+++ b/tests/functional_tests/lib/src/config.c
@@ -1,11 +1,12 @@
+#include "functional_tests/config.h"
 #include <pwd.h>
-#include <unistd.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include "functional_tests/config.h"
+#include <unistd.h>
 
-int functional_tests_get_atkeys_path(const char *atsign, const size_t atsignlen, char *path, const size_t pathsize, size_t *pathlen) {
+int functional_tests_get_atkeys_path(const char *atsign, const size_t atsignlen, char *path, const size_t pathsize,
+                                     size_t *pathlen) {
   // for home directory
   struct passwd *pw = getpwuid(getuid());
   const char *homedir = pw->pw_dir;

--- a/tests/functional_tests/tests/test_atclient_connection.c
+++ b/tests/functional_tests/tests/test_atclient_connection.c
@@ -250,7 +250,7 @@ exit: {
 static int test_6_is_connected_should_be_false(atclient_connection *conn) {
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_6_is_connected_should_be_false Begin\n");
 
-  int ret= 1; 
+  int ret = 1;
 
   if (atclient_connection_is_connected(conn)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
@@ -419,7 +419,7 @@ static int test_14_simulate_server_not_responding(atclient_connection *conn) {
   int ret = 1;
 
   // simulate server not responding
-  ret = mbedtls_ssl_close_notify(&conn->ssl);
+  ret = mbedtls_ssl_close_notify(&conn->_socket.ssl);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to close notify: %d\n", ret);
     goto exit;
@@ -454,7 +454,8 @@ static int test_15_send_should_fail(atclient_connection *conn) {
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Successfully failed at sending message to a disconnected connection: %d\n", ret);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO,
+               "Successfully failed at sending message to a disconnected connection: %d\n", ret);
 
   ret = 0;
   goto exit;

--- a/tests/functional_tests/tests/test_atclient_get_atkeys.c
+++ b/tests/functional_tests/tests/test_atclient_get_atkeys.c
@@ -146,7 +146,6 @@ exit: {
 
 static int test_4_atclient_get_atkeys_null_regex(atclient *ctx, const char *scan_regex, const bool showhidden) {
   int ret = 1;
-  return 0; // NOTE: disabled temporarily DONT LET THIS GET MERGED
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "test_4_atclient_get_atkeys_null_regex\n");
 

--- a/tests/functional_tests/tests/test_atclient_get_atkeys.c
+++ b/tests/functional_tests/tests/test_atclient_get_atkeys.c
@@ -146,6 +146,7 @@ exit: {
 
 static int test_4_atclient_get_atkeys_null_regex(atclient *ctx, const char *scan_regex, const bool showhidden) {
   int ret = 1;
+  return 0; // NOTE: disabled temporarily DONT LET THIS GET MERGED
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "test_4_atclient_get_atkeys_null_regex\n");
 

--- a/tests/functional_tests/tests/test_atclient_monitor.c
+++ b/tests/functional_tests/tests/test_atclient_monitor.c
@@ -176,22 +176,22 @@ static int send_notification(atclient *atclient) {
     goto exit;
   }
 
-  if((ret = atclient_notify_params_set_operation(&params, ATCLIENT_NOTIFY_OPERATION_UPDATE)) != 0) {
+  if ((ret = atclient_notify_params_set_operation(&params, ATCLIENT_NOTIFY_OPERATION_UPDATE)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set operation: %d\n", ret);
     goto exit;
   }
 
-  if((ret = atclient_notify_params_set_atkey(&params, &atkey)) != 0) {
+  if ((ret = atclient_notify_params_set_atkey(&params, &atkey)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set atkey: %d\n", ret);
     goto exit;
   }
 
-  if((ret = atclient_notify_params_set_value(&params, ATKEY_VALUE)) != 0) {
+  if ((ret = atclient_notify_params_set_value(&params, ATKEY_VALUE)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set value: %d\n", ret);
     goto exit;
   }
 
-  if((ret = atclient_notify_params_set_should_encrypt(&params, true)) != 0) {
+  if ((ret = atclient_notify_params_set_should_encrypt(&params, true)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set should_encrypt: %d\n", ret);
     goto exit;
   }
@@ -231,7 +231,7 @@ static int monitor_for_notification(atclient *monitor_conn, atclient *atclient2)
       continue;
     }
 
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Decrypted Value: %s\n",message.notification.decrypted_value);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Decrypted Value: %s\n", message.notification.decrypted_value);
 
     // compare the decrypted value with the expected value
     if (strcmp(message.notification.decrypted_value, ATKEY_VALUE) != 0) {
@@ -322,8 +322,8 @@ static int test_4_re_pkam_auth_and_start_monitor(atclient *monitor_conn) {
   char *atserver_host = strdup(monitor_conn->atserver_connection.host);
   int atserver_port = monitor_conn->atserver_connection.port;
 
-  if ((ret = atclient_monitor_pkam_authenticate(monitor_conn, monitor_conn->atsign, &(monitor_conn->atkeys),
-                                                NULL)) != 0) {
+  if ((ret = atclient_monitor_pkam_authenticate(monitor_conn, monitor_conn->atsign, &(monitor_conn->atkeys), NULL)) !=
+      0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to authenticate with PKAM: %d\n", ret);
     goto exit;
   }

--- a/tests/functional_tests/tests/test_atclient_sharedkey.c
+++ b/tests/functional_tests/tests/test_atclient_sharedkey.c
@@ -161,8 +161,9 @@ static int test_2_get_as_sharedby(atclient *atclient) {
     goto exit;
   }
 
-  if((ret = atclient_get_shared_key_request_options_set_store_atkey_metadata(&request_options, true)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_get_shared_key_request_options_set_store_atkey_metadata: %d\n", ret);
+  if ((ret = atclient_get_shared_key_request_options_set_store_atkey_metadata(&request_options, true)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "atclient_get_shared_key_request_options_set_store_atkey_metadata: %d\n", ret);
     goto exit;
   }
 
@@ -224,8 +225,9 @@ static int test_3_get_as_sharedwith(atclient *atclient2) {
     goto exit;
   }
 
-  if((ret = atclient_get_shared_key_request_options_set_store_atkey_metadata(&request_options, true)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_get_shared_key_request_options_set_store_atkey_metadata: %d\n", ret);
+  if ((ret = atclient_get_shared_key_request_options_set_store_atkey_metadata(&request_options, true)) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "atclient_get_shared_key_request_options_set_store_atkey_metadata: %d\n", ret);
     goto exit;
   }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Moved TLS sockets into a generic interface
  - Connection responsible for managing connections to atDirectory/atServer and parsing/stripping prompts from those connections
  - TLS sockets responsible for establishing TLS connections, and reading/writing raw bytes to and from those sockets

- TLS socket implementation can be swapped out without the need to reimplement all of connection which also contains a bunch of parsing logic

**- How I did it**

**- How to verify it**

**- Description for the changelog**
feat: move mbedtls sockets into its own layer under connection
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
