### PR TITLE
docs: Link to public sbomified profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_c/badge)](https://securityscorecards.dev/viewer/?uri=github.com/atsign-foundation/at_c&sort_by=check-score&sort_direction=desc)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8138/badge)](https://www.bestpractices.dev/projects/8138)
-[![sbomified](https://sbomify.com/assets/images/logo/badge.svg)](https://app.sbomify.com/component/VNl3FVi352OB)
+[![sbomified](https://sbomify.com/assets/images/logo/badge.svg)](https://app.sbomify.com/public/project/RnEa3RVVcZ8I/)
 
 # at_c
 


### PR DESCRIPTION
The link behind the sbomified badge presently leads to a page that's login protected

**- What I did**

Fixed link to point to public profile

**- How I did it**

Copied link from sbomify Project page

**- How to verify it**

Rich diff

**- Description for the changelog**

docs: Link to public sbomified profile
