### PR TITLE
feat(atcommons): memory management util

### DIFF
--- a/packages/atcommons/CMakeLists.txt
+++ b/packages/atcommons/CMakeLists.txt
@@ -3,7 +3,7 @@ option(ATCOMMONS_BUILD_TESTS "Build tests for atcommons" OFF)
 
 # Set include directory and file sources
 set(ATCOMMONS_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
-set(ATCOMMONS_SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/temp.c")
+set(ATCOMMONS_SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/memory_util.c")
 
 # Project setup
 cmake_minimum_required(VERSION 3.24)
@@ -22,7 +22,6 @@ if(ESP_PLATFORM)
   return()
 endif()
 
-set(ATCOMMONS_BUILD_TESTS OFF) # DISABLE TESTS - no tests in atcommons right now
 build_atsdk_package(
     PACKAGE_NAME atcommons
     PACKAGE_DESCRIPTION "Atsign technology common utilities and implementations"

--- a/packages/atcommons/include/atcommons/memory_util.h
+++ b/packages/atcommons/include/atcommons/memory_util.h
@@ -1,0 +1,38 @@
+#ifndef ATCOMMONS_MEMORY_UTIL_H
+#define ATCOMMONS_MEMORY_UTIL_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+// change the following fields to change the maximum size
+// ideally this stays 32 or 64 to align well on 32bit & 64bit systems
+#define ATCOMMONS_MEMLIST_SIZE 32
+#define ATCOMMONS_MEMLIST_BITMASK_TYPE uint32_t
+#define ATCOMMONS_MEMLIST_BITMASK_TYPE_MAX UINT32_MAX
+
+struct atcommons_memory_deallocator {
+  void *memory;            // address of the memory to free
+  void (*free_fn)(void *); // free function
+};
+
+// This could be optimized, but it's good enough for now, stability first
+struct atcommons_memlist {
+  struct atcommons_memory_deallocator memory[ATCOMMONS_MEMLIST_SIZE];
+  ATCOMMONS_MEMLIST_BITMASK_TYPE free_on_success; // bitmask
+  ATCOMMONS_MEMLIST_BITMASK_TYPE allocated;       // bitmask
+  uint32_t len;                                   // length of the list
+};
+
+struct atcommons_memlist atcommons_memlist_create(uint32_t len);
+int atcommons_memlist_add(struct atcommons_memlist *memlist, void *memory, bool free_on_success, void *free_fn);
+int atcommons_memlist_index_free(struct atcommons_memlist *memlist, uint32_t index);
+void atcommons_memlist_failure_free(struct atcommons_memlist *memlist);
+void atcommons_memlist_success_free(struct atcommons_memlist *memlist);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/packages/atcommons/include/atcommons/temp.h
+++ b/packages/atcommons/include/atcommons/temp.h
@@ -1,1 +1,0 @@
-// placeholder file until we have headers to add to atcommons

--- a/packages/atcommons/src/memory_util.c
+++ b/packages/atcommons/src/memory_util.c
@@ -1,0 +1,106 @@
+#include "atlogger/atlogger.h"
+#include <atcommons/memory_util.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define TAG "atcommons_memlist"
+struct atcommons_memlist atcommons_memlist_create(uint32_t len) {
+  // the only way to check this at compile time is the road to macro hell
+  // while it would make more robust code when done right, it would be a waste
+  // of time trying to get it right (at least right now)
+  if (len > ATCOMMONS_MEMLIST_SIZE) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "requested length exceeds the maximum allowed: %d; allocating maximum of %d instead\n", len,
+                 ATCOMMONS_MEMLIST_SIZE);
+    len = ATCOMMONS_MEMLIST_SIZE;
+  }
+  return (struct atcommons_memlist){
+      .len = len,
+      .free_on_success = 0,
+      .allocated = 0,
+      .memory = {(struct atcommons_memory_deallocator){.memory = NULL, .free_fn = NULL}},
+  };
+}
+
+int atcommons_memlist_add(struct atcommons_memlist *memlist, void *memory, bool free_on_success, void *free_fn) {
+  if (memory == NULL && free_fn == NULL) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "One of memory and free_fn must be non-NULL\n");
+    return 1;
+  }
+  uint32_t index = ATCOMMONS_MEMLIST_SIZE; // intentionally out of bounds by default
+  for (uint32_t i = 0; i < memlist->len && i < ATCOMMONS_MEMLIST_SIZE; i++) {
+    if ((memlist->allocated & (0b1 << i)) == 0) {
+      index = i;
+      break;
+    }
+  }
+  if (index == ATCOMMONS_MEMLIST_SIZE) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "No more available space in memlist\n");
+    return 2;
+  }
+
+  memlist->memory[index] = (struct atcommons_memory_deallocator){
+      .memory = memory,
+      .free_fn = free_fn,
+  };
+  memlist->allocated |= (0b1 << index); // set bit at index to 1
+
+  if (free_on_success) {
+    memlist->free_on_success |= (0b1 << index); // set bit at index to 1
+  } else {
+    memlist->free_on_success &= ~(0b1 << index); // set bit at index to 0
+  }
+  return 0;
+}
+
+int atcommons_memlist_index_free(struct atcommons_memlist *memlist, uint32_t index) {
+  if (index > ATCOMMONS_MEMLIST_SIZE || index > memlist->len) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "requested index is invalid\n");
+    return 1;
+  }
+  if ((memlist->allocated & (0b1 << index)) == 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "requested index is not allocated\n");
+    return 2;
+  }
+
+  struct atcommons_memory_deallocator *dealloc = &memlist->memory[index];
+  if (dealloc->memory == NULL && dealloc->free_fn == NULL) {
+    atlogger_log(
+        TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+        "Both memory address and free function are NULL, nothing has been provided to deallocate the memory\n");
+    return 3;
+  }
+
+  // If there's a free function use that to free the memory
+  // It is up to the consumer to call free on the actual memory address if that
+  // is also required with any other cleanup logic
+  if (dealloc->free_fn != NULL) {
+    dealloc->free_fn(dealloc->memory);
+  } else {
+    free(dealloc->memory);
+  }
+
+  dealloc->free_fn = NULL;
+  dealloc->memory = NULL;
+  memlist->allocated &= ~(0b1 << index); // set bit at index to 0
+  return 0;
+}
+
+void atcommons_memlist_failure_free(struct atcommons_memlist *memlist) {
+  for (uint32_t i = 0; i < memlist->len; i++) {
+    if ((memlist->allocated & (0b1 << i)) != 0) {
+      atcommons_memlist_index_free(memlist, i);
+    }
+  }
+}
+
+void atcommons_memlist_success_free(struct atcommons_memlist *memlist) {
+  // create a mask of bits where memory is allocated and free_on_success is true
+  ATCOMMONS_MEMLIST_BITMASK_TYPE bitmask = memlist->allocated & memlist->free_on_success;
+  for (uint32_t i = 0; i < memlist->len; i++) {
+    if ((bitmask & (0b1 << i)) != 0) {
+      atcommons_memlist_index_free(memlist, i);
+    }
+  }
+}

--- a/packages/atcommons/src/temp.c
+++ b/packages/atcommons/src/temp.c
@@ -1,1 +1,0 @@
-// placeholder file until we have source to add to atcommons

--- a/packages/atcommons/tests/CMakeLists.txt
+++ b/packages/atcommons/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+file(GLOB_RECURSE files ${CMAKE_CURRENT_LIST_DIR}/test_*.c)
+foreach(file ${files})
+  # ${filename} - without `.c`
+  get_filename_component(filename ${file} NAME)
+  string(REPLACE ".c" "" filename ${filename})
+
+  add_executable(${filename} ${file})
+  target_link_libraries(${filename} PRIVATE atcommons)
+  add_test(NAME ${filename} COMMAND $<TARGET_FILE:${filename}>)
+endforeach()
+enable_testing()

--- a/packages/atcommons/tests/test_memory_util.c
+++ b/packages/atcommons/tests/test_memory_util.c
@@ -1,0 +1,189 @@
+#include "atlogger/atlogger.h"
+#include <atcommons/memory_util.h>
+
+static int test1a_valid_basic();
+static int test1b_valid_custom_free();
+static int test1c_valid_success_free();
+static int test2a_invalid_exceed_length();
+static int test2b_invalid_create_length();
+static int test2c_invalid_append();
+static int test2d_invalid_delete_index();
+
+#define TAG "test_memory_util"
+int main() {
+  int ret = 0;
+  atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_INFO);
+
+  ret += test1a_valid_basic();
+  ret += test1b_valid_custom_free();
+  ret += test1c_valid_success_free();
+  ret += test2a_invalid_exceed_length();
+  ret += test2b_invalid_create_length();
+  ret += test2c_invalid_append();
+  ret += test2d_invalid_delete_index();
+
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%d tests failed\n", ret);
+  }
+
+  return ret;
+}
+
+static int test1a_valid_basic() {
+  int ret;
+  struct atcommons_memlist memlist = atcommons_memlist_create(2);
+
+  char *a = malloc(16);
+  ret = atcommons_memlist_add(&memlist, a, true, NULL);
+  if (ret != 0) {
+    atlogger_log(TAG " 1a", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to append a to memlist: %d\n", ret);
+    atcommons_memlist_failure_free(&memlist);
+    return 1;
+  }
+
+  unsigned char *b = malloc(32);
+  ret = atcommons_memlist_add(&memlist, b, false, NULL);
+  if (ret != 0) {
+    atlogger_log(TAG " 1a", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to append b to memlist: %d\n", ret);
+    atcommons_memlist_failure_free(&memlist);
+    return 1;
+  }
+
+  atcommons_memlist_failure_free(&memlist);
+  return 0;
+}
+
+static void free1b_char_array(void *ptr) { free(ptr); }
+static int test1b_valid_custom_free() {
+  int ret;
+  struct atcommons_memlist memlist = atcommons_memlist_create(2);
+
+  char *a = malloc(16);
+  ret = atcommons_memlist_add(&memlist, a, true, free1b_char_array);
+  if (ret != 0) {
+
+    atlogger_log(TAG " 1b", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to append a to memlist: %d\n", ret);
+    atcommons_memlist_failure_free(&memlist);
+    return 1;
+  }
+
+  unsigned char *b = malloc(32);
+  ret = atcommons_memlist_add(&memlist, b, false, NULL);
+  if (ret != 0) {
+    atlogger_log(TAG " 1b", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to append b to memlist: %d\n", ret);
+    atcommons_memlist_failure_free(&memlist);
+    return 1;
+  }
+
+  atcommons_memlist_failure_free(&memlist);
+  return 0;
+}
+
+static int test1c_valid_success_free() {
+  int ret;
+  struct atcommons_memlist memlist = atcommons_memlist_create(2);
+
+  char *a = malloc(16);
+  ret = atcommons_memlist_add(&memlist, a, true, NULL);
+  if (ret != 0) {
+
+    atlogger_log(TAG " 1c", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to append a to memlist: %d\n", ret);
+    atcommons_memlist_failure_free(&memlist);
+    return 1;
+  }
+
+  unsigned char *b = malloc(32);
+  ret = atcommons_memlist_add(&memlist, b, false, NULL);
+  if (ret != 0) {
+    atlogger_log(TAG " 1c", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to append b to memlist: %d\n", ret);
+    atcommons_memlist_failure_free(&memlist);
+    return 1;
+  }
+
+  atcommons_memlist_success_free(&memlist);
+
+  if (memlist.allocated != 0b10) {
+    atlogger_log(TAG " 1c", ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "memlist.allocated (after success_free) has an unexpected value (expected %u, actual %u)\n", 0b10,
+                 memlist.allocated);
+    atcommons_memlist_failure_free(&memlist);
+    return 1;
+  }
+
+  atcommons_memlist_failure_free(&memlist);
+  if (memlist.allocated != 0) {
+    atlogger_log(TAG " 1c", ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "memlist.allocated (after failure_free) has an unexpected value (expected %u, actual %u)\n", 0,
+                 memlist.allocated);
+    return 1;
+  }
+  return 0;
+}
+
+// can use stack memory in this since we aren't testing any free capability
+static int test2a_invalid_exceed_length() {
+  int ret;
+  struct atcommons_memlist memlist = atcommons_memlist_create(1);
+
+  char *a = "foo";
+  ret = atcommons_memlist_add(&memlist, a, true, NULL);
+  if (ret != 0) {
+    atlogger_log(TAG " 2a", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to append a to memlist: %d\n", ret);
+    return 1;
+  }
+
+  unsigned char *b = (unsigned char *)"bar";
+  ret = atcommons_memlist_add(&memlist, b, false, NULL);
+  if (ret == 0) {
+    atlogger_log(TAG " 2a", ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "Expected atcommons_memlist_append to fail due to exceeding length\n");
+    return 1;
+  }
+
+  return 0;
+}
+
+static int test2b_invalid_create_length() {
+  struct atcommons_memlist memlist = atcommons_memlist_create(ATCOMMONS_MEMLIST_SIZE + 1);
+
+  if (memlist.len != ATCOMMONS_MEMLIST_SIZE) {
+    atlogger_log(TAG " 2b", ATLOGGER_LOGGING_LEVEL_ERROR, "Expected memlist size to be capped at %d",
+                 ATCOMMONS_MEMLIST_SIZE);
+    return 1;
+  }
+
+  return 0;
+}
+
+static int test2c_invalid_append() {
+  int ret;
+  struct atcommons_memlist memlist = atcommons_memlist_create(2);
+  ret = atcommons_memlist_add(&memlist, NULL, false, NULL);
+  if (ret == 0) {
+    atlogger_log(TAG " 2a", ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "Expected atcommons_memlist_append to fail due to invalid input\n");
+    return 1;
+  }
+
+  return 0;
+}
+
+static int test2d_invalid_delete_index() {
+  int ret;
+  struct atcommons_memlist memlist = atcommons_memlist_create(2);
+  ret = atcommons_memlist_index_free(&memlist, 0);
+  if (ret == 0) {
+    atlogger_log(TAG " 2a", ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "Expected atcommons_memlist_index_free to fail due to unallocated index\n");
+    return 1;
+  }
+
+  ret = atcommons_memlist_index_free(&memlist, 3);
+  if (ret == 0) {
+    atlogger_log(TAG " 2a", ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "Expected atcommons_memlist_index_free to fail due to out of bounds index\n");
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

closes #543 

Created memory management util in atcommons to help address some leaks in atclient.

- Manages a list of up to 32 objects (the struct itself is stack allocated).
- Supports the case where something should remain allocated on success, but not failure.
- Supports custom free functions via a function pointer otherwise calls `free()`

**- How I did it**

**- How to verify it**

**- Description for the changelog**
feat(atcommons): memory management util
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
