### PR TITLE
feat: Conanfile for dummy at_c package to create NoPorts SBOMs

### DIFF
--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -3,6 +3,7 @@
 
 from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.files import get
 
 
 class at_cRecipe(ConanFile):
@@ -21,8 +22,9 @@ class at_cRecipe(ConanFile):
     options = {"shared": [True, False], "fPIC": [True, False]}
     default_options = {"shared": False, "fPIC": True}
 
-    # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "CMakeLists.txt", "src/*", "include/*"
+    def source(self):
+        get(self, f"https://github.com/atsign-foundation/at_c/releases/download/v{self.version}/at_c-v{self.version}.tar.gz",
+              strip_root=True)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -40,15 +42,6 @@ class at_cRecipe(ConanFile):
         deps.generate()
         tc = CMakeToolchain(self)
         tc.generate()
-
-    def build(self):
-        cmake = CMake(self)
-        cmake.configure()
-        cmake.build()
-
-    def package(self):
-        cmake = CMake(self)
-        cmake.install()
 
     def package_info(self):
         self.cpp_info.libs = ["at_c"]


### PR DESCRIPTION
To create a `conan.lock` file for NoPorts we need at_c to be in the local Conan cache.

This revised `conanfile.py` can be used with `conan create tools/` to populate the cache.

**- What I did**

* Point to at_c source tarball
* Remove build and package sections, as we don't want to do this with Conan

**- How I did it**

Based on https://docs.conan.io/2/tutorial/creating_packages/handle_sources_in_packages.html

**- How to verify it**

Here's the command line output I get:

```log
Using lockfile: '/home/chris/git/github.com/atsign-foundation/at_c/tools/conan.lock'

======== Exporting recipe to the cache ========
at_c/0.3.5: Exporting package recipe: /home/chris/git/github.com/atsign-foundation/at_c/tools/conanfile.py
at_c/0.3.5: Copied 1 '.py' file: conanfile.py
at_c/0.3.5: Exported to cache folder: /home/chris/.conan2/p/at_c9e2113819525d/e
at_c/0.3.5: Exported: at_c/0.3.5#34b56d9094830185b0edbc3911bb9a6d (2025-09-02 16:08:35 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux


======== Computing dependency graph ========
Graph root
    cli
Requirements
    at_c/0.3.5#34b56d9094830185b0edbc3911bb9a6d - Cache
    cjson/1.7.18#e67d95071acf8902d892d89a858d31ab - Cache
    mbedtls/3.6.4#b686248bee97f7bc92b88c6bc6e514a2 - Cache

======== Computing necessary packages ========
at_c/0.3.5: Forced build from source
Requirements
    at_c/0.3.5#34b56d9094830185b0edbc3911bb9a6d:7b5cf58520db743abb353abe92508df136590273 - Build
    cjson/1.7.18#e67d95071acf8902d892d89a858d31ab:83bf5a25c2a75ec3d9f5e0d37ab86a61c52dd451#a5536715a0c354b98a64be351ac4c8ab - Cache
    mbedtls/3.6.4#b686248bee97f7bc92b88c6bc6e514a2:f4cbea47cebcd5bf7f05fa8887e85f15ed250daa#9ccd6d5ad379fe4666d070ab97fae725 - Cache

======== Installing packages ========
cjson/1.7.18: Already installed! (1 of 3)
mbedtls/3.6.4: Already installed! (2 of 3)

-------- Installing package at_c/0.3.5 (3 of 3) --------
at_c/0.3.5: Building from source
at_c/0.3.5: Package at_c/0.3.5:7b5cf58520db743abb353abe92508df136590273
at_c/0.3.5: settings: os=Linux arch=x86_64 compiler=gcc compiler.cppstd=gnu17 compiler.libcxx=libstdc++11 compiler.version=13 build_type=Release
at_c/0.3.5: options: fPIC=True shared=False
at_c/0.3.5: requires: mbedtls/3.6.Z cjson/1.7.Z
at_c/0.3.5: Copying sources to build folder
at_c/0.3.5: Building your package in /home/chris/.conan2/p/b/at_c581d07bfbd063/b
at_c/0.3.5: Calling generate()
at_c/0.3.5: Generators folder: /home/chris/.conan2/p/b/at_c581d07bfbd063/b/build/Release/generators
at_c/0.3.5: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(MbedTLS)
    find_package(cJSON)
    target_link_libraries(... MbedTLS::mbedtls cjson::cjson)
at_c/0.3.5: CMakeToolchain generated: conan_toolchain.cmake
at_c/0.3.5: CMakeToolchain generated: /home/chris/.conan2/p/b/at_c581d07bfbd063/b/build/Release/generators/CMakePresets.json
at_c/0.3.5: Generating aggregated env files
at_c/0.3.5: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
at_c/0.3.5: Package '7b5cf58520db743abb353abe92508df136590273' built
at_c/0.3.5: Build folder /home/chris/.conan2/p/b/at_c581d07bfbd063/b/build/Release
at_c/0.3.5: Generating the package
at_c/0.3.5: Packaging in folder /home/chris/.conan2/p/b/at_c581d07bfbd063/p
at_c/0.3.5: package(): WARN: No files in this package!
at_c/0.3.5: Created package revision f9efbd3de6835a286ef2934286b4f047
at_c/0.3.5: Package '7b5cf58520db743abb353abe92508df136590273' created
at_c/0.3.5: Full package reference: at_c/0.3.5#34b56d9094830185b0edbc3911bb9a6d:7b5cf58520db743abb353abe92508df136590273#f9efbd3de6835a286ef2934286b4f047
at_c/0.3.5: Package folder /home/chris/.conan2/p/b/at_cf57b5bfde8e5b/p
```

**- Description for the changelog**

feat: Conanfile for dummy at_c package to create NoPorts SBOMs
