### PR TITLE
ci: Increase timeout for regular unit tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
           cmake --build build --target all
 
       - name: Run tests
-        run: ctest --test-dir build --output-on-failure --timeout 5 -VV
+        run: ctest --test-dir build --output-on-failure --timeout 15 -VV
 
       # Unit tests are so fast we can run them serially and they will still
       # finish before the functional tests.


### PR DESCRIPTION
Related to #692 I'm also seeing timeouts for the unit tests when not running under valgrind - it seems everything has got a bit slower :(

**- What I did**

Increased timeout from 5s to 15s

**- How to verify it**

Observe fewer failures on Dependabot PRs etc.

**- Description for the changelog**

ci: Increase timeout for regular unit tests
