### PR TITLE
fix: atchops_rsa_encrypt takes an output-buffer-size bound

### DIFF
--- a/packages/atauth/src/apkam_keys.c
+++ b/packages/atauth/src/apkam_keys.c
@@ -47,7 +47,7 @@ int atauth_apkam_symmetric_key_generate(struct atauth_apkam_symmetric_key *key,
   }
 
   ret = atchops_rsa_encrypt(default_encryption_public_key, (unsigned char *)key->symmetric_key_base64,
-                            key->symmetric_key_base64_len, cipher_text);
+                            key->symmetric_key_base64_len, cipher_text, cipher_text_len, &cipher_text_len);
   if (ret != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to encrypt symmetric key: %d\n", ret);
     goto exit;

--- a/packages/atchops/include/atchops/rsa.h
+++ b/packages/atchops/include/atchops/rsa.h
@@ -46,11 +46,15 @@ int atchops_rsa_verify(const atchops_rsa_key_public_key *public_key, const atcho
  * @param public_key the public key struct to use for encryption, see atchops_rsa_key_populate_public_key
  * @param plaintext the plaintext to encrypt, in bytes
  * @param plaintext_len the length of the plaintext, most people use strlen() to find this length
- * @param ciphertext the ciphertext buffer to populate, assumed to be 256 bytes long for 2048 RSA modulus
+ * @param ciphertext the ciphertext buffer to populate (e.g. 256 bytes for a 2048 bit RSA modulus)
+ * @param ciphertext_size the size of the ciphertext buffer (allocated size); the operation fails without writing
+ * anything if the key's modulus is longer than this
+ * @param ciphertext_len the written length of the ciphertext (the key's modulus length), may be NULL
  * @return int 0 on success
  */
 int atchops_rsa_encrypt(const atchops_rsa_key_public_key *public_key, const unsigned char *plaintext,
-                        const size_t plaintext_len, unsigned char *ciphertext);
+                        const size_t plaintext_len, unsigned char *ciphertext, const size_t ciphertext_size,
+                        size_t *ciphertext_len);
 
 /**
  * @brief Decrypt bytes with an RSA private key

--- a/packages/atchops/src/rsa.c
+++ b/packages/atchops/src/rsa.c
@@ -250,7 +250,8 @@ exit: {
 }
 
 int atchops_rsa_encrypt(const atchops_rsa_key_public_key *public_key, const unsigned char *plaintext,
-                        const size_t plaintext_len, unsigned char *ciphertext) {
+                        const size_t plaintext_len, unsigned char *ciphertext, const size_t ciphertext_size,
+                        size_t *ciphertext_len) {
   int ret = 1;
 
   /*
@@ -278,6 +279,12 @@ int atchops_rsa_encrypt(const atchops_rsa_key_public_key *public_key, const unsi
   if (ciphertext == NULL) {
     ret = 1;
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ciphertext is NULL\n");
+    return ret;
+  }
+
+  if (ciphertext_size <= 0) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "ciphertext_size is less than or equal to 0\n");
     return ret;
   }
 
@@ -325,14 +332,29 @@ int atchops_rsa_encrypt(const atchops_rsa_key_public_key *public_key, const unsi
   }
 
   /*
-   * 4. Encrypt the plaintext with RSA public key
+   * 4. Encrypt the plaintext with RSA public key. mbedtls writes exactly the
+   * key's modulus length into ciphertext, so refuse to encrypt (rather than
+   * overflow the caller's buffer) when the modulus is longer than the buffer
    */
+  const size_t output_len = mbedtls_rsa_get_len(&rsa);
+  if (output_len > ciphertext_size) {
+    ret = 1;
+    atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
+                 "ciphertext buffer (%zu bytes) is too small for the key's %zu byte modulus\n", ciphertext_size,
+                 output_len);
+    goto exit;
+  }
+
   if ((ret = mbedtls_rsa_pkcs1_encrypt(&rsa, mbedtls_ctr_drbg_random, &ctr_drbg_ctx,
 #ifdef ATCHOPS_MBEDTLS_VERSION_2
                                        MBEDTLS_RSA_PUBLIC,
 #endif
                                        plaintext_len, plaintext, ciphertext)) != 0) {
     goto exit;
+  }
+
+  if (ciphertext_len != NULL) {
+    *ciphertext_len = output_len;
   }
 
   ret = 0;

--- a/packages/atchops/tests/test_rsa_key_generate.c
+++ b/packages/atchops/tests/test_rsa_key_generate.c
@@ -89,7 +89,8 @@ int main() {
   // use the public key to encrypt something
   // use the private key to decrypt it
 
-  if ((ret = atchops_rsa_encrypt(&public_key, (const unsigned char *)PLAINTEXT, strlen(PLAINTEXT), ciphertext)) != 0) {
+  if ((ret = atchops_rsa_encrypt(&public_key, (const unsigned char *)PLAINTEXT, strlen(PLAINTEXT), ciphertext,
+                                 ciphertext_size, NULL)) != 0) {
     atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to encrypt plaintext\n");
     goto exit;
   }
@@ -240,7 +241,8 @@ static int test2_generate_base64() {
   }
 
   // 3b. use it to encrypt the plaintext
-  if ((ret = atchops_rsa_encrypt(&public_key, (const unsigned char *)PLAINTEXT, strlen(PLAINTEXT), ciphertext)) != 0) {
+  if ((ret = atchops_rsa_encrypt(&public_key, (const unsigned char *)PLAINTEXT, strlen(PLAINTEXT), ciphertext,
+                                 ciphertext_size, NULL)) != 0) {
     atlogger_log("test_rsa_generate", ATLOGGER_LOGGING_LEVEL_ERROR, "Failed to encrypt plaintext\n");
     goto exit;
   }

--- a/packages/atchops/tests/test_rsaencrypt.c
+++ b/packages/atchops/tests/test_rsaencrypt.c
@@ -44,13 +44,27 @@ int main() {
   }
   printf("atchops_rsa_key_populate_public_key (success): %d\n", ret);
 
-  ret = atchops_rsa_encrypt(&publickey, (const unsigned char *)plaintext, plaintextlen, ciphertext);
+  ret = atchops_rsa_encrypt(&publickey, (const unsigned char *)plaintext, plaintextlen, ciphertext, ciphertextsize,
+                            NULL);
   if (ret != 0) {
     printf("atchops_rsa_encrypt (failed): %d\n", ret);
     goto ret;
   }
   printf("atchops_rsa_encrypt (success): %d\n", ret);
   printf("ciphertext (base64 encoded): \"%.*s\"\n", (int)ciphertextsize, ciphertext);
+
+  // A ciphertext buffer smaller than the key's modulus must be rejected
+  // without writing anything (issue #701)
+  unsigned char small_buffer[64];
+  ret = atchops_rsa_encrypt(&publickey, (const unsigned char *)plaintext, plaintextlen, small_buffer,
+                            sizeof(small_buffer), NULL);
+  if (ret == 0) {
+    printf("atchops_rsa_encrypt accepted an undersized ciphertext buffer (should have failed)\n");
+    ret = 1;
+    goto ret;
+  }
+  printf("atchops_rsa_encrypt correctly rejected an undersized ciphertext buffer\n");
+  ret = 0;
 
   goto ret;
 

--- a/packages/atclient/src/encryption_key_helpers.c
+++ b/packages/atclient/src/encryption_key_helpers.c
@@ -489,8 +489,8 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(
   memset(shared_encryption_key_base64_encrypted_for_us, 0,
          sizeof(unsigned char) * shared_encryption_key_base64_encrypted_for_us_size);
   if ((ret = atchops_rsa_encrypt(&atclient->atkeys.encrypt_public_key, (unsigned char *)shared_encryption_key_base64,
-                                 shared_encryption_key_base64_len, shared_encryption_key_base64_encrypted_for_us)) !=
-      0) {
+                                 shared_encryption_key_base64_len, shared_encryption_key_base64_encrypted_for_us,
+                                 shared_encryption_key_base64_encrypted_for_us_size, NULL)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR,
                  "failed to encrypt shared enc key for us | atchops_rsa_encrypt: %d\n", ret);
     goto exit;
@@ -513,8 +513,8 @@ int atclient_create_shared_encryption_key_pair_for_me_and_other(
   memset(shared_encryption_key_base64_encrypted_for_them, 0,
          sizeof(unsigned char) * shared_encryption_key_base64_encrypted_for_them_size);
   if ((ret = atchops_rsa_encrypt(&public_key_struct, (unsigned char *)shared_encryption_key_base64,
-                                 shared_encryption_key_base64_len, shared_encryption_key_base64_encrypted_for_them)) !=
-      0) {
+                                 shared_encryption_key_base64_len, shared_encryption_key_base64_encrypted_for_them,
+                                 shared_encryption_key_base64_encrypted_for_them_size, NULL)) != 0) {
     atlogger_log(TAG, ATLOGGER_LOGGING_LEVEL_ERROR, "atchops_rsa_encrypt: %d\n", ret);
     goto exit;
   }


### PR DESCRIPTION
Fixes #701.

`atchops_rsa_encrypt()` wrote exactly the key's modulus length into the caller's `ciphertext` buffer with no way for the caller to declare that buffer's size — an RSA-4096 public key overflows the documented 256-byte convention. This mirrors the safe shape `atchops_rsa_decrypt` already has:

```c
int atchops_rsa_encrypt(const atchops_rsa_key_public_key *public_key, const unsigned char *plaintext,
                        const size_t plaintext_len, unsigned char *ciphertext, const size_t ciphertext_size,
                        size_t *ciphertext_len);
```

- Bounds-check before encrypting: if `mbedtls_rsa_get_len(&rsa) > ciphertext_size`, fail with a clear error **without writing anything**
- `ciphertext_len` (optional, may be NULL) reports the written length, so callers no longer have to assume 256
- All in-repo call sites updated (atauth apkam_keys, atclient encryption_key_helpers ×2, atchops tests ×3)
- `test_rsaencrypt` gains a regression case: encrypting into a 64-byte buffer with an RSA-2048 key must fail

Breaking signature change, per the issue's preferred option — flagged for the next minor version bump. Verified: all 7 atchops tests pass, and the full at_activate stack (atauth → atclient → atchops) builds against the new signature.

Propagation note from the issue: this needs to flow into the Arduino packaging (`at_client_arduino` / PlatformIO `atsign/at_client`) so at_Arduino_NoPorts can drop its call-site workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)