### PR TITLE
fix: Download location

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -37,6 +37,12 @@ jobs:
       id-token: write # IMPORTANT: mandatory for sigstore
       attestations: write
     steps:
+      - name: Get lockfile
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: |
+            tools/conan.lock
+          sparse-checkout-cone-mode: false
       - name: Download tarball
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:

--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -37,15 +37,10 @@ jobs:
       id-token: write # IMPORTANT: mandatory for sigstore
       attestations: write
     steps:
-      - name: Download all the tarballs
+      - name: Download tarball
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           path: tarballs/
-      - name: Move packages for signing
-        run: |
-          cd tarballs
-          mv */*.tar.gz .
-          rm -Rf -- */
       - name: Generate SBOM
         uses: sbomify/github-action@8ea6f28cd562edee2665001cd4f17aaf7a283722 # v0.5.0
         env:


### PR DESCRIPTION
Download artifact v5 has broken the previous behaviour for a single file

**- What I did**

* Removed file manipulation script
* Checkout for conan.lock file

**- How to verify it**

I've tested with a pre-release against this branch, which got a successful [actions run](https://github.com/atsign-foundation/at_c/actions/runs/17378125827). Will do a v0.3.5 release once this is merged.

**- Description for the changelog**

fix: Download location