### PR TITLE
fix: replace newline with null terminator when parsing atserver_message

### DIFF
--- a/packages/atclient/src/atnotification.c
+++ b/packages/atclient/src/atnotification.c
@@ -14,7 +14,26 @@ static int atclient_atnotification_from_cjson_node(atclient_atnotification *noti
 #endif
 
 void atclient_atnotification_init(atclient_atnotification *notification) {
-  memset(notification, 0, sizeof(atclient_atnotification));
+  // most of the fields are char* so manually set each to NULL
+  // in some niche cases, NULL != 0
+  notification->id = NULL;
+  notification->from = NULL;
+  notification->to = NULL;
+  notification->key = NULL;
+  notification->value = NULL;
+  notification->operation = NULL;
+  notification->message_type = NULL;
+  notification->enc_key_name = NULL;
+  notification->enc_algo = NULL;
+  notification->iv_nonce = NULL;
+  notification->ske_enc_key_name = NULL;
+  notification->ske_enc_algo = NULL;
+  notification->decrypted_value = NULL;
+  // Since there are very few non char* values, set each one manually
+  notification->epoch_millis = 0;
+  notification->is_encrypted = false;
+  notification->_initialized_fields[0] = 0;
+  notification->_initialized_fields[1] = 0;
 }
 
 void atclient_atnotification_free(atclient_atnotification *notification) {

--- a/packages/atclient/src/atserver_message.c
+++ b/packages/atclient/src/atserver_message.c
@@ -1,5 +1,9 @@
 #include "./atserver_message.h"
+#include "atlogger/atlogger.h"
 #include <stdlib.h>
+#include <string.h>
+
+#define TAG "atserver_message"
 
 size_t atserver_message_get_body_len(struct atserver_message message) {
   return message.len - message.token_len - message.prompt_len;
@@ -29,7 +33,19 @@ char *atserver_message_get_body(struct atserver_message message) {
 
 static const struct atserver_message EMPTY_MESSAGE = {.buffer = NULL, .len = 0, .prompt_len = 0, .token_len = 0};
 struct atserver_message atserver_message_parse(char *buffer, size_t len) {
-  if (len == 0) {
+  if (len < 1) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Invalid message: not long enough to be a valid server message\n");
+    return EMPTY_MESSAGE;
+  }
+
+  if (len > 2 && buffer[len - 2] == '\r' && buffer[len - 1] == '\n') {
+    buffer[len - 2] = 0;
+    len -= 2;
+  } else if (len > 1 && buffer[len - 1] == '\n') {
+    buffer[len - 1] = 0;
+    len--;
+  } else {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Invalid message: does not end with a newline\n");
     return EMPTY_MESSAGE;
   }
 
@@ -41,6 +57,7 @@ struct atserver_message atserver_message_parse(char *buffer, size_t len) {
     ; // walk to the end of the token section
   if (token_len == len) {
     // Parse error, token not found
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Invalid message: couldn't find body - no ':' token in string\n");
     return EMPTY_MESSAGE;
   }
 
@@ -58,6 +75,7 @@ struct atserver_message atserver_message_parse(char *buffer, size_t len) {
 
   if (prompt_len > ATSERVER_MESSAGE_PROMPT_LEN_MAX || token_len > ATSERVER_MESSAGE_TOKEN_LEN_MAX) {
     // Parse error, by specification they should never come close to exceeding UINT8_MAX
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Invalid message: prompt exceeds valid spec length\n");
     return EMPTY_MESSAGE;
   }
 

--- a/packages/atclient/tests/test_atserver_message.c
+++ b/packages/atclient/tests/test_atserver_message.c
@@ -47,8 +47,10 @@ int main() {
 
 uint8_t test_1a_long_prompt() {
   const char *TAG = BASE_TAG("1a");
-  char *buffer = "@foobar@data:baz";
-  const uint16_t len = strlen(buffer);
+
+  const uint16_t len = 17;
+  char buffer[len];
+  memcpy(buffer, "@foobar@data:baz\n", len);
 
   struct atserver_message message = atserver_message_parse(buffer, len);
 
@@ -67,8 +69,9 @@ uint8_t test_1a_long_prompt() {
 
 uint8_t test_1b_short_prompt() {
   const char *TAG = BASE_TAG("1b");
-  char *buffer = "@data:baz";
-  const uint16_t len = strlen(buffer);
+  const uint16_t len = 10;
+  char buffer[len];
+  memcpy(buffer, "@data:baz\n", len);
 
   struct atserver_message message = atserver_message_parse(buffer, len);
 
@@ -87,8 +90,9 @@ uint8_t test_1b_short_prompt() {
 
 uint8_t test_1c_no_prompt() {
   const char *TAG = BASE_TAG("1c");
-  char *buffer = "data:baz";
-  const uint16_t len = strlen(buffer);
+  const uint16_t len = 9;
+  char buffer[len];
+  memcpy(buffer, "data:baz\n", len);
 
   struct atserver_message message = atserver_message_parse(buffer, len);
 
@@ -107,8 +111,9 @@ uint8_t test_1c_no_prompt() {
 
 uint8_t test_2a_no_token() {
   const char *TAG = BASE_TAG("2a");
-  char *buffer = "@foo@baz";
-  const uint16_t len = strlen(buffer);
+  const uint16_t len = 9;
+  char buffer[len];
+  memcpy(buffer, "@foo@baz\n", len);
 
   struct atserver_message message = atserver_message_parse(buffer, len);
 
@@ -127,8 +132,9 @@ uint8_t test_2a_no_token() {
 
 uint8_t test_3a_no_body() {
   const char *TAG = BASE_TAG("3a");
-  char *buffer = "@foobar@data:";
-  const uint16_t len = strlen(buffer);
+  const uint16_t len = 14;
+  char buffer[len];
+  memcpy(buffer, "@foobar@data:\n", len);
 
   struct atserver_message message = atserver_message_parse(buffer, len);
 
@@ -148,9 +154,8 @@ uint8_t test_3a_no_body() {
 uint8_t test_4a_empty_message() {
   const char *TAG = BASE_TAG("4a");
   char *buffer = "";
-  const uint16_t len = strlen(buffer);
 
-  struct atserver_message message = atserver_message_parse(buffer, len);
+  struct atserver_message message = atserver_message_parse(buffer, 0);
 
   if (message.buffer != NULL) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "message.buffer is expected to be NULL but it isn't\n");
@@ -167,7 +172,7 @@ uint8_t test_4a_empty_message() {
 
 uint8_t test_5a_heap() {
   const char *TAG = BASE_TAG("5a");
-  char *static_buffer = "@foobar@data:baz";
+  char *static_buffer = "@foobar@data:baz\n";
   const uint16_t len = strlen(static_buffer);
   char *heap_buffer = malloc(sizeof(char) * len);
   if (heap_buffer == NULL) {
@@ -210,7 +215,7 @@ uint8_t test_5a_heap() {
 
 uint8_t test_5b_bad_parse_heap() {
   const char *TAG = BASE_TAG("5b");
-  char *static_buffer = "@foobar@baz";
+  char *static_buffer = "@foobar@baz\n";
   const uint16_t len = strlen(static_buffer);
   char *heap_buffer = malloc(sizeof(char) * len);
   if (heap_buffer == NULL) {
@@ -233,7 +238,7 @@ uint8_t test_5b_bad_parse_heap() {
   expect_uint("len", 0, message.len);
 
   // ensure original heap buffer is intact
-  if (strncmp(heap_buffer, static_buffer, len) != 0) {
+  if (strncmp(heap_buffer, static_buffer, len - 1) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "heap_buffer is malformed after a failed parse\n");
     free(heap_buffer);
     return 1;

--- a/packages/atclient/tests/test_parse_monitor.c
+++ b/packages/atclient/tests/test_parse_monitor.c
@@ -39,7 +39,7 @@ int main() {
 }
 
 static int test_1a_populate_data_ok() {
-  const char *input = "@bob@data:foo";
+  const char *input = "@bob@data:foo\n";
   size_t input_len = strlen(input);
   char *buffer = malloc(sizeof(char) * (input_len + 1));
   memcpy(buffer, input, strlen(input));
@@ -78,7 +78,7 @@ static int test_1a_populate_data_ok() {
 }
 
 static int test_1b_populate_data_empty() {
-  char *input = "@bob@data:";
+  char *input = "@bob@data:\n";
   size_t input_len = strlen(input);
   char *buffer = malloc(sizeof(char) * (input_len + 1));
   memcpy(buffer, input, strlen(input));
@@ -106,7 +106,7 @@ static int test_1b_populate_data_empty() {
 }
 
 static int test_2a_populate_error_msg() {
-  char *input = "@bob@error:bar";
+  char *input = "@bob@error:bar\n";
   size_t input_len = strlen(input);
   char *buffer = malloc(sizeof(char) * (input_len + 1));
   memcpy(buffer, input, strlen(input));
@@ -145,7 +145,7 @@ static int test_2a_populate_error_msg() {
 }
 
 static int test_2b_populate_error_empty() {
-  char *input = "@bob@error:";
+  char *input = "@bob@error:\n";
   size_t input_len = strlen(input);
   char *buffer = malloc(sizeof(char) * (input_len + 1));
   memcpy(buffer, input, strlen(input));
@@ -187,7 +187,7 @@ static int test_3a_populate_notification_msg() {
                 "\"operation\":\"update\","
                 "\"messageType\":\"MessageType.key\","
                 "\"isEncrypted\":false"
-                "}";
+                "}\n";
   size_t input_len = strlen(input);
   char *buffer = malloc(sizeof(char) * (input_len + 1));
   memcpy(buffer, input, strlen(input));
@@ -244,7 +244,7 @@ static int test_3a_populate_notification_msg() {
 }
 
 static int test_3b_populate_notification_empty() {
-  char *input = "@bob@notification:";
+  char *input = "@bob@notification:\n";
   size_t input_len = strlen(input);
   char *buffer = malloc(sizeof(char) * (input_len + 1));
   memcpy(buffer, input, strlen(input));
@@ -272,7 +272,7 @@ static int test_3b_populate_notification_empty() {
 }
 
 static int test_3c_populate_notification_invalid_json() {
-  char *input = "@bob@notification:{asdfasdfasdfasd";
+  char *input = "@bob@notification:{asdfasdfasdfasd\n";
   size_t input_len = strlen(input);
   char *buffer = malloc(sizeof(char) * (input_len + 1));
   memcpy(buffer, input, strlen(input));

--- a/test.supp
+++ b/test.supp
@@ -1,14 +1,1 @@
 # Suppressions for test suite
-{
-   Suppress conditional jump for "uninitialised string"
-   Memcheck:Cond
-   ...
-   fun:cJSON_ParseWithOpts
-   fun:cJSON_Parse
-   fun:atclient_atnotification_from_json_str
-   fun:populate_monitor_notification_message
-   fun:populate_monitor_message
-   fun:atclient_monitor_read
-   fun:test_2a_receive_notifications
-   fun:main
-}

--- a/tests/functional_tests/tests/test_atclient_monitor.c
+++ b/tests/functional_tests/tests/test_atclient_monitor.c
@@ -415,8 +415,8 @@ static int test_2a_receive_notifications(atclient *from_client, atclient *to_cli
   }
 
   atclient_monitor_message message1;
-  atclient_monitor_message_init(&message1);
   while (ret == 0) {
+    atclient_monitor_message_init(&message1);
     ret = atclient_monitor_read(to_client, worker_client, &message1, NULL);
     if (ret == 0 && message1.type == ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION &&
         strncmp(message1.notification->id, id1, strlen(message1.notification->id)) == 0) {
@@ -450,7 +450,6 @@ static int test_2a_receive_notifications(atclient *from_client, atclient *to_cli
       break;
     }
     atclient_monitor_message_free(&message1);
-    atclient_monitor_message_init(&message1);
   }
   free(id1);
   if (ret == ATCLIENT_SSL_TIMEOUT_EXITCODE) {
@@ -468,8 +467,8 @@ static int test_2a_receive_notifications(atclient *from_client, atclient *to_cli
   ret = send_notification(from_client, value2, key2, namespace, &id2);
 
   atclient_monitor_message message2;
-  atclient_monitor_message_init(&message2);
   while (ret == 0) {
+    atclient_monitor_message_init(&message2);
     ret = atclient_monitor_read(to_client, worker_client, &message2, NULL);
     if (ret == 0 && message2.type == ATCLIENT_MONITOR_MESSAGE_TYPE_NOTIFICATION &&
         strncmp(message2.notification->id, id2, strlen(id2)) == 0) {
@@ -503,7 +502,6 @@ static int test_2a_receive_notifications(atclient *from_client, atclient *to_cli
       break;
     }
     atclient_monitor_message_free(&message2);
-    atclient_monitor_message_init(&message2);
   }
   free(id2);
   if (ret == ATCLIENT_SSL_TIMEOUT_EXITCODE) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Ensure atserver_message's buffer is null-terminated
- Disabled the one suppression we had added to the test suite

**- How I did it**

- During parsing of atserver_message, replace the newline with a null-terminator
  - Chosen not to do this on the socket level as replacing a character
    would alter socket data and the caller would have to realloc and append
    the character if they want it to be included

Note: it's okay for atserver_message to modify the buffer, because it is meant to take ownership of the memory passed into it. atserver_message is meant to store a buffer and the positions of the prompt, token (data,error,notification) and the message body.

**- How to verify it**

- Ensure all tests are passing

**- Description for the changelog**
fix: replace newline with null terminator when parsing atserver_message
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
