### PR TITLE
feat: atlogger macro

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -2,7 +2,7 @@ CompileFlags:
   # Use gcc in development for better diagnostics
   # & Ensure that compilation doesn't fail due to warnings
   Compiler: gcc
-  Add: [-Wno-error, -xc, -std=c99]
+  Add: [-Wno-error, -xc, -std=c99, -DATSDK_DEBUG_MODE]
 
 Index:
   # Enable background indexing for better symbol information

--- a/cmake/package_util.cmake
+++ b/cmake/package_util.cmake
@@ -71,6 +71,7 @@ function(build_atsdk_package)
     )
 
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+      message(STATUS "LINKING PRIVATE HEADERS FOR DEBUG MODE")
       target_include_directories(
         ${PROJECT_NAME}
         PUBLIC $<BUILD_INTERFACE:${arg_PACKAGE_DIR}/src>

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ release_c_flags := "-std=c99 -Wno-error"
 
 # SETUP COMMANDS
 
-setup: configure-test-all
+setup:  build-test-all
   [ -f "$PWD/compile_commands.json" ] && rm $PWD/compile_commands.json || true
   ln -s {{test_dir}}/compile_commands.json $PWD/
   [ -f "$PWD/tests/compile_commands.json" ] && rm $PWD/tests/compile_commands.json || true

--- a/justfile
+++ b/justfile
@@ -16,7 +16,8 @@ unit_dir := quote(justfile_directory() / "build/unit-") + postfix
 func_dir := quote(justfile_directory() / "build/func-") + postfix
 memcheck_dir := quote(justfile_directory() / "build/memcheck-") + postfix
 
-c_flags := "-std=c99 -Wall -Wextra -Werror-implicit-function-declaration"
+debug_c_flags := "-std=c99 -Wall -Wextra -Werror-implicit-function-declaration -DATSDK_DEBUG_MODE"
+release_c_flags := "-std=c99 -Wno-error"
 
 # SETUP COMMANDS
 
@@ -99,7 +100,7 @@ configure-debug:
     -DCMAKE_INSTALL_PREFIX="$HOME/.local/" \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_C_COMPILER=$C_COMPILER \
-    -DCMAKE_C_FLAGS={{ c_flags }} \
+    -DCMAKE_C_FLAGS={{ debug_c_flags }} \
     -DATSDK_BUILD_TESTS=OFF \
     -DATSDK_MEMCHECK=OFF
 
@@ -109,7 +110,7 @@ configure-release:
     -G "$GENERATOR" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER=$C_COMPILER \
-    -DCMAKE_C_FLAGS="-std=c99 -Wno-error" \
+    -DCMAKE_C_FLAGS={{ release_c_flags }} \
     -DATSDK_BUILD_TESTS=OFF \
     -DATSDK_MEMCHECK=OFF
 
@@ -119,7 +120,7 @@ configure-test-unit:
     -G "$GENERATOR" \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_C_COMPILER=$C_COMPILER \
-    -DCMAKE_C_FLAGS={{ c_flags }} \
+    -DCMAKE_C_FLAGS={{ debug_c_flags }} \
     -DATSDK_BUILD_TESTS="unit" \
     -DATSDK_MEMCHECK=OFF \
     -DFIRST_ATSIGN="\"$FIRST_ATSIGN\"" \
@@ -131,7 +132,7 @@ configure-test-func:
     -G "$GENERATOR" \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_C_COMPILER=$C_COMPILER \
-    -DCMAKE_C_FLAGS={{ c_flags }} \
+    -DCMAKE_C_FLAGS={{ debug_c_flags }} \
     -DATSDK_BUILD_TESTS="func" \
     -DATSDK_MEMCHECK=OFF \
     -DATDIRECTORY_HOST="\"$ATDIRECTORY_HOST\"" \
@@ -150,7 +151,7 @@ configure-test-all:
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_C_COMPILER=$C_COMPILER \
-    -DCMAKE_C_FLAGS={{ c_flags }} \
+    -DCMAKE_C_FLAGS={{ debug_c_flags }} \
     -DATSDK_BUILD_TESTS=ON \
     -DATSDK_MEMCHECK=OFF \
     -DATDIRECTORY_HOST="\"$ATDIRECTORY_HOST\"" \
@@ -168,7 +169,7 @@ configure-test-memcheck:
     -G "$GENERATOR" \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_C_COMPILER=$C_COMPILER \
-    -DCMAKE_C_FLAGS={{ c_flags }} \
+    -DCMAKE_C_FLAGS={{ debug_c_flags }} \
     -DATSDK_BUILD_TESTS=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DATSDK_MEMCHECK=ON \

--- a/packages/atclient/src/atkey.c
+++ b/packages/atclient/src/atkey.c
@@ -397,7 +397,7 @@ int atclient_atkey_to_string(const atclient_atkey *atkey, char **atkeystr) {
 
   if (index_pos != atkey_str_size - 1) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN,
-                 "index_pos != atkey_str_size - 1 (%d != %d - 1). The predicted `atkey_str_size` variable was not "
+                 "index_pos != atkey_str_size - 1 (%zu != %zu - 1). The predicted `atkey_str_size` variable was not "
                  "evaluated correctly.\n",
                  index_pos, atkey_str_size);
   }

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -106,7 +106,7 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
   size_t n1, n2;
   ret = atclient_tls_socket_read(&ctx->_socket, &buf1, &n1, atclient_socket_read_until_char('@'));
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read from the connection\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read from the connection\n");
     goto exit;
   }
   free(buf1);
@@ -118,7 +118,7 @@ int atclient_connection_connect(atclient_connection *ctx, const char *host, cons
 
   ret = atclient_tls_socket_read(&ctx->_socket, &buf2, &n2, atclient_socket_read_until_char('@'));
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read from the connection\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read from the connection\n");
     goto exit;
   }
   free(buf2);
@@ -210,7 +210,7 @@ int atclient_connection_write(atclient_connection *ctx, const unsigned char *val
     if (valuecopy != NULL) {
       memcpy(valuecopy, value, value_len);
       atlogger_fix_stdout_buffer((char *)valuecopy, value_len);
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sSENT: %s\"%.*s\"%s\n", BBLU, HCYN, value_len, valuecopy,
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sSENT: %s\"%.*s\"%s\n", BBLU, HCYN, (int)value_len, valuecopy,
                    ATCLIENT_RESET);
       free(valuecopy);
     } else {
@@ -313,8 +313,8 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     if ((srccopy = malloc(sizeof(unsigned char) * src_len)) != NULL) {
       memcpy(srccopy, src, src_len);
       atlogger_fix_stdout_buffer((char *)srccopy, src_len);
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sSENT: %s\"%.*s\"%s\n", BBLU, HCYN, strlen((char *)srccopy),
-                   srccopy, ATCLIENT_RESET);
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sSENT: %s\"%.*s\"%s\n", BBLU, HCYN,
+                   (int)strlen((char *)srccopy), srccopy, ATCLIENT_RESET);
       free(srccopy);
     } else {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
@@ -387,7 +387,7 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
   size_t read_n;
   ret = atclient_tls_socket_read(&ctx->_socket, &read_buf, &read_n, atclient_socket_read_until_char('\n'));
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read from the connection\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read from the connection\n");
     goto exit;
   }
 
@@ -441,7 +441,7 @@ int atclient_connection_send(atclient_connection *ctx, const unsigned char *src,
     if ((recvcopy = malloc(sizeof(unsigned char) * *recv_len)) != NULL) {
       memcpy(recvcopy, recv, *recv_len);
       atlogger_fix_stdout_buffer((char *)recvcopy, *recv_len);
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, *recv_len, recvcopy,
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, (int)*recv_len, recvcopy,
                    ATCLIENT_RESET);
       free(recvcopy);
     } else {
@@ -576,7 +576,7 @@ int atclient_connection_read(atclient_connection *ctx, unsigned char **value, si
   size_t read_n;
   ret = atclient_tls_socket_read(&ctx->_socket, &read_buf, &read_n, atclient_socket_read_until_char('\n'));
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read from the connection\n", ret);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to read from the connection\n");
     goto exit;
   }
   size_t read_i = 0; // will store where the start of `<type>:` is (if happy path)
@@ -602,7 +602,7 @@ int atclient_connection_read(atclient_connection *ctx, unsigned char **value, si
    * 5. Print debug log
    */
   if (atlogger_get_logging_level() >= ATLOGGER_LOGGING_LEVEL_DEBUG) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, *value_len, *value,
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, (int)*value_len, *value,
                  ATCLIENT_RESET);
   }
 

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -1,6 +1,5 @@
 #include "atclient/monitor.h"
 #include "atclient/atclient.h"
-#include "atclient/atclient_utils.h"
 #include "atclient/atnotification.h"
 #include "atclient/connection.h"
 #include "atclient/constants.h"
@@ -159,7 +158,7 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
   }
   // no longer need to free buffer, memory is owned by message->atserver_message
 
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, buffer_len, buffer,
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sRECV: %s\"%.*s\"%s\n", BMAG, HMAG, (int)buffer_len, buffer,
                ATCLIENT_RESET);
 
   ret = populate_monitor_message(message);
@@ -243,7 +242,7 @@ int populate_monitor_message(atclient_monitor_message *message) {
     }
     break;
   }
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unknown token type: %.*s\n", token_len, token);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unknown token type: %.*s\n", (int)token_len, token);
   message->type = ATCLIENT_MONITOR_MESSAGE_TYPE_NONE;
   return 2;
 }
@@ -390,7 +389,7 @@ int decrypt_notification(atclient *atclient, atclient_atnotification *notificati
 
     if (ivlen != ATCHOPS_IV_BUFFER_SIZE) {
       ret = 1;
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Invalid iv length was decoded. Expected %d but got %d\n",
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Invalid iv length was decoded. Expected %d but got %zu\n",
                    ATCHOPS_IV_BUFFER_SIZE, ivlen);
       goto exit;
     }

--- a/packages/atclient/src/notify.c
+++ b/packages/atclient/src/notify.c
@@ -247,8 +247,9 @@ static size_t calculate_cmd_size(const atclient_notify_params *params, const siz
     cmdsize += strlen(":ttln:") + atclient_string_utils_long_strlen(params->notification_expiry); // :$ttln
   }
 
-  if(atclient_notify_params_is_should_encrypt_initialized(params)) {
-    cmdsize += strlen(":isEncrypted:") + (params->should_encrypt ? strlen("true") : strlen("false")); // :isEncrypted:true | :isEncrypted:false
+  if (atclient_notify_params_is_should_encrypt_initialized(params)) {
+    cmdsize += strlen(":isEncrypted:") +
+               (params->should_encrypt ? strlen("true") : strlen("false")); // :isEncrypted:true | :isEncrypted:false
   }
 
   if (atclient_notify_params_is_atkey_initialized(params)) {
@@ -290,7 +291,7 @@ static int generate_cmd(const atclient_notify_params *params, const char *cmdval
   cmdsize = calculate_cmd_size(params, cmdvaluelen, &atkeylen, &metadatastrlen);
   if (cmdsize <= 0) {
     res = 1;
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "calculate_cmd_size failed with code %d\n", cmdsize);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "calculate_cmd_size failed with code %zu\n", cmdsize);
     goto exit;
   }
 
@@ -341,7 +342,7 @@ static int generate_cmd(const atclient_notify_params *params, const char *cmdval
     off += strlen(":ttln:") + atclient_string_utils_long_strlen(params->notification_expiry);
   }
 
-  if(atclient_notify_params_is_should_encrypt_initialized(params)) {
+  if (atclient_notify_params_is_should_encrypt_initialized(params)) {
     const char *isEncryptedBool = params->should_encrypt ? "true" : "false";
     snprintf(cmd + off, cmdsize - off, ":isEncrypted:%s", isEncryptedBool);
     off += strlen(":isEncrypted:") + strlen(isEncryptedBool);

--- a/packages/atclient/tests/test_atkey_metadata.c
+++ b/packages/atclient/tests/test_atkey_metadata.c
@@ -1,5 +1,6 @@
 #include "atclient/metadata.h"
 #include "atlogger/atlogger.h"
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -142,7 +143,7 @@ static int test_atkey_metadata_from_jsonstr() {
 
   if (metadata.ttl != 86400) {
     ret = 1;
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.ttl != 86400: %ld\n", metadata.ttl);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "metadata.ttl != 86400: %" PRIu64 "\n", metadata.ttl);
     goto exit;
   }
 

--- a/packages/atclient/tests/test_atserver_message.c
+++ b/packages/atclient/tests/test_atserver_message.c
@@ -38,10 +38,10 @@ int main() {
   return ret;
 }
 
-#define expect_uint(TEST_TAG, EXP, ACT)                                                                                \
+#define expect_uint(TEST_TAG, EXP, FMT, ACT)                                                                           \
   if (EXP != ACT) {                                                                                                    \
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%s: incorrect value (expected: %u, actual: %u)\n", TEST_TAG, EXP, \
-                 ACT);                                                                                                 \
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%s: incorrect value (expected: %u, actual: %" FMT ")\n",          \
+                 TEST_TAG, EXP, ACT);                                                                                  \
     return 1;                                                                                                          \
   }
 
@@ -59,10 +59,10 @@ uint8_t test_1a_long_prompt() {
     return 1;
   }
 
-  expect_uint("prompt len", 8, message.prompt_len);
-  expect_uint("token len", 5, message.token_len);
-  expect_uint("body len", 3, atserver_message_get_body_len(message));
-  expect_uint("len", 16, message.len);
+  expect_uint("prompt len", 8, "u", message.prompt_len);
+  expect_uint("token len", 5, "u", message.token_len);
+  expect_uint("body len", 3, "zu", atserver_message_get_body_len(message));
+  expect_uint("len", 16, "zu", message.len);
 
   return 0;
 }
@@ -80,10 +80,10 @@ uint8_t test_1b_short_prompt() {
     return 1;
   }
 
-  expect_uint("prompt len", 1, message.prompt_len);
-  expect_uint("token len", 5, message.token_len);
-  expect_uint("body len", 3, atserver_message_get_body_len(message));
-  expect_uint("len", 9, message.len);
+  expect_uint("prompt len", 1, "u", message.prompt_len);
+  expect_uint("token len", 5, "u", message.token_len);
+  expect_uint("body len", 3, "zu", atserver_message_get_body_len(message));
+  expect_uint("len", 9, "zu", message.len);
 
   return 0;
 }
@@ -101,10 +101,10 @@ uint8_t test_1c_no_prompt() {
     return 1;
   }
 
-  expect_uint("prompt len", 0, message.prompt_len);
-  expect_uint("token len", 5, message.token_len);
-  expect_uint("body len", 3, atserver_message_get_body_len(message));
-  expect_uint("len", 8, message.len);
+  expect_uint("prompt len", 0, "u", message.prompt_len);
+  expect_uint("token len", 5, "u", message.token_len);
+  expect_uint("body len", 3, "zu", atserver_message_get_body_len(message));
+  expect_uint("len", 8, "zu", message.len);
 
   return 0;
 }
@@ -122,10 +122,10 @@ uint8_t test_2a_no_token() {
     return 1;
   }
 
-  expect_uint("prompt len", 0, message.prompt_len);
-  expect_uint("token len", 0, message.token_len);
-  expect_uint("body len", 0, atserver_message_get_body_len(message));
-  expect_uint("len", 0, message.len);
+  expect_uint("prompt len", 0, "u", message.prompt_len);
+  expect_uint("token len", 0, "u", message.token_len);
+  expect_uint("body len", 0, "zu", atserver_message_get_body_len(message));
+  expect_uint("len", 0, "zu", message.len);
 
   return 0;
 }
@@ -143,10 +143,10 @@ uint8_t test_3a_no_body() {
     return 1;
   }
 
-  expect_uint("prompt len", 8, message.prompt_len);
-  expect_uint("token len", 5, message.token_len);
-  expect_uint("body len", 0, atserver_message_get_body_len(message));
-  expect_uint("len", 13, message.len);
+  expect_uint("prompt len", 8, "u", message.prompt_len);
+  expect_uint("token len", 5, "u", message.token_len);
+  expect_uint("body len", 0, "zu", atserver_message_get_body_len(message));
+  expect_uint("len", 13, "zu", message.len);
 
   return 0;
 }
@@ -162,10 +162,10 @@ uint8_t test_4a_empty_message() {
     return 1;
   }
 
-  expect_uint("prompt len", 0, message.prompt_len);
-  expect_uint("token len", 0, message.token_len);
-  expect_uint("body len", 0, atserver_message_get_body_len(message));
-  expect_uint("len", 0, message.len);
+  expect_uint("prompt len", 0, "u", message.prompt_len);
+  expect_uint("token len", 0, "u", message.token_len);
+  expect_uint("body len", 0, "zu", atserver_message_get_body_len(message));
+  expect_uint("len", 0, "zu", message.len);
 
   return 0;
 }
@@ -189,10 +189,10 @@ uint8_t test_5a_heap() {
     return 1;
   }
 
-  expect_uint("prompt len", 8, message.prompt_len);
-  expect_uint("token len", 5, message.token_len);
-  expect_uint("body len", 3, atserver_message_get_body_len(message));
-  expect_uint("len", 16, message.len);
+  expect_uint("prompt len", 8, "u", message.prompt_len);
+  expect_uint("token len", 5, "u", message.token_len);
+  expect_uint("body len", 3, "zu", atserver_message_get_body_len(message));
+  expect_uint("len", 16, "zu", message.len);
 
   message.buffer[0] = 'H';
   if (strncmp(heap_buffer, "Hfoobar@data:baz", len) != 0) {
@@ -204,7 +204,7 @@ uint8_t test_5a_heap() {
   atserver_message_free(&message);
   if (message.buffer != NULL) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "message.buffer is expected to be NULL after free but it isn't: %zu\n", message.buffer);
+                 "message.buffer is expected to be NULL after free but it isn't: %s\n", message.buffer);
     return 1;
   }
 
@@ -232,10 +232,10 @@ uint8_t test_5b_bad_parse_heap() {
     return 1;
   }
 
-  expect_uint("prompt len", 0, message.prompt_len);
-  expect_uint("token len", 0, message.token_len);
-  expect_uint("body len", 0, atserver_message_get_body_len(message));
-  expect_uint("len", 0, message.len);
+  expect_uint("prompt len", 0, "u", message.prompt_len);
+  expect_uint("token len", 0, "u", message.token_len);
+  expect_uint("body len", 0, "zu", atserver_message_get_body_len(message));
+  expect_uint("len", 0, "zu", message.len);
 
   // ensure original heap buffer is intact
   if (strncmp(heap_buffer, static_buffer, len - 1) != 0) {

--- a/packages/atclient/tests/test_parse_at_prompt.c
+++ b/packages/atclient/tests/test_parse_at_prompt.c
@@ -41,8 +41,8 @@ int main() {
 // returns 1 if EXP != ACT and logs the error
 #define expect_size_t(TEST_TAG, EXP, ACT)                                                                              \
   if (EXP != ACT) {                                                                                                    \
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%s: wrong idx value (expected: %d, actual: %d)\n", TEST_TAG, EXP, \
-                 ACT);                                                                                                 \
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "%s: wrong idx value (expected: %d, actual: %zu)\n", TEST_TAG,     \
+                 EXP, ACT);                                                                                            \
     return 1;                                                                                                          \
   }
 

--- a/packages/atlogger/include/atlogger/atlogger.h
+++ b/packages/atlogger/include/atlogger/atlogger.h
@@ -21,6 +21,44 @@ void atlogger_set_opts(int opts);
 void atlogger_log(const char *tag, const enum atlogger_logging_level level, const char *format, ...);
 void atlogger_fix_stdout_buffer(char *str, const size_t strlen);
 
+typedef struct atlogger_ctx {
+  enum atlogger_logging_level level;
+  int opts;
+} atlogger_ctx;
+
+atlogger_ctx *atlogger_get_instance();
+
+#ifndef ATLOGGER_OVERRIDE_LOG_FUNCTION
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#define PREFIX_BUFFER_LEN 64
+void atlogger_get_prefix(enum atlogger_logging_level logging_level, char *prefix, size_t prefixlen);
+void _atlogger_log(const char *tag, enum atlogger_logging_level level, const char *format, ...);
+
+#if defined(ATSDK_DEBUG_MODE)
+#define atlogger_log(TAG, LEVEL, FORMAT, ...)                                                                          \
+  {                                                                                                                    \
+    atlogger_ctx *ctx = atlogger_get_instance();                                                                       \
+    if (LEVEL <= ctx->level) {                                                                                         \
+      if (TAG != NULL) {                                                                                               \
+        char *prefix = malloc(sizeof(char) * PREFIX_BUFFER_LEN);                                                       \
+        if (prefix != NULL) {                                                                                          \
+          atlogger_get_prefix(LEVEL, prefix, PREFIX_BUFFER_LEN);                                                       \
+          printf("%.*s ", (int)strlen(prefix), prefix);                                                                \
+          printf("%s:%d - ", __FILE__, __LINE__);                                                                      \
+          printf("%.*s | ", (int)strlen(TAG), TAG);                                                                    \
+          free(prefix);                                                                                                \
+        }                                                                                                              \
+      }                                                                                                                \
+    }                                                                                                                  \
+    printf(FORMAT __VA_OPT__(, ) __VA_ARGS__);                                                                         \
+  }
+#else
+#define atlogger_log(TAG, LEVEL, FORMAT, ...) _atlogger_log(TAG, LEVEL, FORMAT __VA_OPT__(, ) __VA_ARGS__);
+#endif
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -1,91 +1,33 @@
-
 #include "atlogger/atlogger.h"
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #if !defined(ATLOGGER_DISABLE_TIMESTAMPS) && !defined(ATLOGGER_OVERRIDE_LOG_FUNCTION)
 #include <time.h>
 #endif
 
-#define PREFIX_BUFFER_LEN 64
+#if (_POSIX_VERSION < 200112L)
+#include <inttypes.h>
+#endif
+
 #define INFO_PREFIX "\e[0;32m[INFO]\e[0m"
 #define WARN_PREFIX "\e[0;31m[WARN]\e[0m"
 #define ERROR_PREFIX "\e[1;31m[ERROR]\e[0m"
 #define DEBUG_PREFIX "\e[0;34m[DEBG]\e[0m"
 
-typedef struct atlogger_ctx {
-  enum atlogger_logging_level level;
-  int opts;
-} atlogger_ctx;
-
 static atlogger_ctx ctx;
 static int is_ctx_initalized = 0;
 
-static atlogger_ctx *atlogger_get_instance() {
+atlogger_ctx *atlogger_get_instance() {
   if (is_ctx_initalized == 0) {
     is_ctx_initalized = 1;
   }
   return &ctx;
 }
-
-#ifndef ATLOGGER_OVERRIDE_LOG_FUNCTION
-static void atlogger_get_prefix(enum atlogger_logging_level logging_level, char *prefix, size_t prefixlen) {
-  memset(prefix, 0, prefixlen);
-  int off = 0;
-
-  switch (logging_level) {
-  case ATLOGGER_LOGGING_LEVEL_INFO: {
-    off = strlen(INFO_PREFIX);
-    memcpy(prefix, INFO_PREFIX, off);
-    break;
-  }
-  case ATLOGGER_LOGGING_LEVEL_WARN: {
-    off = strlen(WARN_PREFIX);
-    memcpy(prefix, WARN_PREFIX, off);
-    break;
-  }
-  case ATLOGGER_LOGGING_LEVEL_ERROR: {
-    off = strlen(ERROR_PREFIX);
-    memcpy(prefix, ERROR_PREFIX, off);
-    break;
-  }
-  case ATLOGGER_LOGGING_LEVEL_DEBUG: {
-    off = strlen(DEBUG_PREFIX);
-    memcpy(prefix, DEBUG_PREFIX, off);
-    break;
-  }
-  default: {
-    break;
-  }
-  }
-
-#ifndef ATLOGGER_DISABLE_TIMESTAMPS
-  struct timespec timespec;
-  int res = clock_gettime(CLOCK_REALTIME, &timespec);
-
-  if (res == 0) {
-    res = strftime(prefix + off, PREFIX_BUFFER_LEN - off, " %F %T",
-                   gmtime(&timespec.tv_sec)); // format accurate to the second
-    if (res != 0) {
-      off += res;
-      res = 0;
-    }
-  }
-  if (res == 0) {
-    snprintf(prefix + off, PREFIX_BUFFER_LEN - off, ".%09lu", timespec.tv_nsec);
-    off += strlen(prefix + off);
-  }
-#endif
-
-  off -= 3;
-  snprintf(prefix + off, PREFIX_BUFFER_LEN - off, " |");
-  off += 2;
-  prefix[off] = '\0';
-}
-#endif
 
 enum atlogger_logging_level atlogger_get_logging_level() {
   atlogger_ctx *ctx = atlogger_get_instance();
@@ -101,30 +43,6 @@ void atlogger_set_opts(int opts) {
   atlogger_ctx *ctx = atlogger_get_instance();
   ctx->opts = opts;
 }
-
-#ifndef ATLOGGER_OVERRIDE_LOG_FUNCTION
-void atlogger_log(const char *tag, const enum atlogger_logging_level level, const char *format, ...) {
-  atlogger_ctx *ctx = atlogger_get_instance();
-
-  if (level > ctx->level) {
-    return;
-  }
-
-  va_list args;
-  va_start(args, format);
-  if (tag != NULL) {
-    char *prefix = malloc(sizeof(char) * PREFIX_BUFFER_LEN);
-    if (prefix != NULL) {
-      atlogger_get_prefix(level, prefix, PREFIX_BUFFER_LEN);
-      printf("%.*s ", (int)strlen(prefix), prefix);
-      printf("%.*s | ", (int)strlen(tag), tag);
-      free(prefix);
-    }
-  }
-  vprintf(format, args);
-  va_end(args);
-}
-#endif
 
 void atlogger_fix_stdout_buffer(char *str, const size_t strlen) {
   // if str == 'Jeremy\r\n', i want it to be 'Jeremy'
@@ -174,3 +92,84 @@ void atlogger_fix_stdout_buffer(char *str, const size_t strlen) {
 
 exit: { return; }
 }
+
+#ifndef ATLOGGER_OVERRIDE_LOG_FUNCTION
+void atlogger_get_prefix(enum atlogger_logging_level logging_level, char *prefix, size_t prefixlen) {
+  memset(prefix, 0, prefixlen);
+  int off = 0;
+
+  switch (logging_level) {
+  case ATLOGGER_LOGGING_LEVEL_INFO: {
+    off = strlen(INFO_PREFIX);
+    memcpy(prefix, INFO_PREFIX, off);
+    break;
+  }
+  case ATLOGGER_LOGGING_LEVEL_WARN: {
+    off = strlen(WARN_PREFIX);
+    memcpy(prefix, WARN_PREFIX, off);
+    break;
+  }
+  case ATLOGGER_LOGGING_LEVEL_ERROR: {
+    off = strlen(ERROR_PREFIX);
+    memcpy(prefix, ERROR_PREFIX, off);
+    break;
+  }
+  case ATLOGGER_LOGGING_LEVEL_DEBUG: {
+    off = strlen(DEBUG_PREFIX);
+    memcpy(prefix, DEBUG_PREFIX, off);
+    break;
+  }
+  default: {
+    break;
+  }
+  }
+
+#if !defined(ATLOGGER_DISABLE_TIMESTAMPS)
+#if (_POSIX_VERSION < 200112L)
+  time_t ts = time(NULL);
+  off += snprintf(prefix + off, PREFIX_BUFFER_LEN - off, " %" PRIu64, (uint64_t)ts);
+#else
+  struct timespec timespec;
+  int res = clock_gettime(CLOCK_REALTIME, &timespec);
+
+  if (res == 0) {
+    res = strftime(prefix + off, PREFIX_BUFFER_LEN - off, " %F %T",
+                   gmtime(&timespec.tv_sec)); // format accurate to the second
+    if (res != 0) {
+      off += res;
+      res = 0;
+    }
+  }
+  if (res == 0) {
+    snprintf(prefix + off, PREFIX_BUFFER_LEN - off, ".%09lu", timespec.tv_nsec);
+    off += strlen(prefix + off);
+  }
+#endif
+#endif
+
+  off -= 3;
+  snprintf(prefix + off, PREFIX_BUFFER_LEN - off, " |");
+  off += 2;
+  prefix[off] = '\0';
+}
+
+void _atlogger_log(const char *tag, enum atlogger_logging_level level, const char *format, ...) {
+  atlogger_ctx *ctx = atlogger_get_instance();
+  if (level > ctx->level) {
+    return;
+  }
+  va_list args;
+  va_start(args, format);
+  if (tag != NULL) {
+    char *prefix = malloc(sizeof(char) * PREFIX_BUFFER_LEN);
+    if (prefix != NULL) {
+      atlogger_get_prefix(level, prefix, PREFIX_BUFFER_LEN);
+      printf("%.*s ", (int)strlen(prefix), prefix);
+      printf("%.*s | ", (int)strlen(tag), tag);
+      free(prefix);
+    }
+  }
+  vprintf(format, args);
+  va_end(args);
+}
+#endif

--- a/tests/functional_tests/tests/test_atclient_connection.c
+++ b/tests/functional_tests/tests/test_atclient_connection.c
@@ -309,7 +309,8 @@ static int test_7_send_should_fail(atclient_connection *conn) {
   ret = atclient_connection_send(conn, send_data, send_data_len, recv, recvsize, &recvlen);
   if (ret == 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "Successfully sent \"%s\" when it should have resulted in a failure: %d\n", ret);
+                 "Successfully sent \"%.*s\" when it should have resulted in a failure: %d\n", (int)send_data_len,
+                 send_data, ret);
     ret = 1;
     goto exit;
   }

--- a/tests/functional_tests/tests/test_atclient_publickey.c
+++ b/tests/functional_tests/tests/test_atclient_publickey.c
@@ -289,18 +289,18 @@ static int test_6_get_with_metadata(atclient *atclient) {
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atkey.metadata.ccd: %d\n", atkey.metadata.ccd);
 
   if (atclient_atkey_metadata_is_ttl_initialized(&(atkey.metadata)) && atkey.metadata.ttl != ATKEY_TTL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed ttl comparison, got %d and expected %d\n",
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed ttl comparison, got %" PRIu64 " and expected %d\n",
                  atkey.metadata.ttl, ATKEY_TTL);
     goto exit;
   }
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atkey.metadata.ttl: %d\n", atkey.metadata.ttl);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atkey.metadata.ttl: %" PRIu64 "\n", atkey.metadata.ttl);
 
   if (atclient_atkey_metadata_is_ttr_initialized(&(atkey.metadata)) && atkey.metadata.ttr != ATKEY_TTR) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed ttr comparison, got %d and expected %d\n",
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed ttr comparison, got %" PRIu64 " and expected %d\n",
                  atkey.metadata.ttr, ATKEY_TTR);
     goto exit;
   }
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atkey.metadata.ttr: %d\n", atkey.metadata.ttr);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atkey.metadata.ttr: %" PRIu64 "\n", atkey.metadata.ttr);
 
   if (atclient_atkey_metadata_is_is_encrypted_initialized(&(atkey.metadata)) &&
       atkey.metadata.is_encrypted != ATKEY_ISENCRYPTED) {

--- a/tests/functional_tests/tests/test_atclient_selfkey.c
+++ b/tests/functional_tests/tests/test_atclient_selfkey.c
@@ -313,11 +313,12 @@ static int test_7_get_with_metadata(atclient *atclient) {
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atkey.value: \"%s\" == \"%s\"\n", value, ATKEY_VALUE);
 
   if (atkey.metadata.ttl != ATKEY_TTL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ttl: %d != %d\n", atkey.metadata.ttl, ATKEY_TTL);
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atkey.metadata.ttl: %" PRIu64 " != %d\n", atkey.metadata.ttl,
+                 ATKEY_TTL);
     ret = 1;
     goto exit;
   }
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atkey.metadata.ttl: %d\n", atkey.metadata.ttl);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "atkey.metadata.ttl: %" PRIu64 "\n", atkey.metadata.ttl);
 
   if (atclient_atkey_metadata_is_is_encrypted_initialized(&atkey.metadata) &&
       atkey.metadata.is_encrypted != ATKEY_ISENCRYPTED) {
@@ -403,7 +404,6 @@ static int tear_down(atclient *atclient) {
   const size_t atkeystrsize = 128;
   char atkeystr[atkeystrsize];
   memset(atkeystr, 0, sizeof(char) * atkeystrsize);
-  size_t atkeystrlen = 0;
 
   const size_t commandsize = 256;
   char command[commandsize];

--- a/tests/functional_tests/tests/test_atclient_sharedkey.c
+++ b/tests/functional_tests/tests/test_atclient_sharedkey.c
@@ -167,20 +167,20 @@ static int test_2_get_as_sharedby(atclient *atclient) {
 
   // check ttl, should be 5 minutes
   if (atkey.metadata.ttl != ATKEY_TTL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ttl mismatch. Expected %d, got %d\n", ATKEY_TTL,
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ttl mismatch. Expected %d, got %" PRIu64 "\n", ATKEY_TTL,
                  atkey.metadata.ttl);
     ret = 1;
     goto exit;
   }
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "ttl matched: %d\n", atkey.metadata.ttl);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "ttl matched: %" PRIu64 "\n", atkey.metadata.ttl);
 
   if (atkey.metadata.ttr != ATKEY_TTR) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ttr mismatch. Expected %d, got %d\n", ATKEY_TTR,
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ttr mismatch. Expected %d, got %" PRIu64 "\n", ATKEY_TTR,
                  atkey.metadata.ttr);
     ret = 1;
     goto exit;
   }
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "ttr matched: %d\n", atkey.metadata.ttr);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "ttr matched: %" PRIu64 "\n", atkey.metadata.ttr);
 
   goto exit;
 exit: {
@@ -231,20 +231,20 @@ static int test_3_get_as_sharedwith(atclient *atclient2) {
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "value matched: %s == %s\n", value, ATKEY_VALUE);
 
   if (atclient_atkey_metadata_is_ttl_initialized(&atkey.metadata) && atkey.metadata.ttl != ATKEY_TTL) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ttl mismatch. Expected %d, got %d\n", ATKEY_TTL,
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ttl mismatch. Expected %d, got %" PRIu64 "\n", ATKEY_TTL,
                  atkey.metadata.ttl);
     ret = 1;
     goto exit;
   }
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "ttl matched: %d\n", atkey.metadata.ttl);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "ttl matched: %" PRIu64 "\n", atkey.metadata.ttl);
 
   if (atclient_atkey_metadata_is_ttr_initialized(&atkey.metadata) && atkey.metadata.ttr != ATKEY_TTR) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ttr mismatch. Expected %d, got %d\n", ATKEY_TTR,
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ttr mismatch. Expected %d, got %" PRIu64 "\n", ATKEY_TTR,
                  atkey.metadata.ttr);
     ret = 1;
     goto exit;
   }
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "ttr matched: %d\n", atkey.metadata.ttr);
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "ttr matched: %" PRIu64 "\n", atkey.metadata.ttr);
 
   goto exit;
 exit: {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- atlogger_log becomes an inline macro when the ATSDK_DEBUG_MODE is enabled
  - As a macro, also added `__FILE__:__LINE__` to log prefix for more debugging information in debug mode (enabled in all but the release build of justfile)
  - Automatically enabled in clangd (`.clangd` file settings), which allows clangd to check for format specifier issues
  - Requires a compiler version which supports `__VA_ARG__` and `__VA_OPT__` (only in debug mode)
  - fixed discovered issues
- When timestamps are enabled (on by default), check POSIX version.
  - Use full milliseconds when supported (POSIX.1-2001 i.e. `200112L` - `clock_gettime` function)
  - Otherwise use only seconds (time.h - `time` function)

Example of `__FILE__:__LINE__` output:
![CleanShot 2025-03-05 at 16 39 57@2x](https://github.com/user-attachments/assets/c03602b6-e87f-4807-a05f-5e5eb53ed91a)


**- How I did it**

**- How to verify it**

**- Description for the changelog**
feat: atlogger macro
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
