### PR TITLE
build(deps): Bump cJSON to 1.7.19

### DIFF
--- a/cmake/find_cjson.cmake
+++ b/cmake/find_cjson.cmake
@@ -21,12 +21,9 @@ if(NOT TARGET cjson)
   else()
     FetchContent_Declare(
       cjson
-      URL https://github.com/DaveGamble/cJSON/archive/refs/tags/v1.7.18.zip
+      URL https://github.com/DaveGamble/cJSON/archive/refs/tags/v1.7.19.zip
       URL_HASH
-        SHA256=cc6d93cc3b659037c34193ecc7be5a874a18c2ac67b24efe82db6a759b486b5d # hash for v1.7.18 .zip release source code
-      # FIND_PACKAGE_ARGS 1.7.17 QUIET CONFIG
-      # GIT_REPOSITORY https://github.com/DaveGamble/cJSON.git
-      # GIT_TAG v1.7.18
+        SHA256=83fb7750db0601dca735868b8fb1da1318da2d2a1331a9a7da923cb891d26ea9 # hash for v1.7.19 .zip release source code
       PATCH_COMMAND /bin/sh ${CMAKE_CURRENT_LIST_DIR}/cjson-patch.sh
     )
   endif()

--- a/packages/atclient/CHANGELOG.md
+++ b/packages/atclient/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.6
+
+- build(deps): Bump cJSON to 1.7.19
+
 ## 0.3.5
 
 - feat: Add Conan based SBOM creation with sbomify

--- a/tools/conan.lock
+++ b/tools/conan.lock
@@ -2,7 +2,7 @@
     "version": "0.5",
     "requires": [
         "mbedtls/3.6.4#b686248bee97f7bc92b88c6bc6e514a2%1752241954.6017513",
-        "cjson/1.7.18#e67d95071acf8902d892d89a858d31ab%1743006050.674"
+        "cjson/1.7.19#0f1d9770c2c7898029ef69e0df621838%1757507235.3264372"
     ],
     "build_requires": [],
     "python_requires": [],

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.files import get
 
 class at_cRecipe(ConanFile):
     name = "at_c"
-    version = "0.3.5"
+    version = "0.3.6"
     package_type = "library"
 
     # Optional metadata
@@ -48,4 +48,4 @@ class at_cRecipe(ConanFile):
 
     def requirements(self):
         self.requires("mbedtls/3.6.4")
-        self.requires("cjson/1.7.18")
+        self.requires("cjson/1.7.19")


### PR DESCRIPTION
Multiple bug fixes https://github.com/DaveGamble/cJSON/compare/v1.7.18...v1.7.19

* Fix indentation (should use spaces), see [#814](https://github.com/DaveGamble/cJSON/pull/814)
* Fix spelling errors found by CodeSpell, see [#841](https://github.com/DaveGamble/cJSON/pull/841)
* Check for NULL in cJSON_DetachItemViaPointer, fixes [#882](https://github.com/DaveGamble/cJSON/issues/882), see [#886](https://github.com/DaveGamble/cJSON/pull/886)
* Fix [#881](https://github.com/DaveGamble/cJSON/issues/881), check overlap before calling strcpy in cJSON_SetValuestring, see [#885](https://github.com/DaveGamble/cJSON/pull/885)
* Fix [#880](https://github.com/DaveGamble/cJSON/issues/880) Max recursion depth for cJSON_Duplicate to prevent stack exhaustion, see [#888](https://github.com/DaveGamble/cJSON/pull/888)
* Allocate memory for the temporary buffer when paring numbers, see [#939](https://github.com/DaveGamble/cJSON/pull/939)
* fix the incorrect check in decode_array_index_from_pointer, see [#957](https://github.com/DaveGamble/cJSON/pull/957)

**- What I did**

* Bumped cjson version and hash
* Bumped Conanfile.py and created new lock file
  * Also PR for Conan Center https://github.com/conan-io/conan-center-index/pull/28364
* Bumped version number and changelog for next release

**- Description for the changelog**

build(deps): Bump cJSON to 1.7.19