### PR TITLE
build(deps): Bump CMake to 3.31.10

### DIFF
--- a/.github/workflows/build_source_tests.yaml
+++ b/.github/workflows/build_source_tests.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
         with:
-          cmake-version: "3.31.6"
+          cmake-version: "3.31.10"
 
       - name: Show tooling versions
         run: |
@@ -72,6 +72,6 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
         with:
-          cmake-version: "3.31.6"
+          cmake-version: "3.31.10"
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - run: cmake --workflow --preset ${{ matrix.preset }}

--- a/.github/workflows/build_source_tests.yaml
+++ b/.github/workflows/build_source_tests.yaml
@@ -25,7 +25,7 @@ jobs:
 
         # Pin cmake to <4.0.0
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
           cmake-version: "3.31.10"
 
@@ -70,7 +70,7 @@ jobs:
     steps:
       # Pin cmake to <4.0.0
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
           cmake-version: "3.31.10"
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
         with:
-          cmake-version: "3.31.6"
+          cmake-version: "3.31.10"
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       # Pin cmake to <4.0.0
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
           cmake-version: "3.31.10"
       - name: Checkout repository

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
         with:
-          cmake-version: "3.31.6"
+          cmake-version: "3.31.10"
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Install valgrind
@@ -84,7 +84,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
         with:
-          cmake-version: "3.31.6"
+          cmake-version: "3.31.10"
 
       - name: Build and Run Check Docker Readiness
         working-directory: tests/functional_tests/check_docker_readiness
@@ -130,7 +130,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
         with:
-          cmake-version: "3.31.6"
+          cmake-version: "3.31.10"
       - name: Install atSDK
         run: |
           cmake -S . -B build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Pin cmake to <4.0.0
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
           cmake-version: "3.31.10"
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -82,7 +82,7 @@ jobs:
 
       # Pin cmake to <4.0.0
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
           cmake-version: "3.31.10"
 
@@ -128,7 +128,7 @@ jobs:
 
         # Pin cmake to <4.0.0
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
           cmake-version: "3.31.10"
       - name: Install atSDK


### PR DESCRIPTION
The CMake we use in CI has slipped behind latest patch release as Dependabot doesn't keep these things fresh for us.

**- What I did**

* Bumped to latest patch release (that we use in c_buildimage for builds)
* Added version comment for CMake setup action

**- How to verify it**

CI

**- Description for the changelog**

build(deps): Bump CMake to 3.31.10
