### PR TITLE
fix: atlogger and atauth issues

### DIFF
--- a/packages/atauth/src/enroll_response.c
+++ b/packages/atauth/src/enroll_response.c
@@ -11,6 +11,8 @@
 #define ENROLLMENT_ID "enrollmentId"
 #define STATUS "status"
 
+static int handle_parse_error_token(const char *buffer);
+
 #ifdef ATCOMMONS_JSON_PROVIDER_CJSON
 int parse_enrollment_response(const char *buffer, struct enroll_response *response) {
   char *enrollment_id = NULL;
@@ -18,8 +20,7 @@ int parse_enrollment_response(const char *buffer, struct enroll_response *respon
 
   int ret = strncmp(buffer, "data:", 5);
   if (ret != 0) {
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Did not receive data response from enroll request\n");
-    return 1;
+    return handle_parse_error_token(buffer);
   }
 
   cJSON *json = cJSON_Parse(buffer + 5);
@@ -67,6 +68,18 @@ int parse_enrollment_response(const char *buffer, struct enroll_response *respon
 #else
 #error no json implementation
 #endif
+
+// Should always return non-zero from this function
+static int handle_parse_error_token(const char *buffer) {
+  int ret = strncmp(buffer, "error:", 6);
+  if (ret != 0) {
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unexpected error, please contact support\n");
+    return 2;
+  }
+
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Server responded with error:\n%s\n", buffer + 6);
+  return 1;
+}
 
 void free_enroll_response(struct enroll_response *res) {
   if (res->enrollment_id != NULL) {

--- a/packages/atauth/src/wait_for_enrollment.c
+++ b/packages/atauth/src/wait_for_enrollment.c
@@ -12,8 +12,13 @@ int wait_for_enrollment(atclient *ctx, const char *atsign, const atclient_atkeys
   int ret = 1;
   char *err_msg;
 
-  while (true) {
+  int max_tries = 50;
+  for (int i = 0; i < max_tries; i++) {
+    // Silence logging during pkam auth to suppress error messages which we expect to occur until enrollment is approved
+    enum atlogger_logging_level logging_level = atlogger_get_logging_level();
+    atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_NONE);
     ret = atclient_pkam_authenticate(ctx, atsign, atkeys, (atclient_authenticate_options *)opts, &err_msg);
+    atlogger_set_logging_level(logging_level);
 
     if (ret == 0) {
       atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "enrollment approved | APKAM auth success\n");
@@ -25,12 +30,30 @@ int wait_for_enrollment(atclient *ctx, const char *atsign, const atclient_atkeys
       ret = 1;
       return ret;
     }
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN, "enrollment not approved yet | Retrying in %d secs\n",
-                 ATAUTH_DEFAULT_APKAM_RETRY_INTERVAL);
-    sleep(ATAUTH_DEFAULT_APKAM_RETRY_INTERVAL);
+
+    if (err_msg != NULL && is_enrollment_pending(err_msg)) {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN, "enrollment not approved yet | Retrying in %d secs\n",
+                   ATAUTH_DEFAULT_APKAM_RETRY_INTERVAL);
+      sleep(ATAUTH_DEFAULT_APKAM_RETRY_INTERVAL);
+      continue;
+    }
+
+    if (err_msg != NULL) {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Unexpected error: \n%s\n", err_msg);
+    } else {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "An unknown error occurred, please contact support.\n");
+    }
+    return 2;
   }
+
+  atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Enrollment not completed within %d attempts, exiting\n", max_tries);
+  return 3;
 }
 
 int is_enrollment_denied(const char *err_msg) {
   return strncmp(err_msg, ATAUTH_ENROLLMENT_DENIED_ERR_CODE, strlen(ATAUTH_ENROLLMENT_DENIED_ERR_CODE)) == 0;
+}
+
+int is_enrollment_pending(const char *err_msg) {
+  return strncmp(err_msg, ATAUTH_ENROLLMENT_PENDING_ERR_CODE, strlen(ATAUTH_ENROLLMENT_PENDING_ERR_CODE)) == 0;
 }

--- a/packages/atauth/src/wait_for_enrollment.h
+++ b/packages/atauth/src/wait_for_enrollment.h
@@ -9,6 +9,7 @@ int wait_for_enrollment(atclient *ctx, const char *atsign, const atclient_atkeys
                         const atclient_authenticate_options *opts);
 
 int is_enrollment_denied(const char *err_msg);
+int is_enrollment_pending(const char *err_msg);
 
 #ifdef __cplusplus
 }

--- a/packages/atlogger/include/atlogger/atlogger.h
+++ b/packages/atlogger/include/atlogger/atlogger.h
@@ -40,7 +40,7 @@ void atlogger_get_prefix(enum atlogger_logging_level logging_level, char *prefix
 void _atlogger_log(const char *tag, enum atlogger_logging_level level, const char *format, ...);
 
 #if defined(ATSDK_DEBUG_MODE)
-#define atlogger_log(TAG, LEVEL, FORMAT, ...)                                                                          \
+#define atlogger_log(TAG, LEVEL, ...)                                                                                  \
   {                                                                                                                    \
     atlogger_ctx *ctx = atlogger_get_instance();                                                                       \
     if (LEVEL <= ctx->level) {                                                                                         \
@@ -55,10 +55,10 @@ void _atlogger_log(const char *tag, enum atlogger_logging_level level, const cha
         }                                                                                                              \
       }                                                                                                                \
     }                                                                                                                  \
-    fprintf(atlogger_logging_stream, FORMAT __VA_OPT__(, ) __VA_ARGS__);                                               \
+    fprintf(atlogger_logging_stream, __VA_ARGS__);                                                                     \
   }
 #else
-#define atlogger_log(TAG, LEVEL, FORMAT, ...) _atlogger_log(TAG, LEVEL, FORMAT __VA_OPT__(, ) __VA_ARGS__);
+#define atlogger_log(TAG, LEVEL, ...) _atlogger_log(TAG, LEVEL, __VA_ARGS__);
 #endif
 #endif
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes #570 
closes #548 
closes #549 

**- What I did**

atlogger:


- __VA_OPT__ not supported in c99 by standard (it is in some compilers, but it's not officially supported in c99, started at c++ 20).
- collapsed the format string into __VA_ARGS__ to remove the need for __VA_OPT__

atauth:

- Suppressed error message from failed pkam auth while waiting for approval
- Provided the server message code for duplicate enrollments (and other errors from enroll verb being sent to the server)

**- How I did it**

**- How to verify it**

Note: I did not test

**- Description for the changelog**
fix: atlogger and atauth issues
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
