### PR TITLE
fix: route the enroll connection through 'proxy:' root specs with from:

### DIFF
--- a/packages/atauth/src/run_enroll_command.c
+++ b/packages/atauth/src/run_enroll_command.c
@@ -72,6 +72,35 @@ int atauth_enroll_command(const char *atsign, const char *root_domain, const cha
     goto free_auth_options;
   }
 
+  if (strncmp(root_domain, "proxy:", strlen("proxy:")) == 0) {
+    // A protocol-aware reverse proxy (e.g. proxy0001.atsign.org:443) routes a
+    // connection using the FIRST line the client sends, and only understands
+    // 'from:' - any other first line makes it answer with its own address and
+    // close the socket. The enroll flow's first real command is a lookup, so
+    // in proxy mode issue a from: exchange first and discard the challenge;
+    // the connection is then bridged to the atServer and every subsequent
+    // command flows through. (The atServer still accepts unauthenticated
+    // lookup/enroll verbs after a bare from:.)
+    const char *atsign_without_at = (atsign[0] == '@') ? atsign + 1 : atsign;
+    const size_t from_cmd_size = strlen("from:") + strlen(atsign_without_at) + strlen("\r\n") + 1;
+    char *from_cmd = malloc(from_cmd_size);
+    if (from_cmd == NULL) {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to allocate memory for from_cmd\n");
+      ret = 1;
+      goto free_auth_options;
+    }
+    snprintf(from_cmd, from_cmd_size, "from:%s\r\n", atsign_without_at);
+    unsigned char from_recv[256];
+    size_t from_recv_len = 0;
+    ret = atclient_connection_send(&atclient.atserver_connection, (unsigned char *)from_cmd, strlen(from_cmd),
+                                   from_recv, sizeof(from_recv), &from_recv_len);
+    free(from_cmd);
+    if (ret != 0) {
+      atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to route the connection via the reverse proxy\n");
+      goto free_auth_options;
+    }
+  }
+
   atclient_atkeys atkeys;
   atclient_atkeys_init(&atkeys);
 


### PR DESCRIPTION
## Summary

Fixes #704. `at_activate enroll` through a `proxy:` root server spec failed at its first command:

```
SENT: "lookup:all:publickey@cconstab"
RECV: "proxy0001.atsign.org:443"
ERROR: Failed to get the default encryption public key
```

The protocol-aware reverse proxy routes a connection using the **first line the client sends** and only understands `from:` (`at_secondary_proxy`'s `secondary_connection_bridge.dart`) — anything else gets the proxy's own address back (its atDirectory-emulation behavior) and the socket closed. Onboard works because CRAM leads with `from:`; enroll led with a lookup.

## Fix

When the root spec has the `proxy:` prefix, `atauth_enroll_command` sends a `from:<atsign>` exchange immediately after connecting and discards the challenge; the connection is then bridged and all subsequent commands flow through. Direct (non-proxy) enrollment is unchanged.

## Verification (live proxy, bogus OTP)

Rebuilt `at_activate` with this patch and ran `enroll -r "proxy:proxy0001.atsign.org:443"`:

1. `from:` challenge received through the proxy ✔
2. `lookup:all:publickey@cconstab` returns the real public key ✔
3. `enroll:request` reaches the atServer — rejected only with `AT0022-Exception: invalid otp` (the OTP was deliberately bogus) ✔

The same fix already landed in the Arduino snapshot as atsign-foundation/at_client_arduino#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)