### PR TITLE
chore: remove initialized fields from authenticate_options

### DIFF
--- a/packages/atclient/include/atclient/atclient_utils.h
+++ b/packages/atclient/include/atclient/atclient_utils.h
@@ -18,8 +18,8 @@ extern "C" {
  * @param atserver_port the output port of the secondary server, will be set to 0 if the port is not found
  * @return int 0 on success, non-zero on error
  */
-int atclient_utils_find_atserver_address(const char *atdirectory_host, const int atdirectory_port, const char *atsign,
-                                         char **atserver_host, int *atserver_port);
+int atclient_utils_find_atserver_address(const char *atdirectory_host, const uint16_t atdirectory_port,
+                                         const char *atsign, char **atserver_host, uint16_t *atserver_port);
 
 /**
  * @brief Populate atkeys from the atkeys file in the home directory of the user.

--- a/packages/atclient/include/atclient/request_options.h
+++ b/packages/atclient/include/atclient/request_options.h
@@ -132,10 +132,9 @@ typedef struct atclient_get_atkeys_request_options {
  */
 typedef struct atclient_authenticate_options {
   char *atdirectory_host;
-  int atdirectory_port;
   char *atserver_host;
-  int atserver_port;
-  uint16_t _initialized_fields[1];
+  uint16_t atdirectory_port;
+  uint16_t atserver_port;
 } atclient_authenticate_options;
 
 /*
@@ -258,25 +257,22 @@ int atclient_get_atkeys_request_options_set_show_hidden(atclient_get_atkeys_requ
 void atclient_get_atkeys_request_options_unset_show_hidden(atclient_get_atkeys_request_options *options);
 
 /*
- * 5. AtClient_PKAM_Authenticate Options
+ * 5. AtClient_Authenticate Options
  */
 void atclient_authenticate_options_init(atclient_authenticate_options *options);
 void atclient_authenticate_options_free(atclient_authenticate_options *options);
 
-bool atclient_authenticate_options_is_atdirectory_host_initialized(const atclient_authenticate_options *options);
 int atclient_authenticate_options_set_atdirectory_host(atclient_authenticate_options *options, char *atdirectory_host);
 void atclient_authenticate_options_unset_atdirectory_host(atclient_authenticate_options *options);
 
-bool atclient_authenticate_options_is_atdirectory_port_initialized(const atclient_authenticate_options *options);
-int atclient_authenticate_options_set_atdirectory_port(atclient_authenticate_options *options, int atdirectory_port);
+int atclient_authenticate_options_set_atdirectory_port(atclient_authenticate_options *options,
+                                                       uint16_t atdirectory_port);
 void atclient_authenticate_options_unset_atdirectory_port(atclient_authenticate_options *options);
 
-bool atclient_authenticate_options_is_atserver_host_initialized(const atclient_authenticate_options *options);
 int atclient_authenticate_options_set_atserver_host(atclient_authenticate_options *options, char *atserver_host);
 void atclient_authenticate_options_unset_atserver_host(atclient_authenticate_options *options);
 
-bool atclient_authenticate_options_is_atserver_port_initialized(const atclient_authenticate_options *options);
-int atclient_authenticate_options_set_atserver_port(atclient_authenticate_options *options, int atserver_port);
+int atclient_authenticate_options_set_atserver_port(atclient_authenticate_options *options, uint16_t atserver_port);
 void atclient_authenticate_options_unset_atserver_port(atclient_authenticate_options *options);
 
 #ifdef __cplusplus

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -251,9 +251,7 @@ int atclient_pkam_authenticate(atclient *ctx, const char *atsign, const atclient
   /*
    * 4. Get atdirectory_host and atdirectory_port
    */
-  if (options != NULL && atclient_authenticate_options_is_atdirectory_host_initialized(options) &&
-      options->atdirectory_host != NULL && atclient_authenticate_options_is_atdirectory_port_initialized(options) &&
-      options->atdirectory_port != 0) {
+  if (options != NULL && options->atdirectory_host != NULL && options->atdirectory_port != 0) {
     atdirectory_host = options->atdirectory_host;
     atdirectory_port = options->atdirectory_port;
   } else {
@@ -264,9 +262,7 @@ int atclient_pkam_authenticate(atclient *ctx, const char *atsign, const atclient
   /*
    * 5. Get atserver_host and atserver_port
    */
-  if (options != NULL && atclient_authenticate_options_is_atserver_host_initialized(options) &&
-      options->atserver_host != NULL && atclient_authenticate_options_is_atserver_port_initialized(options) &&
-      options->atserver_port != 0) {
+  if (options != NULL && options->atserver_host != NULL && options->atserver_port != 0) {
     atserver_host = options->atserver_host;
     atserver_port = options->atserver_port;
     should_free_atserver_host = false;
@@ -440,6 +436,8 @@ int atclient_cram_authenticate(atclient *ctx, const char *atsign, const char *cr
   char *from_cmd = NULL;
   char *cram_cmd = NULL;
   char *atsign_with_at = NULL;
+  char *atdirectory_host = NULL;
+  int atdirectory_port = 0;
   char *atserver_host = NULL;
   int atserver_port = 0;
 
@@ -482,17 +480,21 @@ int atclient_cram_authenticate(atclient *ctx, const char *atsign, const char *cr
    * 4. Get atserver_host and atserver_port
    */
   if (options != NULL) {
-    if (atclient_authenticate_options_is_atdirectory_host_initialized(options) &&
-        atclient_authenticate_options_is_atdirectory_port_initialized(options)) {
-      atserver_host = options->atdirectory_host;
-      atserver_port = options->atdirectory_port;
-    }
+    atserver_host = options->atserver_host;
+    atserver_port = options->atserver_port;
+    atdirectory_host = options->atdirectory_host;
+    atdirectory_port = options->atdirectory_port;
   }
 
   if (atserver_host == NULL || atserver_port == 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "Using production atDirectory to lookup atServer host and port\n");
-    if ((ret = atclient_utils_find_atserver_address(ATCLIENT_ATDIRECTORY_PRODUCTION_HOST,
-                                                    ATCLIENT_ATDIRECTORY_PRODUCTION_PORT, atsign, &atserver_host,
+    if (atdirectory_host == NULL) {
+      atdirectory_host = ATCLIENT_ATDIRECTORY_PRODUCTION_HOST;
+    }
+    if (atdirectory_port == 0) {
+      atdirectory_port = ATCLIENT_ATDIRECTORY_PRODUCTION_PORT;
+    }
+    if ((ret = atclient_utils_find_atserver_address(atdirectory_host, atdirectory_port, atsign, &atserver_host,
                                                     &atserver_port)) != 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atclient_utils_find_atserver_address: %d\n", ret);
       goto exit;

--- a/packages/atclient/src/atclient_utils.c
+++ b/packages/atclient/src/atclient_utils.c
@@ -11,9 +11,9 @@
 
 #define TAG "atclient_utils"
 
-int atclient_utils_find_atserver_address(const char *atdirectory_host, const int atdirectory_port, const char *atsign,
-                                         char **atserver_host, int *atserver_port) {
-  return atdirectory_lookup_once(atdirectory_host, atdirectory_port, atsign, atserver_host, (uint16_t *)atserver_port);
+int atclient_utils_find_atserver_address(const char *atdirectory_host, const uint16_t atdirectory_port,
+                                         const char *atsign, char **atserver_host, uint16_t *atserver_port) {
+  return atdirectory_lookup_once(atdirectory_host, atdirectory_port, atsign, atserver_host, atserver_port);
 }
 
 int atclient_utils_populate_atkeys_from_homedir(atclient_atkeys *atkeys, const char *atsign) {

--- a/packages/atclient/src/request_options.c
+++ b/packages/atclient/src/request_options.c
@@ -74,21 +74,6 @@ atclient_get_atkeys_request_options_set_show_hidden_initialized(atclient_get_atk
                                                                 const bool initialized);
 
 /*
- * 5. Authenticate Request Options
- */
-static void atclient_authenticate_options_set_atdirectory_host_initialized(atclient_authenticate_options *options,
-                                                                           const bool initialized);
-
-static void atclient_authenticate_options_set_atdirectory_port_initialized(atclient_authenticate_options *options,
-                                                                           const bool initialized);
-
-static void atclient_authenticate_options_set_atserver_host_initialized(atclient_authenticate_options *options,
-                                                                        const bool initialized);
-
-static void atclient_authenticate_options_set_atserver_port_initialized(atclient_authenticate_options *options,
-                                                                        const bool initialized);
-
-/*
  * =================
  * 1A. Put SelfKey
  * =================
@@ -1598,8 +1583,8 @@ void atclient_get_atkeys_request_options_unset_show_hidden(atclient_get_atkeys_r
 
 void atclient_authenticate_options_init(atclient_authenticate_options *options) {
   memset(options, 0, sizeof(atclient_authenticate_options));
-  options->atdirectory_host = ATCLIENT_ATDIRECTORY_PRODUCTION_HOST;
-  options->atdirectory_port = ATCLIENT_ATDIRECTORY_PRODUCTION_PORT;
+  options->atdirectory_host = NULL;
+  options->atdirectory_port = 0;
   options->atserver_host = NULL;
   options->atserver_port = 0;
 }
@@ -1617,93 +1602,10 @@ void atclient_authenticate_options_free(atclient_authenticate_options *options) 
    * 2. Free options
    */
 
-  if (atclient_authenticate_options_is_atdirectory_host_initialized(options)) {
-    atclient_authenticate_options_unset_atdirectory_host(options);
-  }
-
-  if (atclient_authenticate_options_is_atdirectory_port_initialized(options)) {
-    atclient_authenticate_options_unset_atdirectory_port(options);
-  }
-
-  if (atclient_authenticate_options_is_atserver_host_initialized(options)) {
-    atclient_authenticate_options_unset_atserver_host(options);
-  }
-
-  if (atclient_authenticate_options_is_atserver_port_initialized(options)) {
-    atclient_authenticate_options_unset_atserver_port(options);
-  }
-}
-
-bool atclient_authenticate_options_is_atdirectory_host_initialized(const atclient_authenticate_options *options) {
-  /*
-   * 1. Validate arguments
-   */
-  if (options == NULL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_is_atdirectory_host_initialized: "
-                 "Invalid arguments\n");
-    return false;
-  }
-
-  /*
-   * 2. Check if the at directory host is initialized
-   */
-  return options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INDEX] &
-         ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INITIALIZED;
-}
-
-bool atclient_authenticate_options_is_atdirectory_port_initialized(const atclient_authenticate_options *options) {
-  /*
-   * 1. Validate arguments
-   */
-  if (options == NULL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_is_atdirectory_port_initialized: "
-                 "Invalid arguments\n");
-    return false;
-  }
-
-  /*
-   * Check if the at directory port is initialized
-   */
-  return options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INDEX] &
-         ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INITIALIZED;
-}
-
-bool atclient_authenticate_options_is_atserver_host_initialized(const atclient_authenticate_options *options) {
-  /*
-   * 1. Validate arguments
-   */
-  if (options == NULL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_is_atserver_host_initialized: "
-                 "Invalid arguments\n");
-    return false;
-  }
-
-  /*
-   * Check if the atserver host is initialized
-   */
-  return options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INDEX] &
-         ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INITIALIZED;
-}
-
-bool atclient_authenticate_options_is_atserver_port_initialized(const atclient_authenticate_options *options) {
-  /*
-   * 1. Validate arguments
-   */
-  if (options == NULL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_is_atserver_port_initialized: "
-                 "Invalid arguments\n");
-    return false;
-  }
-
-  /*
-   * Check if the atserver port is initialized
-   */
-  return options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INDEX] &
-         ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INITIALIZED;
+  atclient_authenticate_options_unset_atdirectory_host(options);
+  atclient_authenticate_options_unset_atdirectory_port(options);
+  atclient_authenticate_options_unset_atserver_host(options);
+  atclient_authenticate_options_unset_atserver_port(options);
 }
 
 void atclient_authenticate_options_unset_atdirectory_host(atclient_authenticate_options *options) {
@@ -1718,11 +1620,10 @@ void atclient_authenticate_options_unset_atdirectory_host(atclient_authenticate_
 
   /*
    * 2. Unsetat directory   */
-  if (atclient_authenticate_options_is_atdirectory_host_initialized(options) && options->atdirectory_host != NULL) {
+  if (options->atdirectory_host != NULL) {
     free(options->atdirectory_host);
   }
   options->atdirectory_host = NULL;
-  atclient_authenticate_options_set_atdirectory_host_initialized(options, false);
 }
 
 void atclient_authenticate_options_unset_atdirectory_port(atclient_authenticate_options *options) {
@@ -1734,8 +1635,7 @@ void atclient_authenticate_options_unset_atdirectory_port(atclient_authenticate_
                  "atclient_authenticate_options_unset_atdirectory_port: Invalid arguments\n");
     return;
   }
-  options->atdirectory_port = ATCLIENT_ATDIRECTORY_PRODUCTION_PORT;
-  atclient_authenticate_options_set_atdirectory_port_initialized(options, false);
+  options->atdirectory_port = 0;
 }
 
 void atclient_authenticate_options_unset_atserver_host(atclient_authenticate_options *options) {
@@ -1751,11 +1651,10 @@ void atclient_authenticate_options_unset_atserver_host(atclient_authenticate_opt
   /*
    * 2. Unset atserver host
    */
-  if (atclient_authenticate_options_is_atserver_host_initialized(options) && options->atserver_host != NULL) {
+  if (options->atserver_host != NULL) {
     free(options->atserver_host);
   }
   options->atserver_host = NULL;
-  atclient_authenticate_options_set_atserver_host_initialized(options, false);
 }
 
 void atclient_authenticate_options_unset_atserver_port(atclient_authenticate_options *options) {
@@ -1768,7 +1667,6 @@ void atclient_authenticate_options_unset_atserver_port(atclient_authenticate_opt
     return;
   }
   options->atserver_port = 0;
-  atclient_authenticate_options_set_atserver_port_initialized(options, false);
 }
 
 int atclient_authenticate_options_set_atdirectory_host(atclient_authenticate_options *options, char *atdirectory_host) {
@@ -1785,36 +1683,32 @@ int atclient_authenticate_options_set_atdirectory_host(atclient_authenticate_opt
   }
 
   /*
-   * 2. Unset at directory host, if initialized
-   */
-  if (atclient_authenticate_options_is_atdirectory_host_initialized(options)) {
-    atclient_authenticate_options_unset_atdirectory_host(options);
-  }
-
-  /*
    * 3. Set at directory host
    */
   const size_t atdirectory_host_size = strlen(atdirectory_host) + 1;
-  if ((options->atdirectory_host = (char *)malloc(sizeof(char) * atdirectory_host_size)) == NULL) {
+  char *new_host = (char *)malloc(sizeof(char) * atdirectory_host_size);
+  if (new_host == NULL) {
     ret = 1;
     atlogger_log(
         TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
         "atclient_authenticate_options_set_atdirectory_host: Failed to allocate memory for at directory host\n");
     goto exit;
   }
+  if (options->atdirectory_host != NULL) {
+    atclient_authenticate_options_unset_atdirectory_host(options);
+  }
+  options->atdirectory_host = new_host;
 
-  atclient_authenticate_options_set_atdirectory_host_initialized(options, true);
-
-  const size_t atdirectory_host_len = strlen(atdirectory_host);
-  memcpy(options->atdirectory_host, atdirectory_host, atdirectory_host_len);
-  options->atdirectory_host[atdirectory_host_len] = '\0';
+  memcpy(options->atdirectory_host, atdirectory_host, atdirectory_host_size - 1);
+  options->atdirectory_host[atdirectory_host_size - 1] = '\0';
 
   ret = 0;
   goto exit;
 exit: { return ret; }
 }
 
-int atclient_authenticate_options_set_atdirectory_port(atclient_authenticate_options *options, int atdirectory_port) {
+int atclient_authenticate_options_set_atdirectory_port(atclient_authenticate_options *options,
+                                                       uint16_t atdirectory_port) {
   int ret = 1;
 
   /*
@@ -1828,17 +1722,9 @@ int atclient_authenticate_options_set_atdirectory_port(atclient_authenticate_opt
   }
 
   /*
-   * 2. Unset at directory port, if initialized
-   */
-  if (atclient_authenticate_options_is_atdirectory_port_initialized(options)) {
-    atclient_authenticate_options_unset_atdirectory_host(options);
-  }
-
-  /*
    * 3. Set at directory port
    */
   options->atdirectory_port = atdirectory_port;
-  atclient_authenticate_options_set_atdirectory_port_initialized(options, true);
   ret = 0;
   goto exit;
 exit: { return ret; }
@@ -1856,30 +1742,24 @@ int atclient_authenticate_options_set_atserver_host(atclient_authenticate_option
                  "atclient_authenticate_options_set_atserver_host: Invalid arguments\n");
     return ret;
   }
-
-  /*
-   * 2. Unset the atserver host, if initialized
-   */
-  if (atclient_authenticate_options_is_atserver_host_initialized(options)) {
-    atclient_authenticate_options_unset_atserver_host(options);
-  }
-
   /*
    * 3. Set atserver host
    */
   const size_t atserver_host_size = strlen(atserver_host) + 1;
-  if ((options->atserver_host = (char *)malloc(sizeof(char) * atserver_host_size)) == NULL) {
+  char *new_host = (char *)malloc(sizeof(char) * atserver_host_size);
+  if (new_host == NULL) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                  "atclient_authenticate_options_set_atserver_host: Failed to allocate memory for atserver host\n");
     return ret;
   }
+  if (options->atserver_host != NULL) {
+    atclient_authenticate_options_unset_atserver_host(options);
+  }
+  options->atserver_host = new_host;
 
-  const size_t atserver_host_len = strlen(atserver_host);
-  memcpy(options->atserver_host, atserver_host, atserver_host_len);
-  options->atserver_host[atserver_host_len] = '\0';
-
-  atclient_authenticate_options_set_atserver_host_initialized(options, true);
+  memcpy(options->atserver_host, atserver_host, atserver_host_size - 1);
+  options->atserver_host[atserver_host_size - 1] = '\0';
 
   ret = 0;
   goto exit;
@@ -1887,7 +1767,7 @@ int atclient_authenticate_options_set_atserver_host(atclient_authenticate_option
 exit: { return ret; }
 }
 
-int atclient_authenticate_options_set_atserver_port(atclient_authenticate_options *options, int atserver_port) {
+int atclient_authenticate_options_set_atserver_port(atclient_authenticate_options *options, uint16_t atserver_port) {
   int ret = 1;
 
   /*
@@ -1901,116 +1781,12 @@ int atclient_authenticate_options_set_atserver_port(atclient_authenticate_option
   }
 
   /*
-   * 2. Unset the atserver port, if initialized
-   */
-  if (atclient_authenticate_options_is_atserver_port_initialized(options)) {
-    atclient_authenticate_options_unset_atserver_host(options);
-  }
-
-  /*
    * 3. Set atserver port
    */
   options->atserver_port = atserver_port;
-  atclient_authenticate_options_set_atserver_port_initialized(options, true);
 
   ret = 0;
   goto exit;
 
 exit: { return ret; }
-}
-
-static void atclient_authenticate_options_set_atdirectory_host_initialized(atclient_authenticate_options *options,
-                                                                           const bool initialized) {
-  /*
-   * 1. Validate arguments
-   */
-  if (options == NULL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_set_atdirectory_host_initialized: "
-                 "Invalid arguments\n");
-    return;
-  }
-
-  /*
-   * 2. Set the at directory host initialized
-   */
-  if (initialized) {
-    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INDEX] |=
-        ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INITIALIZED;
-  } else {
-    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INDEX] &=
-        ~ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_HOST_INITIALIZED;
-  }
-}
-
-static void atclient_authenticate_options_set_atdirectory_port_initialized(atclient_authenticate_options *options,
-                                                                           const bool initialized) {
-  /*
-   * 1. Validate arguments
-   */
-  if (options == NULL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_set_atdirectory_port_initialized: "
-                 "Invalid arguments\n");
-    return;
-  }
-
-  /*
-   * 2. Set the at directory port initialized
-   */
-  if (initialized) {
-    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INDEX] |=
-        ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INITIALIZED;
-  } else {
-    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INDEX] &=
-        ~ATCLIENT_AUTHENTICATE_OPTIONS_ATDIRECTORY_PORT_INITIALIZED;
-  }
-}
-
-static void atclient_authenticate_options_set_atserver_host_initialized(atclient_authenticate_options *options,
-                                                                        const bool initialized) {
-  /*
-   * 1. Validate arguments
-   */
-  if (options == NULL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_set_atserver_host_initialized: "
-                 "Invalid arguments\n");
-    return;
-  }
-
-  /*
-   * 2. Set the atserver host initialized
-   */
-  if (initialized) {
-    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INDEX] |=
-        ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INITIALIZED;
-  } else {
-    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INDEX] &=
-        ~ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_HOST_INITIALIZED;
-  }
-}
-
-static void atclient_authenticate_options_set_atserver_port_initialized(atclient_authenticate_options *options,
-                                                                        const bool initialized) {
-  /*
-   * 1. Validate arguments
-   */
-  if (options == NULL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "atclient_authenticate_options_set_atserver_port_initialized: "
-                 "Invalid arguments\n");
-    return;
-  }
-
-  /*
-   * 2. Set the atserver port initialized
-   */
-  if (initialized) {
-    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INDEX] |=
-        ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INITIALIZED;
-  } else {
-    options->_initialized_fields[ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INDEX] &=
-        ~ATCLIENT_AUTHENTICATE_OPTIONS_ATSERVER_PORT_INITIALIZED;
-  }
 }

--- a/tests/functional_tests/tests/test_atclient_pkam_authenticate.c
+++ b/tests/functional_tests/tests/test_atclient_pkam_authenticate.c
@@ -1,11 +1,11 @@
 #include "atclient/request_options.h"
-#include <functional_tests/config.h>
-#include <functional_tests/helpers.h>
 #include <atclient/atclient.h>
 #include <atclient/atclient_utils.h>
 #include <atclient/atkeys_file.h>
 #include <atclient/constants.h>
 #include <atlogger/atlogger.h>
+#include <functional_tests/config.h>
+#include <functional_tests/helpers.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -102,7 +102,7 @@ static int test2_pkam_with_options(const char *path) {
   atclient_authenticate_options_init(&options);
 
   char *atserver_host = NULL;
-  int atserver_port = 0;
+  uint16_t atserver_port = 0;
 
   if ((ret = atclient_atkeys_file_from_path(&atkeys_file, path)) != 0) {
     return ret;

--- a/tests/functional_tests/tests/test_atclient_utils_find_atserver_address.c
+++ b/tests/functional_tests/tests/test_atclient_utils_find_atserver_address.c
@@ -42,7 +42,7 @@ static int test_1_find_atserver_address_should_pass() {
   int expected_port = FIRST_ATSIGN_ATSERVER_PORT;
 
   char *atserver_host = NULL;
-  int atserver_port = 0;
+  uint16_t atserver_port = 0;
 
   if ((ret = atclient_utils_find_atserver_address(ATDIRECTORY_HOST, ATDIRECTORY_PORT, atsign, &atserver_host,
                                                   &atserver_port)) != 0) {
@@ -81,7 +81,7 @@ static int test_2_find_atserver_address_should_fail() {
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_2_find_atserver_address_should_fail Begin\n");
 
   char *atserver_host = NULL;
-  int atserver_port = 0;
+  uint16_t atserver_port = 0;
 
   if ((ret = atclient_utils_find_atserver_address(ATDIRECTORY_HOST, ATDIRECTORY_PORT, UNDEFINED_ATSIGN_WITHOUT_AT,
                                                   &atserver_host, &atserver_port)) == 0) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Remove initialized options from authenticate_options, so it's safe to set values in the struct directly
- changed ports to uint16_t so there are no possible undefined values (authenticate options & atclient_utils_find_atserver_address)
  - 0 = unset
  - 1-65535 = the port

**- How I did it**

**- How to verify it**

Tests pass

**- Description for the changelog**
chore: remove initialized fields from authenticate_options
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
