### PR TITLE
feat: memcheck with tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Configurable options
 set(TARGET_ESPIDF FALSE CACHE BOOL "Build for the espidf platform")
 
+option(ATSDK_MEMCHECK "Enable memcheck configuration" OFF)
 option(ATSDK_BUILD_TESTS "Build tests for atsdk ON | \"unit\" | \"func\" " OFF)
 
 # to avoid caching issues
@@ -21,6 +22,9 @@ else()
   set(ATSDK_BUILD_UNIT_TESTS OFF)
   set(ATSDK_BUILD_FUNCTIONAL_TESTS OFF)
 endif()
+
+# Disable building mbedtls programs
+set(ENABLE_PROGRAMS OFF)
 
 # Basic project setup
 cmake_minimum_required(VERSION 3.24)
@@ -111,5 +115,10 @@ if(ATSDK_BUILD_FUNCTIONAL_TESTS)
 endif()
 
 if(ATSDK_BUILD_UNIT_TESTS OR ATSDK_BUILD_FUNCTIONAL_TESTS)
+  if(ATSDK_MEMCHECK)
+    include(CTest)
+    add_compile_options(-fsanitize=address)
+    add_link_options(-fsanitize=address)
+  endif()
   enable_testing()
 endif()

--- a/justfile
+++ b/justfile
@@ -7,6 +7,8 @@ alias memd := memcheck-docker
 set dotenv-filename := "just.env"
 set dotenv-load
 
+# SETUP COMMANDS
+
 setup: configure-debug configure-test-func
   ln -s $PWD/build/debug/compile_commands.json $PWD
   ln -s $PWD/build/test-func/compile_commands.json $PWD/tests
@@ -19,8 +21,12 @@ clean:
   rm $PWD/compile_commands.json
   rm $PWD/tests/compile_commands.json
 
+# INSTALL COMMANDS
+
 install: build-debug
   cmake: --build $PWD/build/debug --target install
+
+# BUILD COMMANDS
 
 build-debug: configure-debug
   cmake --build $PWD/build/debug
@@ -40,6 +46,8 @@ build-test-all: configure-test-all
 build-test-memcheck: configure-test-memcheck
   cmake --build $PWD/build/test-memcheck
 
+# TEST COMMANDS
+
 test-unit: build-test-unit
   ctest --test-dir $PWD/build/test-unit
 
@@ -54,6 +62,8 @@ memcheck: build-test-memcheck
 
 memcheck-docker:
   docker run --rm --platform linux/amd64 --mount type=bind,src=$PWD,dst=/mnt/at_c atc-memcheck-docker:latest
+
+# CONFIGURE COMMANDS
 
 configure-debug:
   cmake -B $PWD/build/debug -S $PWD \
@@ -111,6 +121,8 @@ configure-test-memcheck:
     -DATSDK_MEMCHECK=ON \
     -DFIRST_ATSIGN="\"$FIRST_ATSIGN\"" \
     -DSECOND_ATSIGN="\"$SECOND_ATSIGN\""
+
+# DIAGNOSTIC COMMANDS
 
 show-env:
   echo "$FIRST_ATSIGN"

--- a/justfile
+++ b/justfile
@@ -57,11 +57,12 @@ test-func: build-test-func
 test-all: build-test-all
   ctest --test-dir $PWD/build/test-all
 
-memcheck: build-test-memcheck
-  ctest -T memcheck --test-dir $PWD/build/test-memcheck
+memcheck +ARGS='': build-test-memcheck
+  ctest -T memcheck --test-dir $PWD/build/test-memcheck {{ARGS}}
 
-memcheck-docker:
-  docker run --rm --platform linux/amd64 --mount type=bind,src=$PWD,dst=/mnt/at_c atc-memcheck-docker:latest
+memcheck-docker +ARGS='':
+  docker run --rm --platform linux/amd64 --mount type=bind,src=$PWD,dst=/mnt/at_c atc-memcheck-docker:latest \
+    just memcheck {{ARGS}}
 
 # CONFIGURE COMMANDS
 

--- a/packages/atauth/src/atactivate_arg_parser.c
+++ b/packages/atauth/src/atactivate_arg_parser.c
@@ -12,9 +12,10 @@ int atactivate_parse_args(const int argc, char *argv[], char **atsign, char **cr
                           char **app_name, char **device_name, char **namespaces, char **root_host, int *root_port) {
   int ret = 0, opt = 0;
   char *root_fqdn = NULL;
-  const char *usage = "Usage: \n\tActivate: \t./atactivate -a atsign -c cram-secret [-k path_to_store_keysfile] [-r root-domain]"
-                      "\n\n\tNew enrollment: ./at_auth_cli -a atsign -s otp/spp -p app_name -d device_name -n "
-                      "namespaces(\"wavi:rw,buzz:r\") [-k path_to_store_keysfile] [-r root-domain]\n";
+  const char *usage =
+      "Usage: \n\tActivate: \t./atactivate -a atsign -c cram-secret [-k path_to_store_keysfile] [-r root-domain]"
+      "\n\n\tNew enrollment: ./at_auth_cli -a atsign -s otp/spp -p app_name -d device_name -n "
+      "namespaces(\"wavi:rw,buzz:r\") [-k path_to_store_keysfile] [-r root-domain]\n";
 
   // Parse command-line arguments
   while ((opt = getopt(argc, argv, "a:c:k:s:p:d:n:r:vh")) != -1) {
@@ -140,12 +141,12 @@ exit:
 }
 
 int parse_root_domain(const char *root_domain_string, char **root_host, int *root_port) {
-  if(root_domain_string == NULL) {
+  if (root_domain_string == NULL) {
     return 1;
   }
   *root_host = strdup(strtok((char *)root_domain_string, ":"));
   *root_port = atoi(strtok(NULL, ":"));
-  if(*root_host == NULL || root_port == NULL) {
+  if (*root_host == NULL || root_port == NULL) {
     return 1;
   }
   return 0;

--- a/packages/atchops/src/rsa_key.c
+++ b/packages/atchops/src/rsa_key.c
@@ -320,12 +320,13 @@ int atchops_rsa_key_generate_base64(unsigned char **public_key_base64_output,
 
   // 7b. Second, we need to add headers to the PKCS#1 formatted private key to make it PKCS#8 formatted
   const size_t private_key_pkcs8_size = private_key_non_base64_len + 22;
-  private_key_pkcs8 = (unsigned char *)malloc(private_key_pkcs8_size);
+  const size_t private_key_alloc_size = private_key_pkcs8_size + 4;
+  private_key_pkcs8 = (unsigned char *)malloc(private_key_alloc_size);
   if (private_key_pkcs8 == NULL) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for private_key_pkcs8\n");
     goto exit;
   }
-  memset(private_key_pkcs8, 0, sizeof(unsigned char) * private_key_pkcs8_size);
+  memset(private_key_pkcs8, 0, sizeof(unsigned char) * private_key_alloc_size);
   // https://lapo.it/asn1js/ use this to debug
   // PrivateKeyInfo SEQUENCE (3 elements)
   private_key_pkcs8[0] = 0x30; // constructed sequence tag

--- a/packages/atchops/tests/test_rsaencrypt.c
+++ b/packages/atchops/tests/test_rsaencrypt.c
@@ -1,9 +1,9 @@
 
 #include "atchops/rsa.h"
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stddef.h>
 
 // #define PUBLICKEYBASE64                                                                                                \
 //   "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAg3P7mefqZg2GNQPiEHYinmTYUcbbW2Ar9Wi5LCD/"                               \
@@ -12,7 +12,12 @@
 //   "FutJTF8M6LKQY8E+h2cQjTEn3RRJlcMp4rwq/0GNmm3mNY5EhUcamKiSWILG9a8nYzeIUafXmESCZk+J1yVu9QcmXP8Dokv+4KLv76/"            \
 //   "Y1RsqQIDAQAB"
 
-#define PUBLICKEYBASE64 "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0puvhTIiwSaqM9j6zPbvgEaj0Byg4AU/mtL5d6j6hnjJt6BDeztfqOxmLz9s+5NYHnS5ZExbtOohlFZXqISI39EWBsKgcqTOgfjCCWj3Cf1BbbNFiz/D322BvT6TLYeMtErSaQYPlQk4i3GZkp2SfwQcJ9CM7Gp+uCHTZ3NxEuU3Ut3roYOhKEVI72XesMPDlf4y8nSAsrpWs9KbU3isflj0yQXqMH3NXbDn2ie7h02Ul+u1fBuRs05TEFfaYt7R5ia+4USvcnkzGtA7mm8Xyo7AF2ZWnWYfx+368936buo7Vu9twt4Xynd/rvMxv2Fc/H/CFN9SI/n6zRN97uf85wIDAQAB"
+#define PUBLICKEYBASE64                                                                                                \
+  "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0puvhTIiwSaqM9j6zPbvgEaj0Byg4AU/"                                       \
+  "mtL5d6j6hnjJt6BDeztfqOxmLz9s+5NYHnS5ZExbtOohlFZXqISI39EWBsKgcqTOgfjCCWj3Cf1BbbNFiz/"                                \
+  "D322BvT6TLYeMtErSaQYPlQk4i3GZkp2SfwQcJ9CM7Gp+"                                                                      \
+  "uCHTZ3NxEuU3Ut3roYOhKEVI72XesMPDlf4y8nSAsrpWs9KbU3isflj0yQXqMH3NXbDn2ie7h02Ul+u1fBuRs05TEFfaYt7R5ia+"               \
+  "4USvcnkzGtA7mm8Xyo7AF2ZWnWYfx+368936buo7Vu9twt4Xynd/rvMxv2Fc/H/CFN9SI/n6zRN97uf85wIDAQAB"
 
 #define PLAINTEXT "banana"
 
@@ -28,7 +33,6 @@ int main() {
   const size_t ciphertextsize = 256;
   unsigned char ciphertext[ciphertextsize];
   memset(ciphertext, 0, sizeof(unsigned char) * ciphertextsize);
-  size_t ciphertextlen = 0;
 
   atchops_rsa_key_public_key publickey;
   atchops_rsa_key_public_key_init(&publickey);
@@ -46,11 +50,9 @@ int main() {
     goto ret;
   }
   printf("atchops_rsa_encrypt (success): %d\n", ret);
-  printf("ciphertext (base64 encoded): \"%s\"\n", ciphertext);
+  printf("ciphertext (base64 encoded): \"%.*s\"\n", (int)ciphertextsize, ciphertext);
 
   goto ret;
 
-ret: {
-  return ret;
-}
+ret: { return ret; }
 }

--- a/packages/atchops/tests/test_rsasign.c
+++ b/packages/atchops/tests/test_rsasign.c
@@ -70,7 +70,7 @@ int main() {
     goto exit;
   }
   printf("atchops_rsa_sign (success): %d\n", ret);
-  printf("signature: \"%s\"\n", signature);
+  printf("signature: \"%.*s\"\n", SIGNATURE_SIZE, signature);
 
   ret = atchops_base64_encode(signature, SIGNATURE_SIZE, (unsigned char *)signaturebase64, SIGNATURE_BASE64_SIZE,
                               &signaturebase64len);

--- a/packages/atclient/tests/CMakeLists.txt
+++ b/packages/atclient/tests/CMakeLists.txt
@@ -8,4 +8,3 @@ foreach(file ${files})
   target_link_libraries(${filename} PRIVATE atclient)
   add_test(NAME ${filename} COMMAND $<TARGET_FILE:${filename}>)
 endforeach()
-

--- a/packages/atcommons/tests/CMakeLists.txt
+++ b/packages/atcommons/tests/CMakeLists.txt
@@ -1,11 +1,11 @@
 include_directories(${PROJECT_SOURCE_DIR}/src)
 file(GLOB_RECURSE files ${CMAKE_CURRENT_LIST_DIR}/test_*.c)
-foreach (file ${files})
-    # ${filename} - without `.c`
-    get_filename_component(filename ${file} NAME)
-    string(REPLACE ".c" "" filename ${filename})
+foreach(file ${files})
+  # ${filename} - without `.c`
+  get_filename_component(filename ${file} NAME)
+  string(REPLACE ".c" "" filename ${filename})
 
-    add_executable(${filename} ${file})
-    target_link_libraries(${filename} PRIVATE atcommons)
-    add_test(NAME ${filename} COMMAND $<TARGET_FILE:${filename}>)
-endforeach ()
+  add_executable(${filename} ${file})
+  target_link_libraries(${filename} PRIVATE atcommons)
+  add_test(NAME ${filename} COMMAND $<TARGET_FILE:${filename}>)
+endforeach()

--- a/valgrind.Dockerfile
+++ b/valgrind.Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get install -y git-core \
 
 WORKDIR /mnt/at_c
 
-CMD [ "just", "memcheck" ]
+CMD [ "tail", "-f", "/dev/null" ]
 

--- a/valgrind.Dockerfile
+++ b/valgrind.Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+
+RUN apt-get update; apt-get upgrade -y
+RUN apt-get install -y git-core \
+  build-essential \
+  sudo \
+  curl \
+  just \
+  valgrind \
+  gcc \
+  cmake
+
+WORKDIR /mnt/at_c
+
+CMD [ "just", "memcheck" ]
+


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added a Dockerfile to build a memcheck environment that can be run locally
  - Neither valgrind or valgrind-macos are supported on apple silicon, hence the need for docker
- Added three main just commands:
  - `just memcheck`
    - run memcheck without the docker container, suitable for machines which are configured to run ctest memcheck
  - `just setup-memcheck-docker`
    - calls docker build with the appropriate arguments
  - `just memcheck-docker` or `just memd` (alias)
    - Runs the `ctest -T memcheck ...` in a temporary docker container
    - The build & test logs are cached on disk, meaning re-runs don't require a full rebuild
- There are some discovered leaks which need to be resolved before we add this to CI

**- How I did it**

**- How to verify it**

Local run:
https://gist.github.com/XavierChanth/7051e076e9e03cdf1444c6484c69a386

**- Description for the changelog**
feat: memcheck with tests
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
