### PR TITLE
fix: Ensure SBOM tags are unique

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -54,7 +54,7 @@ jobs:
           COMPONENT_ID: 'VNl3FVi352OB'
           LOCK_FILE: './tools/conan.lock'
           COMPONENT_NAME: 'at_c'
-          COMPONENT_VERSION: ${{github.ref_name}}
+          COMPONENT_VERSION: ${{github.ref_name}}-gha${{github.run_number}}
           OUTPUT_FILE: 'tarballs/at_c-${{github.ref_name}}-sbom.cdx.json'
           AUGMENT: true
           ENRICH: true


### PR DESCRIPTION
Same issue as https://github.com/atsign-foundation/noports/pull/2459

**- What I did**

Added GitHub Actions run number to COMPONENT_VERSION

**- How I did it**

Based on https://github.com/atsign-foundation/at_server/pull/2514

**- How to verify it**

Inspect sbomify trust centre on next release

**- Description for the changelog**

fix: Ensure SBOM tags are unique
