### PR TITLE
fix: remove private linux header

### DIFF
--- a/packages/atauth/src/atauth_fetch_home_dir.c
+++ b/packages/atauth/src/atauth_fetch_home_dir.c
@@ -11,14 +11,6 @@
 #define PATH_SEPARATOR '\\'
 #define PATH_MAX 260 // Max path length for Windows (adjustable if needed)
 
-// Imports for Linux
-#elif defined(__linux__)
-#include <linux/limits.h>
-#include <pwd.h>
-#include <unistd.h>
-#define PATH_SEPARATOR '/'
-
-// Imports for other platforms
 #else
 #include <limits.h>
 #include <pwd.h>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Use `limits.h` instead of private linux header `linux/limits.h` on linux

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: remove private linux header
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
