### PR TITLE
chore: just command to run a shell in valgrind container

### DIFF
--- a/docs/just.md
+++ b/docs/just.md
@@ -57,13 +57,17 @@ Locally (requires valgrind):
 
 In docker, first run the setup to build the docker image locally:
 
-`just setup-memcheck-docker`
+`just setup-valgrind`
 
 Then whenever you want to run the memory check tests:
 
 `just memd`
 
 > This will create an ephemeral docker container, all of the test output will be located in `build/test-memcheck/` as if it was run locally.
+
+If you want a bash prompt in the valgrind container:
+
+`just vald`
 
 ### See all commands
 

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@ alias test := test-all
 alias unit := test-unit
 alias func := test-func
 alias memd := memcheck-docker
+alias vald := valgrind-docker
 
 set dotenv-filename := "just.env"
 set dotenv-load
@@ -13,7 +14,7 @@ setup: configure-test-all
   ln -s $PWD/build/test-all/compile_commands.json $PWD
   ln -s $PWD/build/test-all/compile_commands.json $PWD/tests
 
-setup-memcheck-docker:
+setup-valgrind:
   docker build --platform linux/amd64 -t atc-memcheck-docker:latest -f $PWD/valgrind.Dockerfile $PWD
 
 clean:
@@ -72,6 +73,14 @@ memcheck-docker +ARGS='':
   --mount type=bind,src=$HOME/.atsign/keys,dst=/root/.atsign/keys \
   atc-memcheck-docker:latest \
   just memcheck {{ARGS}}
+
+valgrind-docker:
+  docker run --rm --platform linux/amd64 \
+  -ti \
+  --mount type=bind,src=$PWD,dst=/mnt/at_c \
+  --mount type=bind,src=$HOME/.atsign/keys,dst=/root/.atsign/keys \
+  atc-memcheck-docker:latest  \
+  /bin/bash
 
 # CONFIGURE COMMANDS
 

--- a/valgrind.Dockerfile
+++ b/valgrind.Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get install -y git-core \
   ninja-build \
   sudo \
   curl \
+  clang \
   just \
   valgrind \
   gcc \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added clang to the valgrind.Dockerfile
- Added a just command launch a bash prompt in the valgrind docker container
  - makes Linux debugging tools (valgrind & gdb) available to macos users
- Updated just documentation

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore: just command to run a shell in valgrind container
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
