### PR TITLE
ci: Use sbomify for SBOM

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -50,7 +50,7 @@ jobs:
         uses: sbomify/github-action@8ea6f28cd562edee2665001cd4f17aaf7a283722 # v0.5.0
         env:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
-          COMPONENT_ID: '-93khk8pUi'
+          COMPONENT_ID: 'VNl3FVi352OB'
           LOCK_FILE: './tools/conan.lock'
           SBOM_VERSION: ${{github.ref_name}}
           OUTPUT_FILE: 'tarballs/at_c-${{github.ref_name}}-sbom.cdx.json'

--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -41,17 +41,22 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: tarballs/
-## 20240807: Need a different approach to SBOMs for C SDK
-#    - name: Generate SBOMs
-#      run: |
-#        syft scan file:./packages/dart/sshnoports/pubspec.lock \
-#          -o 'spdx-json=tarballs/dart_sshnoports_sbom.spdx.json' \
-#          -o 'cyclonedx-json=tarballs/dart_sshnoports_sbom.cyclonedx.json'
       - name: Move packages for signing
         run: |
           cd tarballs
           mv */*.tar.gz .
           rm -Rf -- */
+      - name: Generate SBOM
+        uses: sbomify/github-action@8ea6f28cd562edee2665001cd4f17aaf7a283722 # v0.5.0
+        env:
+          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          COMPONENT_ID: '-93khk8pUi'
+          LOCK_FILE: './tools/conan.lock'
+          SBOM_VERSION: ${{github.ref_name}}
+          OUTPUT_FILE: 'tarballs/at_c-${{github.ref_name}}-sbom.cdx.json'
+          AUGMENT: true
+          ENRICH: true
+          UPLOAD: true
       - name: Generate SHA256 checksums
         working-directory: tarballs
         run: sha256sum * > checksums.txt

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_c/badge)](https://securityscorecards.dev/viewer/?uri=github.com/atsign-foundation/at_c&sort_by=check-score&sort_direction=desc)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8138/badge)](https://www.bestpractices.dev/projects/8138)
+[![sbomified](https://sbomify.com/assets/images/logo/badge.svg)](https://app.sbomify.com/component/VNl3FVi352OB)
 
 # at_c
 

--- a/packages/atclient/CHANGELOG.md
+++ b/packages/atclient/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5
+
+- feat: Add Conan based SBOM creation with sbomify
+
 ## 0.3.4
 
 - build(deps): Bump MbedTLS to 3.6.4

--- a/packages/atclient/include/atclient/version.h
+++ b/packages/atclient/include/atclient/version.h
@@ -4,7 +4,7 @@
 extern "C" {
 #endif
 
-#define ATCLIENT_ATSDK_VERSION "0.3.4"
+#define ATCLIENT_ATSDK_VERSION "0.3.5"
 
 #ifdef __cplusplus
 }

--- a/tools/conan.lock
+++ b/tools/conan.lock
@@ -1,0 +1,10 @@
+{
+    "version": "0.5",
+    "requires": [
+        "mbedtls/3.6.4#b686248bee97f7bc92b88c6bc6e514a2%1752241954.6017513",
+        "cjson/1.7.18#e67d95071acf8902d892d89a858d31ab%1743006050.674"
+    ],
+    "build_requires": [],
+    "python_requires": [],
+    "config_requires": []
+}

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 
 class at_cRecipe(ConanFile):
     name = "at_c"
-    version = "0.3.4"
+    version = "0.3.5"
     package_type = "library"
 
     # Optional metadata

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -15,7 +15,7 @@ class at_cRecipe(ConanFile):
     author = "atsign-foundation"
     url = "https://github.com/atsign-foundation/at_c"
     description = "Cross-platform C implementation of the atSDK for SOC & embedded devices"
-    
+
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "fPIC": [True, False]}
@@ -34,7 +34,7 @@ class at_cRecipe(ConanFile):
 
     def layout(self):
         cmake_layout(self)
-    
+
     def generate(self):
         deps = CMakeDeps(self)
         deps.generate()
@@ -56,4 +56,3 @@ class at_cRecipe(ConanFile):
     def requirements(self):
         self.requires("mbedtls/3.6.4")
         self.requires("cjson/1.7.18")
-

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -1,0 +1,59 @@
+# This Conanfile is presently used to create the at_c SBOM and isn't
+# used to generate CMake builds or anything else.
+
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+
+
+class at_cRecipe(ConanFile):
+    name = "at_c"
+    version = "0.3.4"
+    package_type = "library"
+
+    # Optional metadata
+    license = "BSD-3-Clause"
+    author = "atsign-foundation"
+    url = "https://github.com/atsign-foundation/at_c"
+    description = "Cross-platform C implementation of the atSDK for SOC & embedded devices"
+    
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    # Sources are located in the same place as this recipe, copy them to the recipe
+    exports_sources = "CMakeLists.txt", "src/*", "include/*"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self)
+    
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["at_c"]
+
+    def requirements(self):
+        self.requires("mbedtls/3.6.4")
+        self.requires("cjson/1.7.18")
+


### PR DESCRIPTION
Add an SBOM to releases generated from a Conanfile to progress https://github.com/atsign-foundation/operations/issues/139

**- What I did**

Replaced placeholder for SBOM creation with approach based on Conan and sbomify

**- How I did it**

* Ensured that our dependencies are available in Conan
* Created a conanfile.py that defines the dependencies
* Generated a lockfile
* Modified release workflow to generate an SBOM from the lockfile
* Bumped versions in preparation for a v0.3.5 release that will include an SBOM
* Added sbomified badge to README

**- How to verify it**

Will need a v0.3.5 release once this is merged

**- Description for the changelog**

ci: Use sbomify for SBOM