### PR TITLE
ci: Add COMPONENT_NAME of at_c to SBOM

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -53,6 +53,7 @@ jobs:
           TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
           COMPONENT_ID: 'VNl3FVi352OB'
           LOCK_FILE: './tools/conan.lock'
+          COMPONENT_NAME: 'at_c'
           COMPONENT_VERSION: ${{github.ref_name}}
           OUTPUT_FILE: 'tarballs/at_c-${{github.ref_name}}-sbom.cdx.json'
           AUGMENT: true


### PR DESCRIPTION
Similar to https://github.com/atsign-foundation/noports/pull/2130 the at_c SBOM presently defaults to `/github/workspace/tools/conan.lock` as its name

**- What I did**

Added COMPONENT_NAME

**- How to verify it**

Re-release v0.3.35

**- Description for the changelog**

ci: Add COMPONENT_NAME of at_c to SBOM
