### PR TITLE
feat: flag to link external deps dynamically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ set(TARGET_ESPIDF FALSE CACHE BOOL "Build for the espidf platform")
 
 option(ATSDK_MEMCHECK "Enable memcheck configuration" OFF)
 option(ATSDK_BUILD_TESTS "Build tests for atsdk ON | \"unit\" | \"func\" " OFF)
+option(
+  ATSDK_USE_SHARED_LIBS
+  "Link to shared libs for external dependencies"
+  OFF
+)
 
 # to avoid caching issues
 if(ATSDK_BUILD_TESTS STREQUAL "func")
@@ -34,7 +39,7 @@ include(GNUInstallDirs)
 
 project(
   atsdk
-  VERSION 0.4.0
+  VERSION 0.4.1
   DESCRIPTION "Atsign's atSDK library"
   HOMEPAGE_URL https://github.com/atsign-foundation/at_c
   LANGUAGES C
@@ -96,21 +101,33 @@ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/packages/atauth)
 
 if(NOT ESP_PLATFORM)
   # install dependencies
-  set(
-    ATSDK_TARGETS
-    mbedtls
-    mbedx509
-    mbedcrypto
-    everest
-    p256m
-    atchops
-    cjson
-    atlogger
-    atclient
-    atcommons
-    argparse
-    atauth
-  )
+  if(ATSDK_USE_SHARED_LIBS)
+    set(
+      ATSDK_TARGETS
+      atchops
+      atlogger
+      atclient
+      atcommons
+      argparse
+      atauth
+    )
+  else()
+    set(
+      ATSDK_TARGETS
+      mbedtls
+      mbedx509
+      mbedcrypto
+      everest
+      p256m
+      atchops
+      cjson
+      atlogger
+      atclient
+      atcommons
+      argparse
+      atauth
+    )
+  endif()
 
   install(
     TARGETS ${ATSDK_TARGETS}

--- a/cmake/find_cjson.cmake
+++ b/cmake/find_cjson.cmake
@@ -2,11 +2,15 @@ option(ATSDK_CJSON_PATH "Local cJSON path" OFF)
 option(ENABLE_CJSON_TEST "Test cJSON" OFF)
 set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE OPT_IN) # only try find_package if FIND_PACKAGE_ARGS is set
 
+if(ATSDK_USE_SHARED_LIBS)
+  return()
+endif()
+
 if(NOT TARGET cjson)
   # This installs the target cjson
   # Configurable variables
 
-  message(STATUS "[cJSON] fetching package...")
+  message(STATUS "[cJSON] resolving package...")
   include(FetchContent)
   if(ATSDK_CJSON_PATH)
     FetchContent_Declare(

--- a/cmake/find_mbedtls.cmake
+++ b/cmake/find_mbedtls.cmake
@@ -4,9 +4,13 @@ option(ENABLE_PROGRAMS "Build mbedtls programs" OFF)
 set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE OPT_IN) # only try find_package if FIND_PACKAGE_ARGS is set
 set(CMAKE_POLICY_DEFAULT_CMP0077 OLD)
 
+if(ATSDK_USE_SHARED_LIBS)
+  return()
+endif()
+
 if(NOT TARGET mbedcrypto)
   # This installs the targets mbedtls mbedx509 mbedcrypto everest p256m
-  message(STATUS "[MbedTLS] fetching package...")
+  message(STATUS "[MbedTLS] resolving package...")
   include(FetchContent)
   if(ATSDK_MBEDTLS_PATH)
     FetchContent_Declare(
@@ -24,9 +28,8 @@ if(NOT TARGET mbedcrypto)
       # FIND_PACKAGE_ARGS QUIET CONFIG
     )
   endif()
-
-  FetchContent_MakeAvailable(MbedTLS)
-  install(
-    TARGETS mbedtls mbedx509 mbedcrypto everest p256m
-  )
+    FetchContent_MakeAvailable(MbedTLS)
+    install(
+      TARGETS mbedtls mbedx509 mbedcrypto everest p256m
+    )
 endif()

--- a/cmake/package_util.cmake
+++ b/cmake/package_util.cmake
@@ -1,4 +1,14 @@
 set(ATSDK_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR})
+if(ATSDK_USE_SHARED_LIBS)
+  # predetermine include dirs for shared libs if we will be linking to them
+  find_path(mbedtls_INCLUDE_DIR NAMES mbedtls/x509.h REQUIRED)
+  # find_path(p256m_INCLUDE_DIR NAMES mbedtls/x509.h)
+  find_path(everest_INCLUDE_DIR NAMES everest/everest.h REQUIRED)
+  find_path(cjson_INCLUDE_DIR NAMES cjson/cJSON.h REQUIRED)
+endif()
+
+set(mbedtls_LIB_NAMES libmbedtls.so libmbedcrypto.so libmbedx509.so)
+set(cjson_LIB_NAMES libcjson.so)
 
 # build a package using cmake
 function(build_atsdk_package)
@@ -53,12 +63,24 @@ function(build_atsdk_package)
       include(${ATSDK_CMAKE_DIR}/${package}.cmake)
     endforeach()
 
-    foreach(package ${arg_EXTERNAL_DEPS})
-      include(${ATSDK_CMAKE_DIR}/find_${package}.cmake)
-    endforeach()
-
     # Create library targets
     add_library(${PROJECT_NAME} STATIC ${arg_PACKAGE_SOURCES})
+
+    if(ATSDK_USE_SHARED_LIBS)
+      foreach(package ${arg_EXTERNAL_DEPS})
+        target_include_directories(${PROJECT_NAME} PUBLIC ${${package}_INCLUDE_DIR})
+        foreach(lib ${${package}_LIB_NAMES})
+          find_library(${lib}_lib_path NAMES ${lib} PATHS /usr/lib /usr/lib64 /usr/local/lib NO_CACHE REQUIRED NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_INSTALL_PREFIX)
+          message(STATUS ${lib} -> ${${lib}_lib_path})
+          target_link_libraries(${PROJECT_NAME} PRIVATE ${${lib}_lib_path})
+        endforeach()
+      endforeach()
+    else()
+      foreach(package ${arg_EXTERNAL_DEPS})
+        include(${ATSDK_CMAKE_DIR}/find_${package}.cmake)
+      endforeach()
+    endif()
+
 
     # LINK
     # Link include headers to library targets
@@ -79,7 +101,11 @@ function(build_atsdk_package)
     endif()
 
     # Link dependencies to library targets
-    target_link_libraries(${PROJECT_NAME} PUBLIC ${arg_INSTALL_TARGETS})
+    if(ATSDK_USE_SHARED_LIBS)
+      target_link_libraries(${PROJECT_NAME} PUBLIC ${arg_DEPS})
+    else()
+      target_link_libraries(${PROJECT_NAME} PUBLIC ${arg_INSTALL_TARGETS})
+    endif()
 
     # INSTALL
     # Install the include headers
@@ -89,11 +115,19 @@ function(build_atsdk_package)
     )
 
     # Install libraries to config target
-    install(
-      TARGETS ${PROJECT_NAME} ${arg_INSTALL_TARGETS}
-      EXPORT ${PROJECT_NAME}-config
-      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    )
+    if(ATSDK_USE_SHARED_LIBS)
+      install(
+        TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}-config
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      )
+    else()
+      install(
+        TARGETS ${PROJECT_NAME} ${arg_INSTALL_TARGETS}
+        EXPORT ${PROJECT_NAME}-config
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      )
+    endif()
 
     # EXPORT
     if(NOT PACKAGE_AS_SUBPROJECT)
@@ -132,7 +166,7 @@ function(add_atsdk_espidf_component)
     0
     arg
     "${options}"
-    "${onValueArgs}"
+    "${oneValueArgs}"
     "${multiValueArgs}"
   )
 

--- a/packages/atauth/src/enroll_namespace.c
+++ b/packages/atauth/src/enroll_namespace.c
@@ -1,6 +1,6 @@
 #include "enroll_namespace.h"
+#include "atclient/json.h"
 #include "atlogger/atlogger.h"
-#include "cJSON.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/packages/atauth/src/run_enroll_command.c
+++ b/packages/atauth/src/run_enroll_command.c
@@ -10,7 +10,6 @@
 #include "atclient/constants.h"
 #include "atclient/string_utils.h"
 #include "atlogger/atlogger.h"
-#include "cJSON.h"
 #include "constants.h"
 #include "enroll_namespace.h"
 #include "enroll_params.h"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a cmake build option to link against shared third party dependencies

**- How I did it**

**- How to verify it**

- Install mbedtls and cjson devel packages
- build the project with `-DATSDK_USE_SHARED_LIBS=ON`

Image shows the result of building with the following configuration:
```
cmake -B build/asdf -S . -DATSDK_DEBUG_MODE=1 -DATSDK_BUILD_TESTS=OFF -DATSDK_USE_SHARED_LIBS=ON
```

![image](https://github.com/user-attachments/assets/7beb488a-c78e-40ba-a01a-6e1523161f48)


**- Description for the changelog**
feat: flag to link external deps dynamically
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
