### PR TITLE
chore: Bump version and change log (v0.4.0)

### DIFF
--- a/packages/atclient/CHANGELOG.md
+++ b/packages/atclient/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+- fix: atchops_rsa_encrypt takes an output-buffer-size bound (**breaking API
+  change**: callers must pass ciphertext_size and may receive the written
+  length via a new optional ciphertext_len out-param)
+
 ## 0.3.11
 
 - fix: route the enroll connection through 'proxy:' root specs with from:

--- a/packages/atclient/include/atclient/version.h
+++ b/packages/atclient/include/atclient/version.h
@@ -4,7 +4,7 @@
 extern "C" {
 #endif
 
-#define ATCLIENT_ATSDK_VERSION "0.3.11"
+#define ATCLIENT_ATSDK_VERSION "0.4.0"
 
 #ifdef __cplusplus
 }

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.files import get
 
 class at_cRecipe(ConanFile):
     name = "at_c"
-    version = "0.3.11"
+    version = "0.4.0"
     package_type = "library"
 
     # Optional metadata


### PR DESCRIPTION
Release prep following the v0.3.10/v0.3.11 pattern, for the #709 / #701 fix.

**Version call: 0.4.0 rather than 0.3.12** because #709 is a breaking API change (`atchops_rsa_encrypt` signature) — 0.3.x consumers cannot rebuild unmodified, and a minor bump signals that honestly. Happy to change if the team prefers a different scheme, @cpswan.

- CHANGELOG.md: 0.4.0 — atchops_rsa_encrypt output-buffer bound (breaking)
- `ATCLIENT_ATSDK_VERSION` → 0.4.0
- conanfile.py → 0.4.0 (no dependency changes)

After merge: tag the merge commit `v0.4.0` → `c_release.yml` produces the tarball/SBOM/provenance. Downstream uptakes ready and waiting: atsign-foundation/noports#2879, atsign-foundation/at_client_arduino#10, atsign-foundation/at_Arduino_NoPorts#21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)