### PR TITLE
fix: only include cpack when atsdk is the root project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,13 +40,11 @@ project(
   LANGUAGES C
 )
 
-# Includes from cmake project directory
-include("${CMAKE_CURRENT_LIST_DIR}/cmake/CPackSetup.cmake")
-
 # Determine if atchops is being built as a subproject using add_subdirectory()
 if(NOT DEFINED ATSDK_AS_SUBPROJECT)
   set(ATSDK_AS_SUBPROJECT ON)
   if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    include("${CMAKE_CURRENT_LIST_DIR}/cmake/CPackSetup.cmake")
     set(ATSDK_AS_SUBPROJECT OFF)
   endif()
 endif()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: only include cpack when atsdk is the root project
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
