### PR TITLE
feat: atserver_message struct

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build atSDK
         run: |
-          cmake -S . -B build -DATSDK_BUILD_TESTS="unit"
+          cmake -S . -B build -DATSDK_BUILD_TESTS="unit" -DCMAKE_BUILD_TYPE="Debug"
           cmake --build build --target all
 
       - name: atchops Unit CTest

--- a/justfile
+++ b/justfile
@@ -48,14 +48,14 @@ build-test-memcheck: configure-test-memcheck
 
 # TEST COMMANDS
 
-test-unit: build-test-unit
-  ctest --test-dir $PWD/build/test-unit
+test-unit +ARGS='': build-test-unit
+  ctest --test-dir $PWD/build/test-unit {{ARGS}}
 
-test-func: build-test-func
-  ctest --test-dir $PWD/build/test-func
+test-func +ARGS='': build-test-func
+  ctest --test-dir $PWD/build/test-func {{ARGS}}
 
-test-all: build-test-all
-  ctest --test-dir $PWD/build/test-all
+test-all +ARGS='': build-test-all
+  ctest --test-dir $PWD/build/test-all {{ARGS}}
 
 memcheck +ARGS='': build-test-memcheck
   ctest -T memcheck --test-dir $PWD/build/test-memcheck {{ARGS}}

--- a/packages/atclient/CMakeLists.txt
+++ b/packages/atclient/CMakeLists.txt
@@ -3,6 +3,7 @@ option(ATCLIENT_BUILD_TESTS "Build tests for atclient" OFF)
 
 # Set include directory and file sources
 set(ATCLIENT_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
+set(ATCLIENT_PROTECTED_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
 set(
   ATCLIENT_SOURCES
   ${CMAKE_CURRENT_LIST_DIR}/src/atclient_delete.c
@@ -126,6 +127,13 @@ if(NOT ESP_PLATFORM)
       $<BUILD_INTERFACE:${cjson_SOURCE_DIR}>
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   )
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_include_directories(
+      ${PROJECT_NAME}
+      PUBLIC $<BUILD_INTERFACE:${ATCLIENT_PROTECTED_INCLUDE_DIR}>
+    )
+  endif()
 
   # Link dependencies to library targets
   set(

--- a/packages/atclient/CMakeLists.txt
+++ b/packages/atclient/CMakeLists.txt
@@ -30,6 +30,9 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/src/notify_params.c
   ${CMAKE_CURRENT_LIST_DIR}/src/request_options.c
   ${CMAKE_CURRENT_LIST_DIR}/src/string_utils.c
+  # protected files
+  ${CMAKE_CURRENT_LIST_DIR}/src/atserver_message.h
+  ${CMAKE_CURRENT_LIST_DIR}/src/atserver_message.c
 )
 
 # Project setup

--- a/packages/atclient/src/atserver_message.c
+++ b/packages/atclient/src/atserver_message.c
@@ -1,0 +1,69 @@
+#include "./atserver_message.h"
+#include <stdlib.h>
+
+const char *atserver_message_get_prompt(struct atserver_message message) {
+  if (message.buffer == NULL || atserver_message_get_prompt_len(message) == 0) {
+    return NULL;
+  }
+  return message.buffer;
+}
+
+const char *atserver_message_get_token(struct atserver_message message) {
+  if (message.buffer == NULL || atserver_message_get_token_len(message) == 0) {
+    return NULL;
+  }
+
+  return message.buffer + message.prompt_len;
+}
+
+const char *atserver_message_get_body(struct atserver_message message) {
+  if (message.buffer == NULL || atserver_message_get_body_len(message) == 0) {
+    return NULL;
+  }
+  return message.buffer + message.token_len + message.prompt_len;
+}
+
+uint8_t atserver_message_get_prompt_len(struct atserver_message message) { return message.prompt_len; }
+
+uint8_t atserver_message_get_token_len(struct atserver_message message) { return message.token_len; }
+
+uint16_t atserver_message_get_body_len(struct atserver_message message) {
+  return message.len - message.token_len - message.prompt_len;
+}
+
+struct atserver_message atserver_message_parse(char *buffer, uint16_t len) {
+  uint16_t prompt_len = 0;
+  uint16_t token_len = 0;
+  // 0123456789
+  // @foo@data:bar
+
+  // find the end of the token
+  while (++token_len < len && buffer[token_len] != ':')
+    ; // walk to the end of the token section
+  if (token_len == len) {
+    // Parse error, token not found
+    return (struct atserver_message){NULL, 0, 0, 0};
+  }
+
+  // parse the prompt len (if prompt exists in buffer)
+  if (buffer[0] == '@') {
+    prompt_len = token_len;
+    while (--prompt_len > 0 && prompt_len != '@')
+      ; // walk to the end of the prompt section
+    token_len -= prompt_len;
+
+    prompt_len++; // corrected for 0 based indexing
+  }
+
+  if (prompt_len > UINT8_MAX || token_len > UINT8_MAX) {
+    // Parse error, by specification they should never come close to exceeding UINT8_MAX
+    return (struct atserver_message){NULL, 0, 0, 0};
+  }
+
+  return (struct atserver_message){buffer, len, prompt_len, token_len};
+}
+
+void atserver_message_free(struct atserver_message message) {
+  if (message.buffer != NULL)
+    free((char *)message.buffer);
+}

--- a/packages/atclient/src/atserver_message.h
+++ b/packages/atclient/src/atserver_message.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 struct atserver_message {
-  const char *buffer;
+  char *buffer;
   // metadata about buffer
   // len: length of the buffer
   // prompt: is `@` || `@<atsign>@` portion
@@ -23,15 +23,14 @@ struct atserver_message {
   // body_len = len - prompt_len - token_len
 };
 
-const char *atserver_message_get_prompt(struct atserver_message message);
-const char *atserver_message_get_token(struct atserver_message message);
-const char *atserver_message_get_body(struct atserver_message message);
-
-uint8_t atserver_message_get_prompt_len(struct atserver_message message);
-uint8_t atserver_message_get_token_len(struct atserver_message message);
 uint16_t atserver_message_get_body_len(struct atserver_message message);
 
+const char *atserver_message_get_prompt(struct atserver_message message);
+const char *atserver_message_get_token(struct atserver_message message);
+char *atserver_message_get_body(struct atserver_message message);
+
 struct atserver_message atserver_message_parse(char *buffer, uint16_t len);
+void atserver_message_free(struct atserver_message *message);
 
 #ifdef __cplusplus
 }

--- a/packages/atclient/src/atserver_message.h
+++ b/packages/atclient/src/atserver_message.h
@@ -1,0 +1,40 @@
+#ifndef ATSERVER_MESSAGE_H
+#define ATSERVER_MESSAGE_H
+
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct atserver_message {
+  const char *buffer;
+  // metadata about buffer
+  // len: length of the buffer
+  // prompt: is `@` || `@<atsign>@` portion
+  // token: is `data:` || `error:` || `notification:`
+  // body: is the rest of the response contents
+
+  const uint16_t len;
+  // prompt offset is derived as 0 if prompt_len > 0
+  const uint8_t prompt_len;
+  // token offset = prompt_len
+  const uint8_t token_len;
+  // body offset = prompt_len + token_len
+  // body_len = len - prompt_len - token_len
+};
+
+const char *atserver_message_get_prompt(struct atserver_message message);
+const char *atserver_message_get_token(struct atserver_message message);
+const char *atserver_message_get_body(struct atserver_message message);
+
+uint8_t atserver_message_get_prompt_len(struct atserver_message message);
+uint8_t atserver_message_get_token_len(struct atserver_message message);
+uint16_t atserver_message_get_body_len(struct atserver_message message);
+
+struct atserver_message atserver_message_parse(char *buffer, uint16_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/packages/atclient/tests/test_atserver_message.c
+++ b/packages/atclient/tests/test_atserver_message.c
@@ -1,0 +1,245 @@
+#include "atlogger/atlogger.h"
+#include "atserver_message.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BASE_TAG(X) "test_atserver_message " X
+
+// non-heap tests
+static uint8_t test_1a_long_prompt();
+static uint8_t test_1b_short_prompt();
+static uint8_t test_1c_no_prompt();
+static uint8_t test_2a_no_token();
+static uint8_t test_3a_no_body();
+static uint8_t test_4a_empty_message();
+
+// heap tests
+static uint8_t test_5a_heap();
+static uint8_t test_5b_bad_parse_heap();
+
+int main() {
+  int ret = 0;
+  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
+
+  ret += test_1a_long_prompt();
+  ret += test_1b_short_prompt();
+  ret += test_1c_no_prompt();
+  ret += test_2a_no_token();
+  ret += test_3a_no_body();
+  ret += test_4a_empty_message();
+  ret += test_5a_heap();
+  ret += test_5b_bad_parse_heap();
+
+  if (ret > 0) {
+    atlogger_log("test_atserver_message", ATLOGGER_LOGGING_LEVEL_ERROR, "%d tests failed\n", ret);
+  }
+  return ret;
+}
+
+#define expect_uint(TEST_TAG, EXP, ACT)                                                                                \
+  if (EXP != ACT) {                                                                                                    \
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%s: incorrect value (expected: %u, actual: %u)\n", TEST_TAG, EXP, \
+                 ACT);                                                                                                 \
+    return 1;                                                                                                          \
+  }
+
+uint8_t test_1a_long_prompt() {
+  const char *TAG = BASE_TAG("1a");
+  char *buffer = "@foobar@data:baz";
+  const uint16_t len = strlen(buffer);
+
+  struct atserver_message message = atserver_message_parse(buffer, len);
+
+  if (message.buffer == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "message.buffer is NULL\n");
+    return 1;
+  }
+
+  expect_uint("prompt len", 8, message.prompt_len);
+  expect_uint("token len", 5, message.token_len);
+  expect_uint("body len", 3, atserver_message_get_body_len(message));
+  expect_uint("len", 16, message.len);
+
+  return 0;
+}
+
+uint8_t test_1b_short_prompt() {
+  const char *TAG = BASE_TAG("1b");
+  char *buffer = "@data:baz";
+  const uint16_t len = strlen(buffer);
+
+  struct atserver_message message = atserver_message_parse(buffer, len);
+
+  if (message.buffer == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "message.buffer is NULL\n");
+    return 1;
+  }
+
+  expect_uint("prompt len", 1, message.prompt_len);
+  expect_uint("token len", 5, message.token_len);
+  expect_uint("body len", 3, atserver_message_get_body_len(message));
+  expect_uint("len", 9, message.len);
+
+  return 0;
+}
+
+uint8_t test_1c_no_prompt() {
+  const char *TAG = BASE_TAG("1c");
+  char *buffer = "data:baz";
+  const uint16_t len = strlen(buffer);
+
+  struct atserver_message message = atserver_message_parse(buffer, len);
+
+  if (message.buffer == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "message.buffer is NULL\n");
+    return 1;
+  }
+
+  expect_uint("prompt len", 0, message.prompt_len);
+  expect_uint("token len", 5, message.token_len);
+  expect_uint("body len", 3, atserver_message_get_body_len(message));
+  expect_uint("len", 8, message.len);
+
+  return 0;
+}
+
+uint8_t test_2a_no_token() {
+  const char *TAG = BASE_TAG("2a");
+  char *buffer = "@foo@baz";
+  const uint16_t len = strlen(buffer);
+
+  struct atserver_message message = atserver_message_parse(buffer, len);
+
+  if (message.buffer != NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "message.buffer is expected to be NULL but it isn't\n");
+    return 1;
+  }
+
+  expect_uint("prompt len", 0, message.prompt_len);
+  expect_uint("token len", 0, message.token_len);
+  expect_uint("body len", 0, atserver_message_get_body_len(message));
+  expect_uint("len", 0, message.len);
+
+  return 0;
+}
+
+uint8_t test_3a_no_body() {
+  const char *TAG = BASE_TAG("3a");
+  char *buffer = "@foobar@data:";
+  const uint16_t len = strlen(buffer);
+
+  struct atserver_message message = atserver_message_parse(buffer, len);
+
+  if (message.buffer == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "message.buffer is NULL\n");
+    return 1;
+  }
+
+  expect_uint("prompt len", 8, message.prompt_len);
+  expect_uint("token len", 5, message.token_len);
+  expect_uint("body len", 0, atserver_message_get_body_len(message));
+  expect_uint("len", 13, message.len);
+
+  return 0;
+}
+
+uint8_t test_4a_empty_message() {
+  const char *TAG = BASE_TAG("4a");
+  char *buffer = "";
+  const uint16_t len = strlen(buffer);
+
+  struct atserver_message message = atserver_message_parse(buffer, len);
+
+  if (message.buffer != NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "message.buffer is expected to be NULL but it isn't\n");
+    return 1;
+  }
+
+  expect_uint("prompt len", 0, message.prompt_len);
+  expect_uint("token len", 0, message.token_len);
+  expect_uint("body len", 0, atserver_message_get_body_len(message));
+  expect_uint("len", 0, message.len);
+
+  return 0;
+}
+
+uint8_t test_5a_heap() {
+  const char *TAG = BASE_TAG("5a");
+  char *static_buffer = "@foobar@data:baz";
+  const uint16_t len = strlen(static_buffer);
+  char *heap_buffer = malloc(sizeof(char) * len);
+  if (heap_buffer == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate heap buffer for test\n");
+    return 1;
+  }
+  memcpy(heap_buffer, static_buffer, sizeof(char) * len);
+
+  struct atserver_message message = atserver_message_parse(heap_buffer, len);
+
+  if (message.buffer == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "message.buffer is NULL\n");
+    free(heap_buffer);
+    return 1;
+  }
+
+  expect_uint("prompt len", 8, message.prompt_len);
+  expect_uint("token len", 5, message.token_len);
+  expect_uint("body len", 3, atserver_message_get_body_len(message));
+  expect_uint("len", 16, message.len);
+
+  message.buffer[0] = 'H';
+  if (strncmp(heap_buffer, "Hfoobar@data:baz", len) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "message.buffer is not the original heap buffer\n");
+    free(heap_buffer);
+    return 1;
+  }
+
+  atserver_message_free(&message);
+  if (message.buffer != NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "message.buffer is expected to be NULL after free but it isn't: %zu\n", message.buffer);
+    return 1;
+  }
+
+  atserver_message_free(&message); // call again to ensure resilience against double free
+
+  return 0;
+}
+
+uint8_t test_5b_bad_parse_heap() {
+  const char *TAG = BASE_TAG("5b");
+  char *static_buffer = "@foobar@baz";
+  const uint16_t len = strlen(static_buffer);
+  char *heap_buffer = malloc(sizeof(char) * len);
+  if (heap_buffer == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate heap buffer for test\n");
+    return 1;
+  }
+  memcpy(heap_buffer, static_buffer, sizeof(char) * len);
+
+  struct atserver_message message = atserver_message_parse(heap_buffer, len);
+
+  if (message.buffer != NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "message.buffer is expected to be NULL but it isn't\n");
+    free(heap_buffer);
+    return 1;
+  }
+
+  expect_uint("prompt len", 0, message.prompt_len);
+  expect_uint("token len", 0, message.token_len);
+  expect_uint("body len", 0, atserver_message_get_body_len(message));
+  expect_uint("len", 0, message.len);
+
+  // ensure original heap buffer is intact
+  if (strncmp(heap_buffer, static_buffer, len) != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "heap_buffer is malformed after a failed parse\n");
+    free(heap_buffer);
+    return 1;
+  }
+
+  free(heap_buffer);
+
+  return 0;
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added atserver_message struct with protected header file in `src/`
  - Building atclient in Debug mode will include protected symbols
  - Building atclient in Release mode will not include protected symbols (they will still be built internally but not exposed)
    - Note that referencing symbols must be done using the relative include approach
      i.e `#include "atserver_message.h"` NOT `#include <atserver_message.h>` 
- Added parsing and memory management tests for atserver_message struct
- Added flag passthrough to ctest for other test types in just file

**- How I did it**

**- How to verify it**

- Unit tests pass
  - Future changes to integrate this struct into parts of the SDK will yield further validation or necessary changes

**- Description for the changelog**
feat: atserver_message struct
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
