### PR TITLE
fix: decryption notification with legacy iv

### DIFF
--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -370,7 +370,7 @@ int decrypt_notification(atclient *atclient, atclient_atnotification *notificati
   }
 
   // 2. get iv
-  if (atclient_atnotification_is_iv_nonce_initialized(notification) &&
+  if (atclient_atnotification_is_iv_nonce_initialized(notification) && notification->iv_nonce != NULL &&
       !atclient_string_utils_starts_with(notification->iv_nonce, "null")) {
     size_t ivlen;
     ret = atchops_base64_decode(notification->iv_nonce, strlen(notification->iv_nonce), iv, ATCHOPS_IV_BUFFER_SIZE,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When notification in atnotification.c is decrypted it is NULL not the string "null", so we need to check for this. I've left the string "null" check in place just in case.

fixes the second segfault in https://github.com/atsign-foundation/noports/issues/1767

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: decryption notification with legacy iv
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
