### PR TITLE
ci: Use attest rather than attest-build-provenance

### DIFF
--- a/.github/workflows/c_release.yml
+++ b/.github/workflows/c_release.yml
@@ -73,7 +73,8 @@ jobs:
         working-directory: tarballs
         run: |
           echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      - name: GitHub attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: "tarballs/**"
 


### PR DESCRIPTION
Progresses https://github.com/atsign-foundation/operations/issues/365

**- What I did**

* Replaced `attest-build-provenance` with `attest`
* Added name element to step

**- How I did it**

```diff
- uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+ uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
```

**- How to verify it**

Future releases still provide attestation in GitHub Actions log

**- Description for the changelog**

ci: Use attest rather than attest-build-provenance