### PR TITLE
feat(notifications): set pointer of decrypted_value to value when is_encrypted is false.

### DIFF
--- a/.github/workflows/build_source_tests.yaml
+++ b/.github/workflows/build_source_tests.yaml
@@ -23,8 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Show compiler version
-        run: ${{ matrix.cc }} --version
+      - name: Show tooling versions
+        run: |
+          echo ${{ matrix.cc }} version
+          ${{ matrix.cc }} --version
+          echo cmake version
+          cmake --version
 
       - name: Install atsdk
         run: cmake -S . -B build -DCMAKE_C_COMPILER="${{ matrix.cc }}" \

--- a/cmake/find_cjson.cmake
+++ b/cmake/find_cjson.cmake
@@ -17,9 +17,10 @@ if(NOT TARGET cjson)
   else()
     FetchContent_Declare(
       cjson
-      URL https://github.com/DaveGamble/cJSON/archive/refs/tags/v1.7.17.zip
+      URL https://github.com/DaveGamble/cJSON/archive/refs/tags/v1.7.18.zip
       URL_HASH
-        SHA256=51f3b07aece8d1786e74b951fd92556506586cb36670741b6bfb79bf5d484216 # hash for v1.7.17 .zip release source code
+        # SHA256=51f3b07aece8d1786e74b951fd92556506586cb36670741b6bfb79bf5d484216 # hash for v1.7.17 .zip release source code
+        SHA256=cc6d93cc3b659037c34193ecc7be5a874a18c2ac67b24efe82db6a759b486b5d # hash for v1.7.18 .zip release source code
       # FIND_PACKAGE_ARGS 1.7.17 QUIET CONFIG
     )
   endif()

--- a/packages/atclient/src/atnotification.c
+++ b/packages/atclient/src/atnotification.c
@@ -64,6 +64,10 @@ void atclient_atnotification_free(atclient_atnotification *notification) {
   if (atclient_atnotification_is_message_type_initialized(notification)) {
     atclient_atnotification_unset_message_type(notification);
   }
+  // decrypted_value depends on status of is_encrypted so it must be handled first
+  if (atclient_atnotification_is_decrypted_value_initialized(notification)) {
+    atclient_atnotification_unset_decrypted_value(notification);
+  }
   if (atclient_atnotification_is_is_encrypted_initialized(notification)) {
     atclient_atnotification_unset_is_encrypted(notification);
   }
@@ -81,9 +85,6 @@ void atclient_atnotification_free(atclient_atnotification *notification) {
   }
   if (atclient_atnotification_is_ske_enc_algo_initialized(notification)) {
     atclient_atnotification_unset_ske_enc_algo(notification);
-  }
-  if (atclient_atnotification_is_decrypted_value_initialized(notification)) {
-    atclient_atnotification_unset_decrypted_value(notification);
   }
 }
 
@@ -955,7 +956,9 @@ void atclient_atnotification_unset_decrypted_value(atclient_atnotification *noti
   /*
    * 2. Unset the decrypted_value, if necessary
    */
-  if (atclient_atnotification_is_decrypted_value_initialized(notification)) {
+  bool should_free = atclient_atnotification_is_decrypted_value_initialized(notification) &&
+                     atclient_atnotification_is_is_encrypted_initialized(notification) && notification->is_encrypted;
+  if (should_free) {
     free(notification->decrypted_value);
   }
   notification->decrypted_value = NULL;

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -164,10 +164,6 @@ int atclient_monitor_read(atclient *monitor_conn, atclient *atclient, atclient_m
     return 0;
   }
 
-  if (message->notification->is_encrypted == false) {
-    return 0;
-  }
-
   // Can only be an encrypted success notification at this point, time to decrypt
   if (hooks != NULL && hooks->pre_decrypt_notification != NULL) {
     ret = hooks->pre_decrypt_notification();
@@ -350,11 +346,10 @@ int decrypt_notification(atclient *atclient, atclient_atnotification *notificati
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN,
                  "is_encrypted field was found to be uninitialized, we don't know for sure if we're decrypting "
                  "something that's even encrypted.\n");
-  } else {
-    if (!notification->is_encrypted) {
-      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_WARN,
-                   "is_encrypted is false, we may be trying to decrypt some unencrypted plain text.\n");
-    }
+  } else if (!notification->is_encrypted) {
+    notification->decrypted_value = notification->value;
+    ret = 0;
+    goto exit;
   }
 
   // 1c. get atsign with @

--- a/tests/functional_tests/tests/test_atclient_monitor.c
+++ b/tests/functional_tests/tests/test_atclient_monitor.c
@@ -532,7 +532,7 @@ static int send_non_encrypted_notification(atclient *from_client, char *value, c
   atclient_atkey atkey;
   atclient_atkey_init(&atkey);
 
-  if((ret = atclient_atkey_create_shared_key(&atkey, key, FROM_ATSIGN, TO_ATSIGN, ns)) != 0) {
+  if ((ret = atclient_atkey_create_shared_key(&atkey, key, FROM_ATSIGN, TO_ATSIGN, ns)) != 0) {
     atlogger_log(TAG " send_non_encrypted_notification", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to create shared key\n");
     atclient_atkey_free(&atkey);
     return 1;
@@ -543,8 +543,7 @@ static int send_non_encrypted_notification(atclient *from_client, char *value, c
 
   ret = atclient_notify_params_set_atkey(&notify, &atkey);
   if (ret != 0) {
-    atlogger_log(TAG " send_non_encrypted_notification", ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "Failed to set notify atkey\n");
+    atlogger_log(TAG " send_non_encrypted_notification", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set notify atkey\n");
     atclient_notify_params_free(&notify);
     atclient_atkey_free(&atkey);
     return 1;
@@ -561,8 +560,7 @@ static int send_non_encrypted_notification(atclient *from_client, char *value, c
 
   ret = atclient_notify_params_set_value(&notify, value);
   if (ret != 0) {
-    atlogger_log(TAG " send_non_encrypted_notification", ATLOGGER_LOGGING_LEVEL_ERROR,
-                 "Failed to set notify value\n");
+    atlogger_log(TAG " send_non_encrypted_notification", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to set notify value\n");
     atclient_notify_params_free(&notify);
 
     atclient_atkey_free(&atkey);
@@ -589,13 +587,14 @@ static int send_non_encrypted_notification(atclient *from_client, char *value, c
   return 0;
 }
 
-static int test_2b_receive_non_encrypted_notifications(atclient *from_client, atclient *to_client, atclient *worker_client) {
+static int test_2b_receive_non_encrypted_notifications(atclient *from_client, atclient *to_client,
+                                                       atclient *worker_client) {
   int ret = 1;
 
   atlogger_log(TAG " 2b", ATLOGGER_LOGGING_LEVEL_DEBUG, "Starting test 2b\n");
 
-  const char *key = "non-encrypted-key";
-  const char *value = "non-encrypted-value";
+  char *key = "non-encrypted-key";
+  char *value = "non-encrypted-value";
   const size_t value_len = strlen(value);
 
   // 1. generate a unique namespace
@@ -612,7 +611,7 @@ static int test_2b_receive_non_encrypted_notifications(atclient *from_client, at
     atlogger_log(TAG " 2b", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to generate uuid for namespace\n");
     return 1;
   }
-  namespace[namespace_size-1] = '\0';
+  namespace[namespace_size - 1] = '\0';
 
   ret = atclient_monitor_start(to_client, namespace);
   if (ret != 0) {
@@ -630,7 +629,8 @@ static int test_2b_receive_non_encrypted_notifications(atclient *from_client, at
     return 1;
   }
 
-  atlogger_log(TAG " 2b", ATLOGGER_LOGGING_LEVEL_DEBUG, "Sent non-encrypted notification with id %s\n", expected_notification_id);
+  atlogger_log(TAG " 2b", ATLOGGER_LOGGING_LEVEL_DEBUG, "Sent non-encrypted notification with id %s\n",
+               expected_notification_id);
 
   atclient_monitor_message message;
   while (ret == 0) {
@@ -645,12 +645,11 @@ static int test_2b_receive_non_encrypted_notifications(atclient *from_client, at
         free(expected_notification_id);
         return 1;
       }
-      
+
       size_t actual_len = strlen(message.notification->value);
       if (actual_len != value_len) {
         atlogger_log(TAG " 2b", ATLOGGER_LOGGING_LEVEL_ERROR,
-                     "Monitor value has unexpected length (expected: %zu, actual: %zu)\n",
-                     value_len, actual_len);
+                     "Monitor value has unexpected length (expected: %zu, actual: %zu)\n", value_len, actual_len);
         atclient_monitor_message_free(&message);
         free(expected_notification_id);
         return 1;
@@ -665,7 +664,28 @@ static int test_2b_receive_non_encrypted_notifications(atclient *from_client, at
         free(expected_notification_id);
         return 1;
       }
-      atlogger_log(TAG " 2b", ATLOGGER_LOGGING_LEVEL_DEBUG, "Received non-encrypted notification with id \"%s\" with expected value \"%s\"\n", expected_notification_id, value);
+      actual_len = strlen(message.notification->decrypted_value);
+      if (actual_len != value_len) {
+        atlogger_log(TAG " 2b", ATLOGGER_LOGGING_LEVEL_ERROR,
+                     "Monitor decrypted value has unexpected length (expected: %zu, actual: %zu)\n", value_len,
+                     actual_len);
+        atclient_monitor_message_free(&message);
+        free(expected_notification_id);
+        return 1;
+      }
+      if (strncmp(message.notification->decrypted_value, value, actual_len) != 0) {
+        atlogger_log(TAG " 2b", ATLOGGER_LOGGING_LEVEL_ERROR,
+                     "Monitor decrypted value has unexpected value\n\t\t"
+                     "expected: '%s'\n\t\t"
+                     "actual: '%s'\n",
+                     "non-encrypted-value", message.notification->decrypted_value);
+        atclient_monitor_message_free(&message);
+        free(expected_notification_id);
+        return 1;
+      }
+      atlogger_log(TAG " 2b", ATLOGGER_LOGGING_LEVEL_DEBUG,
+                   "Received non-encrypted notification with id \"%s\" with expected value \"%s\"\n",
+                   expected_notification_id, value);
       atclient_monitor_message_free(&message);
       break;
     }


### PR DESCRIPTION
closes #559 

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
### Some Context

notification contains:

```c
bool is_encrypted;
char* value; // the buffer of value directly from the notification payload
char* decrypted_value; // the buffer of the decrypted value
// ... more irrelevant things
```

**- What I did**

- Previously, decrypted value is NULL if the notification was not encrypted. This change makes decrypted_value point to the same buffer as value when we parse notifications.
- Upgraded cJSON to 1.7.18, to deal with cmake deprecations.

**- How I did it**

- Made it so that decrypt_notification is called for non-encrypted notifications
- Only free decrypted_value in a notification if is_encrypted is true, other wise we get a double free since value and decrypted_value point to the same memory.
- Added code to point decrypted_value at value when is_encrypted is false.
- During cleanup ensure that decrypted_value is handled before is_encrypted, since there is a dependency on it (comment added to code to avoid regressions)

**- How to verify it**

Tests should pass.

There was already a test for non-encrypted notifications, so I extended it to check both value and decrypted_value for the expected value.

**- Description for the changelog**
feat(notifications): set pointer of decrypted_value to value when is_encrypted is false.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
