### PR TITLE
fix: openwrt upstream build

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -2,7 +2,17 @@ CompileFlags:
   # Use gcc in development for better diagnostics
   # & Ensure that compilation doesn't fail due to warnings
   Compiler: gcc
-  Add: [-Wno-error, -xc, -std=c99, -DATSDK_DEBUG_MODE]
+  Add:
+    - -xc
+    - -std=c99
+    - -DATSDK_DEBUG_MODE
+    - -Wno-error
+    - -Wall
+    - -Wextra
+    - -Werror-implicit-function-declaration
+    - -Wtype-limits
+    - -Wimplicit-fallthrough
+    - -Wmissing-field-initializers
 
 Index:
   # Enable background indexing for better symbol information

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,27 @@ if(NOT DEFINED ATSDK_AS_SUBPROJECT)
 endif()
 message(STATUS "[ATSDK] ATSDK_AS_SUBPROJECT: ${ATSDK_AS_SUBPROJECT}")
 
+# Shared compile options between clang & gcc
+add_compile_options("-Wall")
+add_compile_options("-Wextra")
+add_compile_options("-Werror-implicit-function-declaration")
+add_compile_options("-Wtype-limits")
+add_compile_options("-Wimplicit-fallthrough")
+add_compile_options("-Wmissing-field-initializers")
+# This enforces strictly using ISO standard (definitely overkill, hence pedantic)
+# enable this to check our deviations from the standard
+# add_compile_options("-pedantic-errors") 
+
+# Custom compiler-based compiler options
+if(CMAKE_C_COMPILER MATCHES ".*clang.*")
+  message(STATUS "[ATSDK] DETECTED COMPILER: clang")
+  if(CMAKE_BUILD_TYPE STREQUAL Release)
+    add_compile_options("-Wno-calloc-transposed-args")
+  endif()
+else() # Assume gcc as the default
+  message(STATUS "[ATSDK] DETECTED COMPILER: gcc")
+endif()
+
 # install each package
 message(STATUS "Building atlogger")
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/packages/atlogger)

--- a/justfile
+++ b/justfile
@@ -16,12 +16,12 @@ unit_dir := quote(justfile_directory() / "build/unit-") + postfix
 func_dir := quote(justfile_directory() / "build/func-") + postfix
 memcheck_dir := quote(justfile_directory() / "build/memcheck-") + postfix
 
-debug_c_flags := "-std=c99 -DATSDK_DEBUG_MODE=1"
-release_c_flags := "-std=c99 -Wno-error"
+debug_c_flags := "-std=c99 -Wno-error -DATSDK_DEBUG_MODE=1"
+release_c_flags := "-std=c99 -Werror"
 
 # SETUP COMMANDS
 
-setup:  build-test-all
+setup: build-test-all
   [ -f "$PWD/compile_commands.json" ] && rm $PWD/compile_commands.json || true
   ln -s {{test_dir}}/compile_commands.json $PWD/
   [ -f "$PWD/tests/compile_commands.json" ] && rm $PWD/tests/compile_commands.json || true

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ unit_dir := quote(justfile_directory() / "build/unit-") + postfix
 func_dir := quote(justfile_directory() / "build/func-") + postfix
 memcheck_dir := quote(justfile_directory() / "build/memcheck-") + postfix
 
-debug_c_flags := "-std=c99 -Wall -Wextra -Werror-implicit-function-declaration -DATSDK_DEBUG_MODE=1"
+debug_c_flags := "-std=c99 -DATSDK_DEBUG_MODE=1"
 release_c_flags := "-std=c99 -Wno-error"
 
 # SETUP COMMANDS

--- a/packages/atclient/src/connection.c
+++ b/packages/atclient/src/connection.c
@@ -841,12 +841,6 @@ static int atclient_connection_set_port(atclient_connection *ctx, const uint16_t
     return ret;
   }
 
-  if (port < 0) {
-    ret = 1;
-    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "port is less than 0\n");
-    return ret;
-  }
-
   /*
    * 2. Set the port
    */

--- a/packages/atclient/src/monitor.c
+++ b/packages/atclient/src/monitor.c
@@ -1,6 +1,5 @@
 #include "atclient/monitor.h"
 #include "atclient/atclient.h"
-#include "atclient/atclient_utils.h"
 #include "atclient/atnotification.h"
 #include "atclient/connection.h"
 #include "atclient/constants.h"
@@ -39,6 +38,7 @@ void atclient_monitor_message_free(atclient_monitor_message *message) {
   case ATCLIENT_MONITOR_ERROR_DECRYPT_NOTIFICATION:
     atclient_atnotification_free(message->notification);
     free(message->notification);
+    __attribute__((fallthrough));
   default:
     if (message->atserver_message != NULL) {
       atserver_message_free((struct atserver_message *)message->atserver_message);

--- a/tests/functional_tests/lib/src/helpers.c
+++ b/tests/functional_tests/lib/src/helpers.c
@@ -1,5 +1,4 @@
 #include "functional_tests/helpers.h"
-#include "functional_tests/config.h"
 #include <atclient/atclient.h>
 #include <atclient/atclient_utils.h>
 #include <atclient/constants.h>
@@ -103,7 +102,6 @@ int functional_tests_publickey_exists(atclient *atclient, const char *key, const
   const short atkeystrsize = 128;
   char atkeystr[atkeystrsize];
   memset(atkeystr, 0, sizeof(char) * atkeystrsize);
-  size_t atkeystrlen = 0;
 
   const short commandsize = 256;
   char command[commandsize];
@@ -161,7 +159,6 @@ int functional_tests_selfkey_exists(atclient *atclient, const char *key, const c
   const short atkeystrsize = 128;
   char atkeystr[atkeystrsize];
   memset(atkeystr, 0, sizeof(char) * atkeystrsize);
-  size_t atkeystrlen = 0;
 
   const short commandsize = 256;
   char command[commandsize];
@@ -219,7 +216,6 @@ int functional_tests_sharedkey_exists(atclient *atclient, const char *key, const
   const short atkeystrsize = 128;
   char atkeystr[atkeystrsize];
   memset(atkeystr, 0, sizeof(char) * atkeystrsize);
-  size_t atkeystrlen = 0;
 
   const short commandsize = 256;
   char command[commandsize];

--- a/tests/functional_tests/tests/test_atclient_connection.c
+++ b/tests/functional_tests/tests/test_atclient_connection.c
@@ -28,7 +28,7 @@ static int test_15_send_should_fail(atclient_connection *conn);
 static int test_16_is_connected_should_be_false(atclient_connection *conn);
 static int test_17_disconnect(atclient_connection *conn);
 
-int main(int argc, char *argv[]) {
+int main() {
   int ret = 1;
 
   atlogger_set_logging_level(ATLOGGER_LOGGING_LEVEL_DEBUG);

--- a/tests/functional_tests/tests/test_atclient_get_atkeys.c
+++ b/tests/functional_tests/tests/test_atclient_get_atkeys.c
@@ -10,10 +10,10 @@
 
 #define SCAN_REGEX ".*"
 
-static int test_1_atclient_get_atkeys(atclient *ctx, const char *scan_regex, const bool showhidden);
-static int test_2_atclient_get_atkeys_null(atclient *ctx, const char *scan_regex, const bool showhidden);
-static int test_3_atclient_get_atkeys_null_ctx(const char *scan_regex, const bool showhidden);
-static int test_4_atclient_get_atkeys_null_regex(atclient *ctx, const char *scan_regex, const bool showhidden);
+static int test_1_atclient_get_atkeys(atclient *ctx);
+static int test_2_atclient_get_atkeys_null(atclient *ctx);
+static int test_3_atclient_get_atkeys_null_ctx(void);
+static int test_4_atclient_get_atkeys_null_regex(atclient *ctx);
 
 int main() {
   int ret = 1;
@@ -36,22 +36,22 @@ int main() {
     goto exit;
   }
 
-  if ((ret = test_1_atclient_get_atkeys(&atclient1, SCAN_REGEX, false)) != 0) {
+  if ((ret = test_1_atclient_get_atkeys(&atclient1)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_1_atclient_get_atkeys failed: %d\n", ret);
     goto exit;
   }
 
-  if ((ret = test_2_atclient_get_atkeys_null(&atclient1, SCAN_REGEX, false)) != 0) {
+  if ((ret = test_2_atclient_get_atkeys_null(&atclient1)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_2_atclient_get_atkeys_null failed: %d", ret);
     goto exit;
   }
 
-  if ((ret = test_3_atclient_get_atkeys_null_ctx(SCAN_REGEX, false)) != 0) {
+  if ((ret = test_3_atclient_get_atkeys_null_ctx()) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_3_atclient_get_atkeys_null_ctx failed: %d", ret);
     goto exit;
   }
 
-  if ((ret = test_4_atclient_get_atkeys_null_regex(&atclient1, SCAN_REGEX, false)) != 0) {
+  if ((ret = test_4_atclient_get_atkeys_null_regex(&atclient1)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "test_4_atclient_get_atkeys_null_regex failed: %d", ret);
     goto exit;
   }
@@ -66,7 +66,7 @@ exit: {
 }
 }
 
-static int test_1_atclient_get_atkeys(atclient *ctx, const char *scan_regex, const bool showhidden) {
+static int test_1_atclient_get_atkeys(atclient *ctx) {
   int ret = 1;
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "test_1_atclient_get_atkeys\n");
@@ -98,7 +98,7 @@ exit: {
 }
 }
 
-static int test_2_atclient_get_atkeys_null(atclient *ctx, const char *scan_regex, const bool showhidden) {
+static int test_2_atclient_get_atkeys_null(atclient *ctx) {
   int ret = 1;
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "test_2_atclient_get_atkeys_null\n");
@@ -119,7 +119,7 @@ exit: {
 }
 }
 
-static int test_3_atclient_get_atkeys_null_ctx(const char *scan_regex, const bool showhidden) {
+static int test_3_atclient_get_atkeys_null_ctx() {
   int ret = 1;
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "test_3_atclient_get_atkeys_null_ctx\n");
@@ -143,7 +143,7 @@ exit: {
 }
 }
 
-static int test_4_atclient_get_atkeys_null_regex(atclient *ctx, const char *scan_regex, const bool showhidden) {
+static int test_4_atclient_get_atkeys_null_regex(atclient *ctx) {
   int ret = 1;
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_DEBUG, "test_4_atclient_get_atkeys_null_regex\n");

--- a/tests/functional_tests/tests/test_atclient_notify.c
+++ b/tests/functional_tests/tests/test_atclient_notify.c
@@ -101,8 +101,8 @@
 
 #define ATNOTIFICATION_OPERATION ATCLIENT_NOTIFY_OPERATION_UPDATE
 
-static int test_1_notify(atclient *atclient, char *notification_id);
-static int test_2_notify_long_text(atclient *atclient, char *notification_id);
+static int test_1_notify(atclient *atclient);
+static int test_2_notify_long_text(atclient *atclient);
 
 int main() {
   int ret = 1;
@@ -128,12 +128,12 @@ int main() {
     goto exit;
   }
 
-  if ((ret = test_1_notify(&atclient1, notification_id)) != 0) {
+  if ((ret = test_1_notify(&atclient1)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to test notify: %d\n", ret);
     goto exit;
   }
 
-  if ((ret = test_2_notify_long_text(&atclient1, notification_id)) != 0) {
+  if ((ret = test_2_notify_long_text(&atclient1)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to test notify long text: %d\n", ret);
     goto exit;
   }
@@ -148,7 +148,7 @@ exit: {
 }
 }
 
-static int test_1_notify(atclient *atclient, char *notification_id) {
+static int test_1_notify(atclient *atclient) {
   int ret = 1;
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_1_notify Begin\n");
@@ -200,7 +200,7 @@ exit: {
 }
 }
 
-static int test_2_notify_long_text(atclient *atclient, char *notification_id) {
+static int test_2_notify_long_text(atclient *atclient) {
   int ret = 1;
 
   atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_INFO, "test_2_notify_long_text Begin\n");

--- a/tests/functional_tests/tests/test_atclient_publickey.c
+++ b/tests/functional_tests/tests/test_atclient_publickey.c
@@ -385,7 +385,6 @@ static int tear_down(atclient *atclient) {
   const size_t atkeystrsize = 128;
   char atkeystr[atkeystrsize];
   memset(atkeystr, 0, sizeof(char) * atkeystrsize);
-  size_t atkeystrlen = 0;
 
   const size_t recvsize = 256;
   char recv[recvsize];


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added additional warning checks:
  - `-Wtype-limits`
  - `-Wimplicit-fallthrough`
  - `-Wmissing-field-initializers`
- Moved warning compiler options from justfile / CMakePresets to CMakeLists.txt / .clangd
- Fixed any newly revealed warnings (they align with what we saw in openwrt build)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
fix: openwrt upstream build
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
