### PR TITLE
ci: Extend timeout for rsa keygen test

### DIFF
--- a/.github/workflows/build_source_tests.yaml
+++ b/.github/workflows/build_source_tests.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         with:
-          cmake-version: "3.31.10"
+          cmake-version: "3.31.12"
 
       - name: Show tooling versions
         run: |
@@ -72,6 +72,6 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         with:
-          cmake-version: "3.31.10"
+          cmake-version: "3.31.12"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: cmake --workflow --preset ${{ matrix.preset }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         with:
-          cmake-version: "3.31.10"
+          cmake-version: "3.31.12"
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         with:
-          cmake-version: "3.31.10"
+          cmake-version: "3.31.12"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install valgrind
@@ -42,8 +42,9 @@ jobs:
       # Unit tests are so fast we can run them serially and they will still
       # finish before the functional tests.
       # Long timeout because RSA keygen test sometimes takes a while
+      # 20260805 60s timeout extended to 300s due to repeated failures of rsa test
       - name: Run memcheck tests
-        run: ctest -T memcheck --test-dir build --output-on-failure --timeout 60 -VV
+        run: ctest -T memcheck --test-dir build --output-on-failure --timeout 300 -VV
 
   functional-tests:
     strategy:
@@ -84,7 +85,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         with:
-          cmake-version: "3.31.10"
+          cmake-version: "3.31.12"
 
       - name: Build and Run Check Docker Readiness
         working-directory: tests/functional_tests/check_docker_readiness
@@ -130,7 +131,7 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         with:
-          cmake-version: "3.31.10"
+          cmake-version: "3.31.12"
       - name: Install atSDK
         run: |
           cmake -S . -B build


### PR DESCRIPTION
Fixes #692 

**- What I did**

* Extended timeout to 300s
* Also bumped CMake version to latest patch, which is 3.31.12

**- How I did it**

Followed Co-pilot guidance per #692

**- How to verify it**

CI should run clean

**- Description for the changelog**

ci: Extend timeout for rsa keygen test
