### PR TITLE
ci: Update sbomify syntax

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -53,7 +53,7 @@ jobs:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: 'VNl3FVi352OB'
           LOCK_FILE: './tools/conan.lock'
-          SBOM_VERSION: ${{github.ref_name}}
+          COMPONENT_VERSION: ${{github.ref_name}}
           OUTPUT_FILE: 'tarballs/at_c-${{github.ref_name}}-sbom.cdx.json'
           AUGMENT: true
           ENRICH: true


### PR DESCRIPTION
On [v0.3.5 release actions run](https://github.com/atsign-foundation/at_c/actions/runs/17406765303/job/49413090636)

```log
[2025-09-02 14:29:46] WARNING - sbomify_action - SBOM_VERSION is deprecated. Please use COMPONENT_VERSION instead.
```

**- What I did**

Swapped SBOM_VERSION for COMPONENT_VERSION

**- How to verify it**

Warning should not be there for next release

**- Description for the changelog**

ci: Update sbomify syntax
