### PR TITLE
feat: CMakePresets & CPack Workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cmake_install.cmake
 compile_commands.json
 
 build/
+package-source/
 install/
 bin/
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,90 @@
+{
+  "version": 8,
+  "configurePresets": [
+    {
+      "name": "ci-base",
+      "hidden": true,
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/ci"
+    },
+    {
+      "name": "ci-unit-test",
+      "inherits": "ci-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ATSDK_BUILD_TESTS": "unit",
+        "ATSDK_MEMCHECK": "OFF"
+      }
+    },
+    {
+      "name": "ci-func-test",
+      "inherits": "ci-base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ATSDK_BUILD_TESTS": "func",
+        "ATSDK_MEMCHECK": "OFF",
+        "ATDIRECTORY_HOST": "\"vip.ve.atsign.zone\"",
+        "ATDIRECTORY_PORT": "64",
+        "FIRST_ATSIGN": "\"@alice🛠\"",
+        "SECOND_ATSIGN": "\"@bob🛠\"",
+        "FIRST_ATSIGN_ATSERVER_HOST": "\"vip.ve.atsign.zone\"",
+        "FIRST_ATSIGN_ATSERVER_PORT": "25000",
+        "SECOND_ATSIGN_ATSERVER_HOST": "\"vip.ve.atsign.zone\"",
+        "SECOND_ATSIGN_ATSERVER_PORT": "25003"
+      }
+    },
+    {
+      "name": "release-static",
+      "binaryDir": "${sourceDir}/build/release-static",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "OFF",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_FLAGS": "-std=c99 -Wno-error",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/package-source/install",
+        "ATSDK_BUILD_TESTS": "OFF",
+        "ATSDK_MEMCHECK": "OFF",
+        "ENABLE_TESTING": "OFF",
+        "ENABLE_PROGRAMS": "OFF",
+        "ENABLE_CJSON_TEST": "OFF",
+        "CJSON_OVERRIDE_BUILD_SHARED_LIBS": "ON",
+        "CJSON_BUILD_SHARED_LIBS": "OFF",
+        "BUILD_SHARED_AND_STATIC_LIBS": "OFF",
+        "ENABLE_TARGET_EXPORT": "OFF",
+        "ENABLE_CJSON_VERSION_SO": "OFF"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "release-static",
+      "configurePreset": "release-static"
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "static-zip",
+      "generators": ["ZIP"],
+      "configurePreset": "release-static",
+      "packageDirectory": "${sourceDir}/package-source",
+      "configFile": "${sourceDir}/CPackSourceConfig.cmake"
+    },
+    {
+      "name": "static-tgz",
+      "generators": ["TGZ"],
+      "configurePreset": "release-static",
+      "packageDirectory": "${sourceDir}/package-source",
+      "configFile": "${sourceDir}/CPackSourceConfig.cmake"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "package-static",
+      "steps": [
+        { "type": "configure", "name": "release-static" },
+        { "type": "build", "name": "release-static" },
+        { "type": "package", "name": "static-zip" },
+        { "type": "package", "name": "static-tgz" }
+      ]
+    }
+  ]
+}

--- a/CPackSourceConfig.cmake
+++ b/CPackSourceConfig.cmake
@@ -1,0 +1,7 @@
+set(CPACK_PACKAGE_FILE_NAME atsdk)
+set(CPACK_PACKAGE_NAME atsdk)
+set(CPACK_PACKAGE_DESCRIPTION "Atsign's atSDK library")
+set(CPACK_PACKAGE_VERSION 0.3.0)
+set(CPACK_PACKAGE_VENDOR_NAME atsign-foundation)
+set(CPACK_CMAKE_GENERATOR "Unix Makefiles")
+set(CPACK_INSTALL_CMAKE_PROJECTS ".;atsdk;ALL;/")

--- a/cmake/find_mbedtls.cmake
+++ b/cmake/find_mbedtls.cmake
@@ -1,7 +1,8 @@
 if(NOT TARGET mbedcrypto)
   # This installs the targets mbedtls mbedx509 mbedcrypto everest p256m
   # Configurable variables
-  option(ENABLE_TESTING "Enable MbedTLS tests" OFF)
+  set(ENABLE_TESTING "Enable MbedTLS tests" OFF)
+  set(ENABLE_PROGRAMS "Enable MbedTLS programs" OFF)
   set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE OPT_IN) # only try find_package if FIND_PACKAGE_ARGS is set
 
   message(STATUS "[MbedTLS] fetching package...")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added CMakePresets file with presets for ci & static-release configuration
  - usage: `cmake --preset <preset-name>`
- Added build & package presets for static releases (zip & tar.gz)
- Added workflow for a static release which combines all of the above
  - usage: `cmake --workflow --preset package-static`
  - This runs the configure & build steps, then uses the `package-source` dir to generate an appropriate source file structure and then generates zip & tar.gz files.

> For some reason, the cJSON build always tries to install system headers, so I've set the install directory to `package-source/install` to prevent cmake from trying to install these to a privileged directory.

**- How I did it**

**- How to verify it**

Checkout & execute this command:
`cmake --workflow --preset package-static`

**- Description for the changelog**
feat: CMakePresets & CPack Workflow
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
