### PR TITLE
fix: memory leaks in tests

### DIFF
--- a/packages/atchops/src/rsa.c
+++ b/packages/atchops/src/rsa.c
@@ -243,6 +243,8 @@ int atchops_rsa_verify(const atchops_rsa_key_public_key *public_key, const atcho
   goto exit;
 exit: {
   mbedtls_rsa_free(&rsa);
+  mbedtls_entropy_free(&entropy_ctx);
+  mbedtls_ctr_drbg_free(&ctr_drbg_ctx);
   return ret;
 }
 }

--- a/packages/atchops/src/rsa_key.c
+++ b/packages/atchops/src/rsa_key.c
@@ -403,6 +403,9 @@ int atchops_rsa_key_generate_base64(unsigned char **public_key_base64_output,
   (*private_key_base64_output)[private_key_base64_pkcs8_len] = '\0';
 
 exit: {
+  mbedtls_ctr_drbg_free(&ctr_drbg);
+  mbedtls_entropy_free(&entropy);
+  mbedtls_pk_free(&pk);
   free(private_key_non_base64);
   free(private_key_pkcs8);
   free(private_key_pkcs8_base64);

--- a/packages/atchops/tests/test_rsadecrypt.c
+++ b/packages/atchops/tests/test_rsadecrypt.c
@@ -74,5 +74,8 @@ int main() {
 
   goto ret;
 
-ret: { return ret; }
+ret: {
+  atchops_rsa_key_private_key_free(&privatekey);
+  return ret;
+}
 }

--- a/packages/atchops/tests/test_rsaencrypt.c
+++ b/packages/atchops/tests/test_rsaencrypt.c
@@ -54,5 +54,8 @@ int main() {
 
   goto ret;
 
-ret: { return ret; }
+ret: {
+  atchops_rsa_key_public_key_free(&publickey);
+  return ret;
+}
 }

--- a/packages/atchops/tests/test_rsaprivatepopulate.c
+++ b/packages/atchops/tests/test_rsaprivatepopulate.c
@@ -85,5 +85,8 @@ int main() {
   printf("\n");
 
   goto exit;
-exit: { return ret; }
+exit: {
+  atchops_rsa_key_private_key_free(&privatekey);
+  return ret;
+}
 }

--- a/packages/atchops/tests/test_rsapublicpopulate.c
+++ b/packages/atchops/tests/test_rsapublicpopulate.c
@@ -1,8 +1,8 @@
 
 #include "atchops/rsa_key.h"
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
-#include <stddef.h>
 
 #define PUBLIC_KEY_BASE64                                                                                              \
   "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsuuD88vWQ3Zunves9w5o3pLQ+7ClKONAMftVQ9dirJt6VD0xg5DNzX+"                \
@@ -48,5 +48,8 @@ int main() {
   printf("\n");
 
   goto exit;
-exit: { return ret; }
+exit: {
+  atchops_rsa_key_public_key_free(&publickey);
+  return ret;
+}
 }

--- a/packages/atchops/tests/test_rsasign.c
+++ b/packages/atchops/tests/test_rsasign.c
@@ -92,5 +92,8 @@ int main() {
 
   goto exit;
 
-exit: { return ret; }
+exit: {
+  atchops_rsa_key_private_key_free(&privatekey);
+  return ret;
+}
 }

--- a/packages/atchops/tests/test_rsaverify.c
+++ b/packages/atchops/tests/test_rsaverify.c
@@ -103,5 +103,9 @@ int main() {
 
   goto exit;
 
-exit: { return ret; }
+exit: {
+  atchops_rsa_key_public_key_free(&publickey);
+  atchops_rsa_key_private_key_free(&privatekey);
+  return ret;
+}
 }

--- a/packages/atclient/src/atkey.c
+++ b/packages/atclient/src/atkey.c
@@ -65,6 +65,10 @@ exit: { return ret; }
 }
 
 void atclient_atkey_free(atclient_atkey *atkey) {
+  atclient_atkey_unset_key(atkey);
+  atclient_atkey_unset_namespace_str(atkey);
+  atclient_atkey_unset_shared_by(atkey);
+  atclient_atkey_unset_shared_with(atkey);
   atclient_atkey_metadata_free(&(atkey->metadata));
   memset(atkey, 0, sizeof(atclient_atkey));
 }

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -747,6 +747,7 @@ static int atclient_connection_set_host(atclient_connection *ctx, const char *ho
     return ret;
   }
 
+  char *old_host = ctx->host;
   /*
    * 2. Allocate memory for the host
    */
@@ -757,6 +758,7 @@ static int atclient_connection_set_host(atclient_connection *ctx, const char *ho
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for host\n");
     goto exit;
   }
+  free(old_host);
 
   /*
    * 3. Copy the host

--- a/packages/atclient/src/socket_mbedtls.c
+++ b/packages/atclient/src/socket_mbedtls.c
@@ -133,12 +133,12 @@ exit:
 
 void atclient_tls_socket_free(struct atclient_tls_socket *socket) {
   if (socket != NULL) {
-    atclient_raw_socket_free(&socket->raw);
     mbedtls_ssl_free(&socket->ssl);
     mbedtls_ssl_config_free(&socket->ssl_config);
     mbedtls_entropy_free(&(socket->entropy));
     mbedtls_ctr_drbg_free(&(socket->ctr_drbg));
     mbedtls_x509_crt_free(&(socket->cacert));
+    atclient_raw_socket_free(&socket->raw);
     memset(socket, 0, sizeof(struct atclient_tls_socket));
   }
 }
@@ -147,7 +147,7 @@ static int atclient_tls_socket_ssl_handshake(struct atclient_tls_socket *socket,
 
 int atclient_tls_socket_connect(struct atclient_tls_socket *socket, const char *host, const uint16_t port) {
   if (socket == NULL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "tls socket is when trying to connect NULL\n");
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "tls socket is NULL when trying to connect\n");
     return 1;
   }
 
@@ -217,8 +217,11 @@ int atclient_tls_socket_disconnect(struct atclient_tls_socket *socket) {
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN,
                  "mbedtls_ssl_close_notify failed, socket will be silently closed, exit code: %d\n", ret);
-    return ret;
   }
+
+  mbedtls_ssl_free(&socket->ssl);
+  mbedtls_net_close(&socket->raw.net);
+  mbedtls_net_free(&socket->raw.net);
 
   return ret;
 }

--- a/packages/atclient/tests/test_atkey_from_string.c
+++ b/packages/atclient/tests/test_atkey_from_string.c
@@ -175,8 +175,8 @@ static int test1a_cached_publickey_without_namespace() {
   ret = 0;
   goto exit;
 exit: {
-  return ret;
   atclient_atkey_free(&atkey);
+  return ret;
 }
 }
 

--- a/packages/atclient/tests/test_atkey_metadata.c
+++ b/packages/atclient/tests/test_atkey_metadata.c
@@ -316,6 +316,9 @@ static int test_atkey_metadata_to_protocolstr() {
   goto exit;
 exit: {
   atclient_atkey_metadata_free(&metadata);
+  if (protocolfragment != NULL) {
+    free(protocolfragment);
+  }
   return ret;
 }
 }
@@ -373,6 +376,9 @@ static int test_atkey_metadata_to_protocolstr2() {
   goto exit;
 exit: {
   atclient_atkey_metadata_free(&metadata);
+  if (protocolfragment != NULL) {
+    free(protocolfragment);
+  }
   return ret;
 }
 }

--- a/packages/atclient/tests/test_atkey_to_string.c
+++ b/packages/atclient/tests/test_atkey_to_string.c
@@ -218,6 +218,7 @@ static int test1b_publickey_without_namespace() {
   ret = 0;
   goto exit;
 exit: {
+  atclient_atkey_free(&atkey);
   free(string);
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "test1b_publickey_without_namespace Ended:%d\n", ret);
   return ret;
@@ -481,6 +482,7 @@ static int test2c_sharedkey_without_namespace() {
   ret = 0;
   goto exit;
 exit: {
+  atclient_atkey_free(&atkey);
   free(string);
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "test2c_sharedkey_without_namespace Ended:%d\n", ret);
   return ret;

--- a/tests/functional_tests/tests/test_atclient_connection.c
+++ b/tests/functional_tests/tests/test_atclient_connection.c
@@ -1,7 +1,7 @@
 #include <atclient/connection.h>
 #include <atlogger/atlogger.h>
-#include <functional_tests/helpers.h>
 #include <functional_tests/config.h>
+#include <functional_tests/helpers.h>
 #include <string.h>
 
 #define TAG "test_atclient_connection"
@@ -71,17 +71,17 @@ int main(int argc, char *argv[]) {
   }
 
   if ((ret = test_8_reconnect(&root_conn)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_7_reconnect: %d\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_8_reconnect: %d\n", ret);
     goto exit;
   }
 
   if ((ret = test_9_is_connected_should_be_true(&root_conn)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_8_is_connected: %d\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_9_is_connected: %d\n", ret);
     goto exit;
   }
 
   if ((ret = test_10_free(&root_conn)) != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_9_free: %d\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_10_free: %d\n", ret);
     goto exit;
   }
 
@@ -122,7 +122,10 @@ int main(int argc, char *argv[]) {
 
   ret = 0;
   goto exit;
-exit: { return ret; }
+exit: {
+  atclient_connection_free(&root_conn);
+  return ret;
+}
 }
 
 static int assert_equals(bool actual, bool expected) {
@@ -187,7 +190,7 @@ static int test_3_is_connected_should_be_true(atclient_connection *conn) {
   int ret = 1;
 
   // give enough time for virtualenv root:64 to respond to the \n command
-  atclient_connection_set_read_timeout(conn, 10*1000); // 10 second read timeout
+  atclient_connection_set_read_timeout(conn, 10 * 1000); // 10 second read timeout
 
   if (!atclient_connection_is_connected(conn)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
@@ -295,7 +298,7 @@ static int test_7_send_should_fail(atclient_connection *conn) {
 
   int ret = 1;
 
-  const unsigned char *send_data = (const unsigned char *) FIRST_ATSIGN "\r\n";
+  const unsigned char *send_data = (const unsigned char *)FIRST_ATSIGN "\r\n";
   const size_t send_data_len = strlen((const char *)send_data);
 
   const size_t recvsize = 1024;
@@ -351,7 +354,7 @@ static int test_9_is_connected_should_be_true(atclient_connection *conn) {
 
   int ret = 1;
 
-  atclient_connection_set_read_timeout(conn, 10*1000); // 10 second read timeout
+  atclient_connection_set_read_timeout(conn, 10 * 1000); // 10 second read timeout
 
   if (!atclient_connection_is_connected(conn)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
@@ -426,7 +429,7 @@ static int test_13_is_connected_should_be_true(atclient_connection *conn) {
 
   int ret = 1;
 
-  atclient_connection_set_read_timeout(conn, 10*1000); // 10 second read timeout
+  atclient_connection_set_read_timeout(conn, 10 * 1000); // 10 second read timeout
 
   if (!atclient_connection_is_connected(conn)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to connect: %d\n", ret);
@@ -497,7 +500,7 @@ static int test_16_is_connected_should_be_false(atclient_connection *conn) {
 
   int ret = 1;
 
-  atclient_connection_set_read_timeout(conn, 10*1000); // 10 second read timeout
+  atclient_connection_set_read_timeout(conn, 10 * 1000); // 10 second read timeout
 
   if (atclient_connection_is_connected(conn)) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,

--- a/tests/functional_tests/tests/test_atclient_pkam_authenticate.c
+++ b/tests/functional_tests/tests/test_atclient_pkam_authenticate.c
@@ -58,33 +58,35 @@ static int test1_pkam_no_options() {
   atclient_authenticate_options authenticate_options;
   atclient_authenticate_options_init(&authenticate_options);
 
-  if((ret = atclient_authenticate_options_set_atdirectory_host(&authenticate_options, ATDIRECTORY_HOST)) != 0) {
-    return ret;
+  if ((ret = atclient_authenticate_options_set_atdirectory_host(&authenticate_options, ATDIRECTORY_HOST)) != 0) {
+    goto exit;
   }
 
-  if((ret = atclient_authenticate_options_set_atdirectory_port(&authenticate_options, ATDIRECTORY_PORT)) != 0) {
-    return ret;
+  if ((ret = atclient_authenticate_options_set_atdirectory_port(&authenticate_options, ATDIRECTORY_PORT)) != 0) {
+    goto exit;
   }
 
   if ((ret = atclient_atkeys_file_from_path(&atkeys_file, atkeyspath)) != 0) {
-    return ret;
+    goto exit;
   }
   atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_file_from_string: %d\n", ret);
 
   if ((ret = atclient_atkeys_populate_from_atkeys_file(&atkeys, &atkeys_file)) != 0) {
-    return ret;
+    goto exit;
   }
   atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_populate_from_atkeys_file: %d\n", ret);
 
   if ((ret = atclient_pkam_authenticate(&atclient, atsign, &atkeys, &authenticate_options, NULL)) != 0) {
     atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to authenticate\n");
-    return ret;
+    goto exit;
   } else {
     atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_DEBUG, "Authenticated\n");
   }
 
+exit: {
   atclient_authenticate_options_free(&authenticate_options);
   return ret;
+}
 }
 
 static int test2_pkam_with_options() {
@@ -116,8 +118,7 @@ static int test2_pkam_with_options() {
   }
   atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_INFO, "atclient_atkeys_populate_from_atkeys_file: %d\n", ret);
 
-  if ((ret = atclient_utils_find_atserver_address(ATDIRECTORY_HOST,
-                                                  ATDIRECTORY_PORT, atsign, &atserver_host,
+  if ((ret = atclient_utils_find_atserver_address(ATDIRECTORY_HOST, ATDIRECTORY_PORT, atsign, &atserver_host,
                                                   &atserver_port)) != 0) {
     atlogger_log(tag, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_utils_find_atserver_address: %d\n", ret);
     return ret;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This PR removes 114 known memory leaks in at_c's tests:

```
Memory Leak - 114
Potential Memory Leak - 9
```

These remaining 9 potential leaks are in the mbedtls_ssl_handshake, and it doesn't seem to be user-controlled memory, I've tried force freeing different pieces of state and the defects remain. My assumption is that these are false positives. They are subject to further investigation / testing in the future to confirm.

Note that some leaks are in the package code, and some are limited to some needed cleanup in just the tests, both types are addressed.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: memory leaks in tests
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
