### PR TITLE
chore: Bump version and change log (v0.3.11)

### DIFF
--- a/packages/atclient/CHANGELOG.md
+++ b/packages/atclient/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.11
+
+- fix: route the enroll connection through 'proxy:' root specs with from:
+
 ## 0.3.10
 
 - feat: at_activate supports 'proxy:' root server specs (activation via 443)

--- a/packages/atclient/include/atclient/version.h
+++ b/packages/atclient/include/atclient/version.h
@@ -4,7 +4,7 @@
 extern "C" {
 #endif
 
-#define ATCLIENT_ATSDK_VERSION "0.3.10"
+#define ATCLIENT_ATSDK_VERSION "0.3.11"
 
 #ifdef __cplusplus
 }

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.files import get
 
 class at_cRecipe(ConanFile):
     name = "at_c"
-    version = "0.3.10"
+    version = "0.3.11"
     package_type = "library"
 
     # Optional metadata


### PR DESCRIPTION
Prep for the v0.3.11 release, following the v0.3.10 pattern (#703):

- CHANGELOG.md: 0.3.11 — fix: route the enroll connection through 'proxy:' root specs with from: (#705, plus the #707 review nits)
- `ATCLIENT_ATSDK_VERSION` -> 0.3.11
- conanfile.py version -> 0.3.11 (no Conan dependency changes needed — underlying deps unchanged, per @cpswan)

Once merged, tagging the merge commit `v0.3.11` triggers `c_release.yml` for the tarball/checksums/provenance. Downstream: noports will pin atsdk to the tagged SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)