### PR TITLE
fix: cjson patch with sed

### DIFF
--- a/cmake/cjson-patch.sh
+++ b/cmake/cjson-patch.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# This PATCH_COMMAND script performs the following:
+# Replaces the following line in the cJSON CMakeLists.txt:
+# `cmake_minimum_required(VERSION 3.0)`
+# With the line:
+# `cmake_minimum_required(VERSION 3.24)`
+# This allows us to build it with CMake v4
+if [ "$(uname)" = 'Darwin' ]; then
+  # Unix sed
+  sed -e '2s/0/24/' -i '' CMakeLists.txt
+else
+  # GNU sed
+  sed -e '2s/0/24/' -i CMakeLists.txt
+fi

--- a/cmake/cjson.patch
+++ b/cmake/cjson.patch
@@ -1,6 +1,0 @@
---- i/CMakeLists.txt
-+++ w/CMakeLists.txt
-@@ -1,2 +1,2 @@
- set(CMAKE_LEGACY_CYGWIN_WIN32 0)
--cmake_minimum_required(VERSION 3.0)
-+cmake_minimum_required(VERSION 3.24)

--- a/cmake/cjson.patch
+++ b/cmake/cjson.patch
@@ -1,5 +1,3 @@
-# cmake <3.5 is deprecated by cmake 4.0, so we need at least 3.5.
-# 3.24 was chosen because it is our baseline in atsdk.
 --- i/CMakeLists.txt
 +++ w/CMakeLists.txt
 @@ -1,2 +1,2 @@

--- a/cmake/find_cjson.cmake
+++ b/cmake/find_cjson.cmake
@@ -27,13 +27,7 @@ if(NOT TARGET cjson)
       # FIND_PACKAGE_ARGS 1.7.17 QUIET CONFIG
       # GIT_REPOSITORY https://github.com/DaveGamble/cJSON.git
       # GIT_TAG v1.7.18
-      # This PATCH_COMMAND entry performs the following:
-      # Replaces the following line in the cJSON CMakeLists.txt:
-      # `cmake_minimum_required(VERSION 3.0)`
-      # With the line:
-      # `cmake_minimum_required(VERSION 3.24)`
-      # This allows us to build it with CMake v4
-      PATCH_COMMAND bash -c "sed -e '2s/0/24/' -i CMakeLists.txt"
+      PATCH_COMMAND /bin/sh ${CMAKE_CURRENT_LIST_DIR}/cjson-patch.sh
     )
   endif()
   FetchContent_MakeAvailable(cjson)

--- a/cmake/find_cjson.cmake
+++ b/cmake/find_cjson.cmake
@@ -27,7 +27,13 @@ if(NOT TARGET cjson)
       # FIND_PACKAGE_ARGS 1.7.17 QUIET CONFIG
       # GIT_REPOSITORY https://github.com/DaveGamble/cJSON.git
       # GIT_TAG v1.7.18
-      PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_LIST_DIR}/cjson.patch
+      # This PATCH_COMMAND entry performs the following:
+      # Replaces the following line in the cJSON CMakeLists.txt:
+      # `cmake_minimum_required(VERSION 3.0)`
+      # With the line:
+      # `cmake_minimum_required(VERSION 3.24)`
+      # This allows us to build it with CMake v4
+      PATCH_COMMAND bash -c "sed -e '2s/0/24/' -i CMakeLists.txt"
     )
   endif()
   FetchContent_MakeAvailable(cjson)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Replaced patch command with sed script to patch cjson.

Both patch and sed are different in GNU & Unix, but I am already familiar with the differences in sed, so I switched to that.

From reading the patch man pages, I couldn't find anything which indicated that the patch in cmake should fail on MacOS but it is.

The sed command will only work from within a shell, this should work on any platform which meets the following three things:

1. /bin/sh is a posix compliant shell AND
2. sed is GNU sed OR (linux)
3. sed is Unix sed AND uname = 'Darwin' (macos)

**- How I did it**

**- How to verify it**

Tested on:

- Macos 15.5, with CMake 4.0.1 & gcc (Apple clang version 16.0.0)
- Arch latest, with CMake 4.0.2 & clang 19.1.7

**- Description for the changelog**
fix: cjson patch with sed
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
