### PR TITLE
fix: mount atkeys in memcheck docker container

### DIFF
--- a/justfile
+++ b/justfile
@@ -67,8 +67,11 @@ memcheck +ARGS='': build-test-memcheck
   ctest -T memcheck --test-dir $PWD/build/test-memcheck {{ARGS}}
 
 memcheck-docker +ARGS='':
-  docker run --rm --platform linux/amd64 --mount type=bind,src=$PWD,dst=/mnt/at_c atc-memcheck-docker:latest \
-    just memcheck {{ARGS}}
+  docker run --rm --platform linux/amd64 \
+  --mount type=bind,src=$PWD,dst=/mnt/at_c \
+  --mount type=bind,src=$HOME/.atsign/keys,dst=/root/.atsign/keys \
+  atc-memcheck-docker:latest \
+  just memcheck {{ARGS}}
 
 # CONFIGURE COMMANDS
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added option to mount keys directory into the docker container for memcheck docker from justfile
- ensures we can run functional_tests under memcheck-docker

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: mount atkeys in memcheck docker container
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
