### PR TITLE
fix: use atclient_connection_write for monitor start

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ unit_dir := quote(justfile_directory() / "build/unit-") + postfix
 func_dir := quote(justfile_directory() / "build/func-") + postfix
 memcheck_dir := quote(justfile_directory() / "build/memcheck-") + postfix
 
-debug_c_flags := "-std=c99 -Wall -Wextra -Werror-implicit-function-declaration -DATSDK_DEBUG_MODE"
+debug_c_flags := "-std=c99 -Wall -Wextra -Werror-implicit-function-declaration -DATSDK_DEBUG_MODE=1"
 release_c_flags := "-std=c99 -Wno-error"
 
 # SETUP COMMANDS

--- a/packages/atauth/src/run_enroll_command.c
+++ b/packages/atauth/src/run_enroll_command.c
@@ -319,8 +319,8 @@ static int fetch_and_decrypt_key(atclient_connection *conn, const char *key_name
     }
     if (iv_raw_len != ATCHOPS_IV_BUFFER_SIZE) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
-                   "Unexpected size for base64 decoded iv (expected: %zu, actual: %zu)\n", ATCHOPS_IV_BUFFER_SIZE,
-                   iv_raw_len);
+                   "Unexpected size for base64 decoded iv (expected: %zu, actual: %zu)\n",
+                   (size_t)ATCHOPS_IV_BUFFER_SIZE, iv_raw_len);
       cJSON_Delete(json_server_resp);
       return ret;
     }

--- a/packages/atclient/src/atclient.c
+++ b/packages/atclient/src/atclient.c
@@ -270,7 +270,7 @@ int atclient_pkam_authenticate(atclient *ctx, const char *atsign, const atclient
 
   if (atserver_host == NULL || atserver_port == 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO,
-                 "Missing atServer host or port. Using %s:%lu atDirectory to find atServer address\n", atdirectory_host,
+                 "Missing atServer host or port. Using %s:%u atDirectory to find atServer address\n", atdirectory_host,
                  atdirectory_port);
     if ((ret = atclient_utils_find_atserver_address(atdirectory_host, atdirectory_port, atsign, &atserver_host,
                                                     &atserver_port)) != 0) {

--- a/packages/atclient/src/encryption_key_helpers.c
+++ b/packages/atclient/src/encryption_key_helpers.c
@@ -318,7 +318,7 @@ int atclient_get_shared_encryption_key_shared_by_other(atclient *ctx, const char
   if (!atclient_string_utils_starts_with(response, "data:")) {
     if (atclient_string_utils_starts_with(response, "error:AT0015-key not found")) {
       ret = ATCLIENT_ERR_AT0015_KEY_NOT_FOUND;
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "key not found\n", ret);
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "key not found\n");
       return ret;
     }
   }

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -1,5 +1,6 @@
 #include "atclient/monitor.h"
 #include "atclient/atclient.h"
+#include "atclient/atclient_utils.h"
 #include "atclient/atnotification.h"
 #include "atclient/connection.h"
 #include "atclient/constants.h"
@@ -73,7 +74,6 @@ void atclient_monitor_set_read_timeout(atclient *monitor_conn, const int timeout
 int atclient_monitor_start(atclient *monitor_conn, const char *regex) {
   int ret = 1;
 
-  size_t cmdsize = 0;
   char *cmd = NULL;
 
   const size_t regexlen = strlen(regex);
@@ -82,14 +82,12 @@ int atclient_monitor_start(atclient *monitor_conn, const char *regex) {
   // atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Building monitor command...\n");
 
   // 2. build cmd
-  cmdsize += 7 + 2; // monitor + \r\n
+  size_t cmdsize = 10; // monitor + \r\n\0
   if (regexlen > 0) {
     cmdsize += regexlen + 1; // $regex + ' '
   }
-  cmdsize += 1; // null terminator
   cmd = malloc(sizeof(char) * cmdsize);
   memset(cmd, 0, sizeof(char) * cmdsize);
-  const size_t cmdlen = cmdsize - 1;
 
   if (regexlen > 0) {
     snprintf(cmd, cmdsize, "monitor %.*s\r\n", (int)regexlen, regex);
@@ -97,17 +95,12 @@ int atclient_monitor_start(atclient *monitor_conn, const char *regex) {
     snprintf(cmd, cmdsize, "monitor\r\n");
   }
 
-  monitor_conn->async_read = true;
-
-  ret = atclient_connection_send(&monitor_conn->atserver_connection, (unsigned char *)cmd, cmdlen, NULL, 0, NULL);
+  ret = atclient_connection_write(&monitor_conn->atserver_connection, (unsigned char *)cmd, cmdsize - 1);
   // 3. send monitor cmd
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to send monitor command: %d\n", ret);
     goto exit;
   }
-  atlogger_fix_stdout_buffer(cmd, cmdsize);
-  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "\t%sSENT: %s\"%.*s\"%s\n", BBLK, HCYN, (int)strlen(cmd), cmd,
-               ATCLIENT_RESET);
 
   ret = 0;
   goto exit;

--- a/packages/atclient/src/socket_mbedtls.c
+++ b/packages/atclient/src/socket_mbedtls.c
@@ -322,7 +322,7 @@ int atclient_tls_socket_read_until_char(struct atclient_tls_socket *socket, unsi
         continue;   // continue if not found char yet
       }
       // handle non-happy path
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Socket read error: %d\n", ret);
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "Socket read error: -%#x\n", -ret);
       switch (ret) {
       case 0:                                 // connection is closed
       case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY: // connection is closed

--- a/packages/atlogger/include/atlogger/atlogger.h
+++ b/packages/atlogger/include/atlogger/atlogger.h
@@ -5,6 +5,7 @@ extern "C" {
 #endif
 
 #include <stddef.h>
+#include <stdio.h>
 
 enum atlogger_logging_level {
   ATLOGGER_LOGGING_LEVEL_NONE = 0,   // literally nothing, not verbose at all
@@ -17,6 +18,7 @@ enum atlogger_logging_level {
 
 enum atlogger_logging_level atlogger_get_logging_level();
 void atlogger_set_logging_level(const enum atlogger_logging_level level);
+void atlogger_set_logging_stream(FILE *);
 void atlogger_set_opts(int opts);
 void atlogger_log(const char *tag, const enum atlogger_logging_level level, const char *format, ...);
 void atlogger_fix_stdout_buffer(char *str, const size_t strlen);
@@ -27,6 +29,7 @@ typedef struct atlogger_ctx {
 } atlogger_ctx;
 
 atlogger_ctx *atlogger_get_instance();
+extern FILE *atlogger_logging_stream;
 
 #ifndef ATLOGGER_OVERRIDE_LOG_FUNCTION
 #include <stdio.h>
@@ -45,14 +48,14 @@ void _atlogger_log(const char *tag, enum atlogger_logging_level level, const cha
         char *prefix = malloc(sizeof(char) * PREFIX_BUFFER_LEN);                                                       \
         if (prefix != NULL) {                                                                                          \
           atlogger_get_prefix(LEVEL, prefix, PREFIX_BUFFER_LEN);                                                       \
-          printf("%.*s ", (int)strlen(prefix), prefix);                                                                \
-          printf("%s:%d - ", __FILE__, __LINE__);                                                                      \
-          printf("%.*s | ", (int)strlen(TAG), TAG);                                                                    \
+          fprintf(atlogger_logging_stream, "%.*s ", (int)strlen(prefix), prefix);                                      \
+          fprintf(atlogger_logging_stream, "%s:%d - ", __FILE__, __LINE__);                                            \
+          fprintf(atlogger_logging_stream, "%.*s | ", (int)strlen(TAG), TAG);                                          \
           free(prefix);                                                                                                \
         }                                                                                                              \
       }                                                                                                                \
     }                                                                                                                  \
-    printf(FORMAT __VA_OPT__(, ) __VA_ARGS__);                                                                         \
+    fprintf(atlogger_logging_stream, FORMAT __VA_OPT__(, ) __VA_ARGS__);                                               \
   }
 #else
 #define atlogger_log(TAG, LEVEL, FORMAT, ...) _atlogger_log(TAG, LEVEL, FORMAT __VA_OPT__(, ) __VA_ARGS__);

--- a/packages/atlogger/src/atlogger.c
+++ b/packages/atlogger/src/atlogger.c
@@ -21,13 +21,19 @@
 
 static atlogger_ctx ctx;
 static int is_ctx_initalized = 0;
+FILE *atlogger_logging_stream = NULL;
 
 atlogger_ctx *atlogger_get_instance() {
+  if (atlogger_logging_stream == NULL) {
+    atlogger_logging_stream = stdout;
+  }
   if (is_ctx_initalized == 0) {
     is_ctx_initalized = 1;
   }
   return &ctx;
 }
+
+void atlogger_set_logging_stream(FILE *stream) { atlogger_logging_stream = stream; }
 
 enum atlogger_logging_level atlogger_get_logging_level() {
   atlogger_ctx *ctx = atlogger_get_instance();
@@ -164,12 +170,12 @@ void _atlogger_log(const char *tag, enum atlogger_logging_level level, const cha
     char *prefix = malloc(sizeof(char) * PREFIX_BUFFER_LEN);
     if (prefix != NULL) {
       atlogger_get_prefix(level, prefix, PREFIX_BUFFER_LEN);
-      printf("%.*s ", (int)strlen(prefix), prefix);
-      printf("%.*s | ", (int)strlen(tag), tag);
+      fprintf(atlogger_logging_stream, "%.*s ", (int)strlen(prefix), prefix);
+      fprintf(atlogger_logging_stream, "%.*s | ", (int)strlen(tag), tag);
       free(prefix);
     }
   }
-  vprintf(format, args);
+  vfprintf(atlogger_logging_stream, format, args);
   va_end(args);
 }
 #endif


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Don't try to read when we send the monitor command
- Fix a bunch more discovered format specifier issues
- Add the ability to set the stream that atlogger writes to (for sshnpd)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: use atclient_connection_write for monitor start
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
