### PR TITLE
fix: suppress pkam auth failed message while waiting for enrollment

### DIFF
--- a/packages/atauth/src/wait_for_enrollment.c
+++ b/packages/atauth/src/wait_for_enrollment.c
@@ -21,7 +21,7 @@ int wait_for_enrollment(atclient *ctx, const char *atsign, const atclient_atkeys
     }
 
     if (err_msg != NULL && is_enrollment_denied(err_msg)) {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "enrollment id: %s has been denied\n", atkeys->enrollment_id);
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "enrollment id: %s has been denied\n", atkeys->enrollment_id);
       ret = 1;
       return ret;
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes https://github.com/atsign-foundation/noports/issues/1667

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: suppress pkam auth failed message while waiting for enrollment
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
