### PR TITLE
feat: let the caller handle monitor timeout behavior

### DIFF
--- a/packages/atclient/include/atclient/atclient_utils.h
+++ b/packages/atclient/include/atclient/atclient_utils.h
@@ -30,6 +30,17 @@ int atclient_utils_find_atserver_address(const char *atdirectory_host, const int
  */
 int atclient_utils_populate_atkeys_from_homedir(atclient_atkeys *atkeys, const char *atsign);
 
+/**
+ * @brief find the index of the next character after an atServer / atDirectory's prompt
+ *
+ * @param read_buf buffer to check
+ * @param read_n length of the buffer to check
+ * @param read_i output parameter containing the first token after the prompt
+ *
+ * @return int 0 on success, non-zero on error
+ */
+int atclient_utils_find_index_past_at_prompt(const unsigned char *read_buf, size_t read_n, size_t *read_i);
+
 #ifdef __cplusplus
 }
 #endif

--- a/packages/atclient/include/atclient/socket_shared.h
+++ b/packages/atclient/include/atclient/socket_shared.h
@@ -58,11 +58,6 @@ struct atclient_socket_read_options {
  */
 struct atclient_socket_read_options atclient_socket_read_until_char(char read_until);
 
-/**
- * @brief Creates read options configured to read until a specific character is encountered
- */
-struct atclient_socket_read_options atclient_socket_read_clear_at_prompt();
-
 #ifdef __cplusplus
 }
 #endif

--- a/packages/atclient/src/atclient_utils.c
+++ b/packages/atclient/src/atclient_utils.c
@@ -125,12 +125,16 @@ int atclient_utils_populate_atkeys_from_homedir(atclient_atkeys *atkeys, const c
 exit: { return ret; }
 }
 
-// TODO: unit test
 int atclient_utils_find_index_past_at_prompt(const unsigned char *read_buf, size_t read_n, size_t *read_i) {
   // NOTE: if you change this if, check the second while loop
   // it depends on this guard clause
   *read_i = 0;
   if (read_n != 0 && read_buf[0] != '@') { // Doesn't start with a prompt
+    return 0;
+  }
+
+  if (read_n >= 5 && strncmp((const char *)read_buf, "@null", 5) == 0) {
+    *read_i = 1;
     return 0;
   }
 

--- a/packages/atclient/src/atclient_utils.c
+++ b/packages/atclient/src/atclient_utils.c
@@ -124,3 +124,30 @@ int atclient_utils_populate_atkeys_from_homedir(atclient_atkeys *atkeys, const c
 
 exit: { return ret; }
 }
+
+// TODO: unit test
+int atclient_utils_find_index_past_at_prompt(const unsigned char *read_buf, size_t read_n, size_t *read_i) {
+  // NOTE: if you change this if, check the second while loop
+  // it depends on this guard clause
+  *read_i = 0;
+  if (read_n != 0 && read_buf[0] != '@') { // Doesn't start with a prompt
+    return 0;
+  }
+
+  while (++*read_i < read_n && read_buf[*read_i] != ':')
+    ;                      // Walks forward to the end of the buffer or first ':'
+  if (*read_i == read_n) { // Past the end of the buffer, did not find `:`
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "Unable to find command result token `:`, connection should be reset\n");
+    return 1;
+  }
+  // We are at a `:`
+  while (--*read_i > 0 && read_buf[*read_i] != '@')
+    ; // Walk backwards to the first '@' we find
+  // We are at the first character or last '@' before a `:`
+  // but the first character is '@' so we are at '@'
+
+  ++*read_i; // move forward one to be after the '@'
+
+  return 0;
+}

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -86,7 +86,7 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
 
   ret = atclient_tls_socket_connect(&ctx->_socket, host, port);
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "failed to connect to %s:%u", host, port);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "failed to connect to %s:%u\n", host, port);
     return ret;
   }
 

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -1,4 +1,5 @@
 #include "atclient/connection.h"
+#include "atclient/atclient_utils.h"
 #include "atclient/connection_hooks.h"
 #include "atclient/constants.h"
 #include "atclient/socket.h"
@@ -244,37 +245,6 @@ int atclient_connection_write(atclient_connection *ctx, const unsigned char *val
 exit: { return ret; }
 }
 
-// TODO:  unit test later, this is a pure function
-// TODO: name this better later, this is a private function
-// read_buf is the buffer to search
-// read_n is the length of the buffer
-// read_i is the output of the start of `data:` or other token like error
-
-static int find_index_past_at_prompt(const unsigned char *read_buf, size_t read_n, size_t *read_i) {
-  // NOTE: if you change this if, check the second while loop
-  // it depends on this guard clause
-  if (read_n != 0 && read_buf[0] != '@') { // Doesn't start with a prompt
-    return 0;
-  }
-
-  while (++*read_i < read_n && read_buf[*read_i] != ':')
-    ;                      // Walks forward to the end of the buffer or first ':'
-  if (*read_i == read_n) { // Past the end of the buffer, did not find `:`
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "Unable to find command result token `:`, connection should be reset\n");
-    return 1;
-  }
-  // We are at a `:`
-  while (--*read_i > 0 && read_buf[*read_i] != '@')
-    ; // Walk backwards to the first '@' we find
-  // We are at the first character or last '@' before a `:`
-  // but the first character is '@' so we are at '@'
-
-  ++*read_i; // move forward one to be after the '@'
-
-  return 0;
-}
-
 int atclient_connection_send(atclient_connection *ctx, const unsigned char *src, const size_t src_len,
                              unsigned char *recv, const size_t recv_size, size_t *recv_len) {
   int ret = 1;
@@ -423,7 +393,7 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
   }
 
   size_t read_i = 0; // will store where the start of `<type>:` is (if happy path)
-  ret = find_index_past_at_prompt(read_buf, read_n, &read_i);
+  ret = atclient_utils_find_index_past_at_prompt(read_buf, read_n, &read_i);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to parse the result read from the connection\n");
     free(read_buf);
@@ -435,9 +405,9 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     free(read_buf);
     goto exit;
   }
-
+  read_n -= read_i;
   // copy to recv, discarding the prompt
-  memcpy(recv, read_buf + read_i, read_n - read_i);
+  memcpy(recv, read_buf + read_i, read_n);
   free(read_buf);
   recv[read_n - 1] = '\0'; // null terminate the string
   *recv_len = read_n;
@@ -602,12 +572,32 @@ int atclient_connection_read(atclient_connection *ctx, unsigned char **value, si
   /*
    * 4. Read the value
    */
-  ret = atclient_tls_socket_read(&ctx->_socket, value, value_len, atclient_socket_read_until_char('\n'));
+  unsigned char *read_buf;
+  size_t read_n;
+  ret = atclient_tls_socket_read(&ctx->_socket, &read_buf, &read_n, atclient_socket_read_until_char('\n'));
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read from the connection\n", ret);
     goto exit;
   }
-  *value[*value_len - 1] = '\0'; // replace '\n' with '\0'
+  size_t read_i = 0; // will store where the start of `<type>:` is (if happy path)
+  ret = atclient_utils_find_index_past_at_prompt(*value, *value_len, &read_i);
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to parse the result read from the connection\n");
+    free(read_buf);
+    goto exit;
+  }
+  read_n -= read_i;
+  *value = malloc(read_n * sizeof(char));
+  if (*value == NULL) {
+    free(read_buf);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for the final output buffer\n");
+    goto exit;
+  }
+  memcpy(*value, read_buf + read_i, read_n);
+  free(read_buf);
+  *value[read_n - 1] = '\0'; // null terminate the string
+  *value_len = read_n;
+
   /*
    * 5. Print debug log
    */

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -1,5 +1,6 @@
 #include "atclient/monitor.h"
 #include "atclient/atclient.h"
+#include "atclient/atclient_utils.h"
 #include "atclient/atnotification.h"
 #include "atclient/connection.h"
 #include "atclient/constants.h"
@@ -18,7 +19,7 @@
 
 #define TAG "atclient_monitor"
 
-static int parse_message(char *original, char **message_type, char **message_body);
+static int parse_message(char *original, size_t original_len, char **message_type, char **message_body);
 static int parse_notification(atclient_atnotification *notification, const char *messagebody);
 static int decrypt_notification(atclient *monitor_conn, atclient_atnotification *notification);
 
@@ -125,17 +126,17 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
     goto exit;
   }
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, (int)strlen((char *)buffer),
-               buffer, ATCLIENT_RESET);
-
   char *messagetype = NULL;
   char *messagebody = NULL;
-  ret = parse_message((char *)buffer, &messagetype, &messagebody);
+  ret = parse_message((char *)buffer, buffer_len, &messagetype, &messagebody);
   if (ret != 0) {
     message->type = ATCLIENT_MONITOR_ERROR_PARSE_NOTIFICATION;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Failed to find message type and message body from: %s\n", buffer);
     goto exit;
   }
+
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, (int)strlen((char *)buffer),
+               buffer, ATCLIENT_RESET);
 
   if (strcmp(messagetype, "notification") == 0) {
     message->type = ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION;
@@ -212,10 +213,20 @@ bool atclient_monitor_is_connected(atclient *monitor_conn) {
 // given a string notification (*original is assumed to JSON parsable), we can deduce the message_type (e.g. data,
 // error, notification) and return the message body which is everything after the prefix (data:, error:, notification:).
 // This function will modify *message_type and *message_body to point to the respective values in *original.
-static int parse_message(char *original, char **message_type, char **message_body) {
+static int parse_message(char *original, size_t original_len, char **message_type, char **message_body) {
   int ret = -1;
   char *temp = NULL;
   char *saveptr;
+
+  size_t read_i;
+  ret = atclient_utils_find_index_past_at_prompt((unsigned char *)original, original_len, &read_i);
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Failed to parse the message: %.*s\n", original_len, original);
+    goto exit;
+  }
+  original = original + read_i;
+  original_len = original_len - read_i;
+  original[original_len - 1] = '\0';
 
   // Parse the message type (everything before ':')
   temp = strtok_r(original, ":", &saveptr);

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -126,6 +126,9 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
     goto exit;
   }
 
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, buffer_len, buffer,
+               ATCLIENT_RESET);
+
   char *messagetype = NULL;
   char *messagebody = NULL;
   ret = parse_message((char *)buffer, buffer_len, &messagetype, &messagebody);
@@ -134,9 +137,6 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Failed to find message type and message body from: %s\n", buffer);
     goto exit;
   }
-
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, (int)strlen((char *)buffer),
-               buffer, ATCLIENT_RESET);
 
   if (strcmp(messagetype, "notification") == 0) {
     message->type = ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION;

--- a/packages/atclient/src/socket_mbedtls.c
+++ b/packages/atclient/src/socket_mbedtls.c
@@ -343,7 +343,7 @@ int atclient_tls_socket_read_until_char(struct atclient_tls_socket *socket, unsi
         } else {
           char strerr[512];
           mbedtls_strerror(ret, strerr, 512);
-          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%s", strerr);
+          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%s\n", strerr);
         }
         free(recv);
         return ret;

--- a/packages/atclient/src/socket_mbedtls.c
+++ b/packages/atclient/src/socket_mbedtls.c
@@ -297,7 +297,6 @@ int atclient_tls_socket_read_until_char(struct atclient_tls_socket *socket, unsi
 
     // Read into current block
     size_t pos = 0; // position in current block
-    int timeout_count = 0;
     do {
       // When reading to a character we must read byte by byte to prevent
       // over reading and risk corrupting the next message
@@ -334,15 +333,8 @@ int atclient_tls_socket_read_until_char(struct atclient_tls_socket *socket, unsi
       case MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS: // crypto operation in progress
                                                // async error, we need to try again
         break;
-      case MBEDTLS_ERR_SSL_TIMEOUT: // timeout before reading the expected character
-                                    // timeout usually indicates nothing to read
-        timeout_count++;
-        if (timeout_count == MAX_READ_TIMEOUTS) {
-          atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Failed to read the full message after %d attempts\n",
-                       MAX_READ_TIMEOUTS);
-          return ATCLIENT_SSL_TIMEOUT_EXITCODE;
-        }
-        usleep(1000);
+      case MBEDTLS_ERR_SSL_TIMEOUT:
+        return ATCLIENT_SSL_TIMEOUT_EXITCODE;
         break;
         // unexpected errors while reading
       default:

--- a/packages/atclient/tests/test_parse_at_prompt.c
+++ b/packages/atclient/tests/test_parse_at_prompt.c
@@ -1,0 +1,206 @@
+#include "atlogger/atlogger.h"
+#include <atclient/atclient_utils.h>
+#include <stdio.h>
+#include <string.h>
+
+#define TAG "test_parse_at_prompt"
+static int test_1_atdirectory();
+static int test_2_raw_atdirectory();
+static int test_3_raw_notification();
+static int test_4_prompt_notification();
+static int test_5_data_response();
+static int test_6_raw_data_response();
+static int test_7_authed_data_response();
+static int test_8_data_response();
+static int test_9_raw_data_response();
+static int test_10_authed_data_response();
+static int test_11_null_atdirectory();
+
+int main() {
+  int ret = 0;
+  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
+
+  ret += test_1_atdirectory();
+  ret += test_2_raw_atdirectory();
+  ret += test_3_raw_notification();
+  ret += test_4_prompt_notification();
+  ret += test_5_data_response();
+  ret += test_6_raw_data_response();
+  ret += test_7_authed_data_response();
+  ret += test_8_data_response();
+  ret += test_9_raw_data_response();
+  ret += test_10_authed_data_response();
+  ret += test_11_null_atdirectory();
+
+  if (ret > 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%d tests failed\n", ret);
+  }
+  return ret;
+}
+
+// returns 1 if EXP != ACT and logs the error
+#define expect_size_t(TEST_TAG, EXP, ACT)                                                                              \
+  if (EXP != ACT) {                                                                                                    \
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%s: wrong idx value (expected: %d, actual: %d)\n", TEST_TAG, EXP, \
+                 ACT);                                                                                                 \
+    return 1;                                                                                                          \
+  }
+
+#define test_1_buffer "@190de331-8c62-42af-a549-6d3cd449fd16.swarm0001.atsign.zone:1234"
+#define test_1_length strlen(test_1_buffer)
+int test_1_atdirectory() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_1_buffer, test_1_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+  expect_size_t("test 1", 1, idx);
+
+  return 0;
+}
+
+#define test_2_buffer "190de331-8c62-42af-a549-6d3cd449fd16.swarm0001.atsign.zone:1234"
+#define test_2_length strlen(test_2_buffer)
+int test_2_raw_atdirectory() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_2_buffer, test_2_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+
+  expect_size_t("test 2", 0, idx);
+
+  return 0;
+}
+
+#define test_3_buffer                                                                                                  \
+  "notification:{\"id\":\"-1\",\"from\":\"@snooker25\",\"to\":\"@snooker25\",\"key\":\"statsNotification.@"            \
+  "snooker25\",\"value\":\"6356\",\"operation\":\"update\",\"epochMillis\":1734724406170,"                             \
+  "\"messageType\":\"MessageType.key\",\"isEncrypted\":false,\"metadata\":null}"
+#define test_3_length strlen(test_3_buffer)
+int test_3_raw_notification() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_3_buffer, test_3_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+
+  expect_size_t("test 3", 0, idx);
+
+  return 0;
+}
+
+#define test_4_buffer                                                                                                  \
+  "@snooker25@notification:{\"id\":\"-1\",\"from\":\"@snooker25\",\"to\":\"@snooker25\",\"key\":\"statsNotification.@" \
+  "snooker25\",\"value\":\"6356\",\"operation\":\"update\",\"epochMillis\":1734724406170,"                             \
+  "\"messageType\":\"MessageType.key\",\"isEncrypted\":false,\"metadata\":null}"
+#define test_4_length strlen(test_4_buffer)
+int test_4_prompt_notification() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_4_buffer, test_4_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+
+  expect_size_t("test 4", 11, idx);
+
+  return 0;
+}
+
+#define test_5_buffer "@data:ok"
+#define test_5_length sizeof(test_5_buffer)
+int test_5_data_response() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_5_buffer, test_5_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+
+  expect_size_t("test 5", 1, idx);
+
+  return 0;
+}
+
+#define test_6_buffer "data:ok"
+#define test_6_length sizeof(test_6_buffer)
+int test_6_raw_data_response() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_6_buffer, test_6_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+
+  expect_size_t("test 6", 0, idx);
+
+  return 0;
+}
+
+#define test_7_buffer "@snooker25@data:ok"
+#define test_7_length sizeof(test_7_buffer)
+int test_7_authed_data_response() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_7_buffer, test_7_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+
+  expect_size_t("test 7", 11, idx);
+
+  return 0;
+}
+
+#define test_8_buffer "@error:AT0003-Invalid syntax : invalid command"
+#define test_8_length sizeof(test_8_buffer)
+int test_8_data_response() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_8_buffer, test_8_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+
+  expect_size_t("test 8", 1, idx);
+
+  return 0;
+}
+
+#define test_9_buffer "error:AT0003-Invalid syntax : invalid command"
+#define test_9_length sizeof(test_9_buffer)
+int test_9_raw_data_response() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_9_buffer, test_9_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+
+  expect_size_t("test 9", 0, idx);
+
+  return 0;
+}
+
+#define test_10_buffer "@snooker25@error:AT0003-Invalid syntax : invalid command"
+#define test_10_length sizeof(test_10_buffer)
+int test_10_authed_data_response() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_10_buffer, test_10_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+
+  expect_size_t("test 10", 11, idx);
+
+  return 0;
+}
+
+#define test_11_buffer "@null"
+#define test_11_length strlen(test_11_buffer)
+int test_11_null_atdirectory() {
+  size_t idx;
+  int ret = atclient_utils_find_index_past_at_prompt((unsigned char *)test_11_buffer, test_11_length, &idx);
+  if (ret != 0) {
+    return 1;
+  }
+
+  expect_size_t("test 11", 1, idx);
+
+  return 0;
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- mbedtls carries an internal buffer, so if we get a timeout there was truly nothing to read, which means the caller should handle it rather than monitor retrying

**- How I did it**

**- How to verify it**

**- Description for the changelog**
feat: let the caller handle monitor timeout behavior
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
