### PR TITLE
build(deps): Bump MbedTLS to 3.6.4

### DIFF
--- a/cmake/find_mbedtls.cmake
+++ b/cmake/find_mbedtls.cmake
@@ -22,9 +22,9 @@ if(NOT TARGET mbedcrypto)
     FetchContent_Declare(
       MbedTLS
       URL
-        https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.1/mbedtls-3.6.1.tar.bz2
+        https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.4/mbedtls-3.6.4.tar.bz2
       URL_HASH
-        SHA256=fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3 # hash for v3.6.1 .tar.bz2 release source code
+        SHA256=ec35b18a6c593cf98c3e30db8b98ff93e8940a8c4e690e66b41dfc011d678110 # hash for v3.6.4 .tar.bz2 release source code
       # FIND_PACKAGE_ARGS QUIET CONFIG
     )
   endif()

--- a/packages/atclient/CHANGELOG.md
+++ b/packages/atclient/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+- build(deps): Bump MbedTLS to 3.6.4
+
 ## 0.3.3
 
 - fix: monitor resiliency

--- a/packages/atclient/include/atclient/version.h
+++ b/packages/atclient/include/atclient/version.h
@@ -4,7 +4,7 @@
 extern "C" {
 #endif
 
-#define ATCLIENT_ATSDK_VERSION "0.3.3"
+#define ATCLIENT_ATSDK_VERSION "0.3.4"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**- What I did**

* Updated URL and SHA for latest patch release of MbedTLS
* Bumped changelog and version.h

**- Description for the changelog**

build(deps): Bump MbedTLS to 3.6.4