### PR TITLE
fix(ci): pin cmake to 3.31.6

### DIFF
--- a/.github/workflows/build_source_tests.yaml
+++ b/.github/workflows/build_source_tests.yaml
@@ -23,6 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+        # Pin cmake to <4.0.0
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        with:
+          cmake-version: "3.31.6"
+
       - name: Show tooling versions
         run: |
           echo ${{ matrix.cc }} version
@@ -62,5 +68,10 @@ jobs:
         preset: ["package-static", "package-source"]
     runs-on: "ubuntu-latest"
     steps:
+      # Pin cmake to <4.0.0
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        with:
+          cmake-version: "3.31.6"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: cmake --workflow --preset ${{ matrix.preset }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,14 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "trunk" ]
+    branches: ["trunk"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "trunk" ]
+    branches: ["trunk"]
   schedule:
-    - cron: '25 19 * * 1'
+    - cron: "25 19 * * 1"
 
-permissions:  # added using https://github.com/step-security/secure-repo
+permissions: # added using https://github.com/step-security/secure-repo
   contents: read
 
 jobs:
@@ -41,46 +41,51 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'c-cpp' ]
+        language: ["c-cpp"]
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # Pin cmake to <4.0.0
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        with:
+          cmake-version: "3.31.6"
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    # Manual build steps from build_source_tests
-    - name: Install atsdk
-      run: |
-        cmake -S . -B build
-        sudo cmake --build build --target install
+      # Manual build steps from build_source_tests
+      - name: Install atsdk
+        run: |
+          cmake -S . -B build
+          sudo cmake --build build --target install
 
-    - name: Build sample_cmake_project
-      working-directory: examples/desktop/sample_cmake_project
-      run: |
-        cmake -S . -B build
-        cmake --build build
+      - name: Build sample_cmake_project
+        working-directory: examples/desktop/sample_cmake_project
+        run: |
+          cmake -S . -B build
+          cmake --build build
 
-    - name: Run sample_cmake_project executable
-      working-directory: examples/desktop/sample_cmake_project
-      run: |
-        ./build/main
+      - name: Run sample_cmake_project executable
+        working-directory: examples/desktop/sample_cmake_project
+        run: |
+          ./build/main
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@1b549b9259bda1cb5ddde3b41741a82a2d15a841 # v3.28.13
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,11 @@ jobs:
   unit-tests:
     runs-on: "ubuntu-latest"
     steps:
+      # Pin cmake to <4.0.0
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        with:
+          cmake-version: "3.31.6"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install valgrind
@@ -75,6 +80,12 @@ jobs:
           sleep 1
           ./pkam_virtualenv.sh
 
+      # Pin cmake to <4.0.0
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        with:
+          cmake-version: "3.31.6"
+
       - name: Build and Run Check Docker Readiness
         working-directory: tests/functional_tests/check_docker_readiness
         run: |
@@ -115,6 +126,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+        # Pin cmake to <4.0.0
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        with:
+          cmake-version: "3.31.6"
       - name: Install atSDK
         run: |
           cmake -S . -B build


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Some GHA runners have silently upgraded themselves to cmake 4.0.0 which breaks cJSON's build.
Using a separate action to setup cmake instead of the system one 

see: https://github.com/actions/runner-images/issues/11926

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix(ci): pin cmake to 3.31.6
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
